### PR TITLE
fix(auth): throttle password resets and redirect staff guests to /scp

### DIFF
--- a/app/Http/Controllers/Auth/PasswordResetController.php
+++ b/app/Http/Controllers/Auth/PasswordResetController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
@@ -17,6 +18,8 @@ use Inertia\Response;
 
 class PasswordResetController extends Controller
 {
+    private const RESET_LINK_THROTTLE_SECONDS = 60;
+
     public function showForgotForm(): Response
     {
         return Inertia::render('Auth/ForgotPassword');
@@ -28,7 +31,21 @@ class PasswordResetController extends Controller
             'email' => ['required', 'email'],
         ]);
 
-        $staff = Staff::where('email', (string) $request->input('email'))
+        $email = trim((string) $request->input('email'));
+        $normalizedEmail = Str::lower($email);
+        $throttleKey = sprintf('password-reset.%s.%s', $normalizedEmail, $request->ip());
+
+        if (RateLimiter::tooManyAttempts($throttleKey, 1)) {
+            $seconds = RateLimiter::availableIn($throttleKey);
+
+            return back()->withErrors([
+                'email' => "Please wait {$seconds} seconds before requesting another reset link.",
+            ]);
+        }
+
+        RateLimiter::hit($throttleKey, self::RESET_LINK_THROTTLE_SECONDS);
+
+        $staff = Staff::where('email', $email)
             ->where('isactive', 1)
             ->first();
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ use App\Http\Middleware\AuthenticateStaff;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\LegacyAuthBridge;
 use App\Http\Middleware\RequireDepartmentAccess;
+use Illuminate\Http\Request;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -16,6 +17,13 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->encryptCookies(except: ['OSTSESSID']);
+        $middleware->redirectUsersTo(function (Request $request): string {
+            if ($request->route()?->named('scp.*')) {
+                return route('scp.dashboard');
+            }
+
+            return '/';
+        });
 
         $middleware->web(append: [
             LegacyAuthBridge::class,

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -36,7 +36,7 @@ test('authenticated staff are redirected from login page', function () {
 
     $response = $this->get('/scp/login');
 
-    $response->assertStatus(200);
+    $response->assertRedirect('/scp');
 });
 
 test('login requires username and password', function () {
@@ -165,4 +165,28 @@ test('forgot password shows generic success message regardless of account existe
     $response = $this->post('/scp/password/forgot', ['email' => 'nobody@example.com']);
 
     $response->assertSessionHas('status');
+});
+
+test('forgot password requests are rate limited', function () {
+    Mail::fake();
+
+    DB::connection('legacy')->table('staff')->insert([
+        'staff_id' => 99,
+        'username' => 'resetstaff',
+        'firstname' => 'Reset',
+        'lastname' => 'Staff',
+        'email' => 'reset@example.com',
+        'passwd' => bcrypt('password'),
+        'isactive' => 1,
+        'isadmin' => 0,
+        'created' => now(),
+    ]);
+
+    $this->post('/scp/password/forgot', ['email' => 'reset@example.com'])
+        ->assertSessionHas('status');
+
+    $response = $this->post('/scp/password/forgot', ['email' => 'reset@example.com']);
+
+    $response->assertSessionHasErrors(['email']);
+    Mail::assertSentCount(1);
 });


### PR DESCRIPTION
## Overview
Add an explicit throttle to the staff password-reset email endpoint and teach Laravel's authenticated-guest redirect hook to send already-authenticated staff back to /scp instead of /, closing the two auth-flow issues identified in the review.

## Problem
The staff password reset flow and the guest:staff route group each had a separate edge-case problem.

1. PasswordResetController::sendResetLink() accepted unlimited POSTs for the same email address. The handler correctly returned a generic success message regardless of whether the account existed, so it did not leak staff enumeration data, but it still allowed an attacker who knew a valid staff email to repeatedly trigger reset mails with no backoff. Because the controller invalidates the previous reset token before issuing a new one, the abuse was not about multiple concurrently valid tokens; it was about unbounded email volume and needless churn on the reset link.

2. The staff login, 2FA, and password-reset routes sit behind Laravel's built-in guest:staff middleware. In Laravel 13, authenticated users hitting guest routes are redirected via the middleware's configured authenticated-user redirect target. This app had not configured one for the staff area, and there is no global dashboard or home route name for the framework fallback to discover, so an authenticated staff member who requested /scp/login or another guest-only SCP route would be redirected to / instead of /scp. That is mostly a cosmetic bug, but it produces the wrong destination for the admin panel and makes the auth flow feel inconsistent.

## Fix
Added a dedicated rate limit to PasswordResetController::sendResetLink(). The action now trims the submitted email, normalizes it for the rate-limit key, combines it with the request IP, and allows only one attempt per 60-second window. When a client exceeds that limit, the controller returns a validation-style error on the email field with the remaining wait time instead of sending another message. The actual staff lookup still uses the submitted email value as-is, so this change does not silently alter lookup semantics against the legacy database collation.

The throttle is intentionally applied before checking whether a matching active staff account exists. That keeps the endpoint's existing anti-enumeration behaviour intact: known and unknown addresses both consume the same throttle bucket shape and both avoid revealing whether an account exists.

Configured the framework-level authenticated-user redirect in bootstrap/app.php via redirectUsersTo(). The callback now routes any authenticated request for an scp.* guest route to route('scp.dashboard'), which resolves to /scp, while leaving non-SCP guest redirects on the default / path. This fixes the staff-area redirect centrally instead of relying on dead-code controller fallbacks.

Updated tests/Feature/Auth/LoginTest.php to match the corrected behaviour. The existing authenticated-login-page test now asserts a redirect to /scp instead of a 200 response, and a new forgot-password rate-limit test verifies that a second reset request within the cooldown period produces an error and does not send a second mail.

## Verification
- Source review of PasswordResetController throttle path and bootstrap/app.php redirect hook
- Updated feature tests in tests/Feature/Auth/LoginTest.php for both fixes
- Could not run php artisan test in this workspace because vendor/autoload.php is missing and Laravel cannot boot without installed dependencies