### PR TITLE
fix(mail): keep replies on ticket threads and seed lastupdate

### DIFF
--- a/app/Console/Commands/FetchMailCommand.php
+++ b/app/Console/Commands/FetchMailCommand.php
@@ -175,7 +175,9 @@ final class FetchMailCommand extends Command
 
         $entry = ThreadEntryEmail::whereIn('mid', $messageIds)->first();
 
-        return $entry?->threadEntry?->thread ?? null;
+        $thread = $entry?->threadEntry?->thread;
+
+        return ($thread && $thread->object_type === 'T') ? $thread : null;
     }
 
     private function createTicket(
@@ -199,6 +201,7 @@ final class FetchMailCommand extends Command
 
         DB::connection('legacy')->transaction(function () use ($account, $number, $headers, $body, $attachments) {
             $userId = $this->resolveOrCreateUser($headers['from_email'], $headers['from_name']);
+            $timestamp = now()->format('Y-m-d H:i:s');
 
             $ticket = Ticket::create([
                 'number' => $number,
@@ -208,8 +211,9 @@ final class FetchMailCommand extends Command
                 'email_id' => $account->email_id,
                 'source' => 'Email',
                 'ip_address' => '',
-                'created' => now()->format('Y-m-d H:i:s'),
-                'updated' => now()->format('Y-m-d H:i:s'),
+                'lastupdate' => $timestamp,
+                'created' => $timestamp,
+                'updated' => $timestamp,
             ]);
 
             TicketCdata::updateOrCreate(

--- a/tests/Feature/FetchMailCommandTest.php
+++ b/tests/Feature/FetchMailCommandTest.php
@@ -1,0 +1,277 @@
+<?php
+
+use App\Console\Commands\FetchMailCommand;
+use App\Models\EmailAccount;
+use App\Models\EmailModel;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+beforeEach(function () {
+    ensureFetchMailLegacyTables();
+
+    foreach ([
+        'thread_entry_email',
+        'thread_entry',
+        'thread',
+        'ticket__cdata',
+        'ticket',
+        'sequence',
+        'user_email',
+        'user',
+    ] as $table) {
+        DB::connection('legacy')->table($table)->delete();
+    }
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+test('findExistingThread ignores task threads', function () {
+    $threadId = DB::connection('legacy')->table('thread')->insertGetId([
+        'object_id' => 41,
+        'object_type' => 'A',
+        'created' => '2026-04-14 10:00:00',
+    ]);
+
+    $entryId = DB::connection('legacy')->table('thread_entry')->insertGetId([
+        'thread_id' => $threadId,
+        'staff_id' => 0,
+        'user_id' => 0,
+        'type' => 'M',
+        'poster' => 'Task Sender',
+        'source' => 'Email',
+        'title' => 'Task message',
+        'body' => 'Body',
+        'format' => 'text',
+        'created' => '2026-04-14 10:00:00',
+        'updated' => '2026-04-14 10:00:00',
+    ]);
+
+    DB::connection('legacy')->table('thread_entry_email')->insert([
+        'thread_entry_id' => $entryId,
+        'email_id' => 7,
+        'mid' => '<task@example.test>',
+        'headers' => 'Message-ID: <task@example.test>',
+    ]);
+
+    $thread = callFetchMailCommandPrivateMethod(
+        makeFetchMailCommand(),
+        'findExistingThread',
+        [['<task@example.test>']]
+    );
+
+    expect($thread)->toBeNull();
+});
+
+test('findExistingThread returns matching ticket threads', function () {
+    $threadId = DB::connection('legacy')->table('thread')->insertGetId([
+        'object_id' => 42,
+        'object_type' => 'T',
+        'created' => '2026-04-14 10:00:00',
+    ]);
+
+    $entryId = DB::connection('legacy')->table('thread_entry')->insertGetId([
+        'thread_id' => $threadId,
+        'staff_id' => 0,
+        'user_id' => 0,
+        'type' => 'M',
+        'poster' => 'Ticket Sender',
+        'source' => 'Email',
+        'title' => 'Ticket message',
+        'body' => 'Body',
+        'format' => 'text',
+        'created' => '2026-04-14 10:00:00',
+        'updated' => '2026-04-14 10:00:00',
+    ]);
+
+    DB::connection('legacy')->table('thread_entry_email')->insert([
+        'thread_entry_id' => $entryId,
+        'email_id' => 7,
+        'mid' => '<ticket@example.test>',
+        'headers' => 'Message-ID: <ticket@example.test>',
+    ]);
+
+    $thread = callFetchMailCommandPrivateMethod(
+        makeFetchMailCommand(),
+        'findExistingThread',
+        [['<ticket@example.test>']]
+    );
+
+    expect($thread)->not->toBeNull();
+    expect($thread->id)->toBe($threadId);
+    expect($thread->object_type)->toBe('T');
+});
+
+test('createTicket initializes lastupdate for new email tickets', function () {
+    Carbon::setTestNow('2026-04-14 12:34:56');
+
+    DB::connection('legacy')->table('sequence')->insert([
+        'id' => 1,
+        'next' => 9001,
+        'increment' => 1,
+        'padding' => 0,
+        'updated' => '2026-04-14 12:00:00',
+    ]);
+
+    $account = new EmailAccount([
+        'email_id' => 7,
+    ]);
+    $account->setRelation('email', new EmailModel([
+        'email_id' => 7,
+        'dept_id' => 9,
+    ]));
+
+    callFetchMailCommandPrivateMethod(
+        makeFetchMailCommand(),
+        'createTicket',
+        [
+            $account,
+            [
+                'from_email' => 'sender@example.test',
+                'from_name' => 'Sender',
+                'subject' => 'New ticket subject',
+                'message_id' => '<new-ticket@example.test>',
+                'in_reply_to' => '',
+                'references' => '',
+                'date' => '2026-04-14 12:00:00',
+            ],
+            [
+                'body' => 'Ticket body',
+                'format' => 'text',
+            ],
+            [],
+        ]
+    );
+
+    $ticket = DB::connection('legacy')->table('ticket')->first();
+    $thread = DB::connection('legacy')->table('thread')->first();
+    $email = DB::connection('legacy')->table('thread_entry_email')->first();
+
+    expect($ticket)->not->toBeNull();
+    expect($ticket->number)->toBe('9001');
+    expect($ticket->dept_id)->toBe(9);
+    expect($ticket->lastupdate)->toBe('2026-04-14 12:34:56');
+    expect($ticket->created)->toBe('2026-04-14 12:34:56');
+    expect($ticket->updated)->toBe('2026-04-14 12:34:56');
+    expect($thread)->not->toBeNull();
+    expect($thread->object_type)->toBe('T');
+    expect($email)->not->toBeNull();
+    expect($email->mid)->toBe('<new-ticket@example.test>');
+});
+
+function ensureFetchMailLegacyTables(): void
+{
+    $schema = Schema::connection('legacy');
+
+    if (! $schema->hasTable('thread')) {
+        $schema->create('thread', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('object_id')->default(0);
+            $table->char('object_type', 1);
+            $table->dateTime('created')->nullable();
+        });
+    }
+
+    if (! $schema->hasTable('thread_entry')) {
+        $schema->create('thread_entry', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('thread_id');
+            $table->unsignedInteger('staff_id')->default(0);
+            $table->unsignedInteger('user_id')->default(0);
+            $table->char('type', 1);
+            $table->string('poster')->default('');
+            $table->string('source')->default('');
+            $table->string('title')->default('');
+            $table->text('body')->nullable();
+            $table->string('format')->default('text');
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+    }
+
+    if (! $schema->hasTable('thread_entry_email')) {
+        $schema->create('thread_entry_email', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('thread_entry_id');
+            $table->unsignedInteger('email_id')->default(0);
+            $table->string('mid');
+            $table->text('headers')->nullable();
+        });
+    }
+
+    if (! $schema->hasTable('ticket')) {
+        $schema->create('ticket', function (Blueprint $table) {
+            $table->increments('ticket_id');
+            $table->string('number');
+            $table->unsignedInteger('user_id')->default(0);
+            $table->unsignedInteger('dept_id')->default(0);
+            $table->unsignedInteger('status_id')->default(0);
+            $table->unsignedInteger('email_id')->default(0);
+            $table->string('source')->default('');
+            $table->string('ip_address')->default('');
+            $table->dateTime('lastupdate')->nullable();
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+    }
+
+    if (! $schema->hasTable('ticket__cdata')) {
+        $schema->create('ticket__cdata', function (Blueprint $table) {
+            $table->unsignedInteger('ticket_id')->primary();
+            $table->text('subject')->nullable();
+        });
+    }
+
+    if (! $schema->hasTable('sequence')) {
+        $schema->create('sequence', function (Blueprint $table) {
+            $table->unsignedInteger('id')->primary();
+            $table->unsignedInteger('next');
+            $table->unsignedInteger('increment')->default(1);
+            $table->unsignedInteger('padding')->default(0);
+            $table->dateTime('updated')->nullable();
+        });
+    }
+
+    if (! $schema->hasTable('user')) {
+        $schema->create('user', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('org_id')->default(0);
+            $table->unsignedInteger('default_email_id')->default(0);
+            $table->unsignedInteger('status')->default(0);
+            $table->string('name')->default('');
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+    }
+
+    if (! $schema->hasTable('user_email')) {
+        $schema->create('user_email', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('flags')->default(0);
+            $table->string('address')->unique();
+        });
+    }
+}
+
+function callFetchMailCommandPrivateMethod(FetchMailCommand $command, string $method, array $arguments): mixed
+{
+    $reflection = new ReflectionMethod($command, $method);
+    $reflection->setAccessible(true);
+
+    return $reflection->invokeArgs($command, $arguments);
+}
+
+function makeFetchMailCommand(): FetchMailCommand
+{
+    $command = new FetchMailCommand();
+    $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput()));
+
+    return $command;
+}


### PR DESCRIPTION
## Overview
Ensure fetch-mail only reuses ticket-owned threads for reply matching and initialize ticket.lastupdate when a new email creates a ticket, closing the two threading/state issues identified in review.

## Problem
FetchMailCommand had two separate correctness gaps in its inbound email flow.

1. findExistingThread() looked up a matching ThreadEntryEmail by Message-ID and returned its related Thread without checking the polymorphic discriminator. Because ost_thread is shared by tickets and tasks, a reply to a task email could be treated as a ticket reply if its Message-ID matched. That misroutes the incoming message onto the wrong object and also makes the later Ticket::where('ticket_id', ->object_id)->update(...) call unsafe in the task-thread case.

2. createTicket() inserted created and updated timestamps on the new ost_ticket row but left lastupdate unset. The same command explicitly updates lastupdate when appending a reply, and the project notes document lastupdate as the schema's last-message field. Leaving it null on freshly emailed tickets makes the initial row inconsistent with later reply handling and risks incorrect queue ordering until a second message arrives.

## Fix
Adjusted findExistingThread() to keep the existing lookup shape but add a post-fetch guard on the resolved thread. The method now returns the thread only when the related record exists and object_type === 'T'; task-owned threads are ignored and fall back to the new-ticket path.

Updated createTicket() to capture a single formatted timestamp inside the transaction and reuse it for lastupdate, created, and updated on the inserted ticket row. Using one shared value keeps the three ticket timestamps aligned for a single inbound message instead of formatting now() repeatedly.

Added tests/Feature/FetchMailCommandTest.php with focused regression coverage for both behaviours. The new tests verify that task-thread Message-ID matches are ignored, ticket-thread matches are still accepted, and createTicket() writes lastupdate when creating a new email ticket. The test file provisions only the minimal legacy SQLite tables needed for these command paths and invokes the private methods via reflection to keep the scope tight.

## Verification
- php artisan test tests/Feature/FetchMailCommandTest.php
- Manual review of app/Models/Thread.php, app/Models/Ticket.php, and app/Models/Task.php to confirm the ticket/task discriminator contract is object_type='T' vs object_type='A'
- Test run currently emits a missing .env warning in this workspace, but the FetchMailCommand assertions pass