### PR TITLE
fix(console): report actual deleted row count instead of pre-computed…

### DIFF
--- a/app/Console/Commands/CleanupDraftsCommand.php
+++ b/app/Console/Commands/CleanupDraftsCommand.php
@@ -43,9 +43,9 @@ final class CleanupDraftsCommand extends Command
         }
 
         if (! $dryRun) {
-            $query->delete();
+            $deleted = $query->delete();
 
-            $this->comment("{$count} draft(s) deleted");
+            $this->comment("{$deleted} draft(s) deleted");
         } else {
             $this->comment("Would delete {$count} draft(s)");
         }

--- a/app/Console/Commands/PurgeLogsCommand.php
+++ b/app/Console/Commands/PurgeLogsCommand.php
@@ -43,9 +43,9 @@ final class PurgeLogsCommand extends Command
         }
 
         if (! $dryRun) {
-            $query->delete();
+            $deleted = $query->delete();
 
-            $this->comment("{$count} log entry(ies) deleted");
+            $this->comment("{$deleted} log entry(ies) deleted");
         } else {
             $this->comment("Would delete {$count} log entry(ies)");
         }


### PR DESCRIPTION
… estimate

## Overview
Capture the return value of delete() in PurgeLogsCommand and CleanupDraftsCommand so the reported count reflects the actual number of rows removed, not a stale estimate from an earlier count() call.

## Problem
Both PurgeLogsCommand and CleanupDraftsCommand called $query->count() to preview matching rows, then called $query->delete() without capturing its return value. The commands reported the pre-computed $count instead of the actual number of deleted rows. If rows were added or removed by concurrent processes between the count() and delete() calls, the logged count would be inaccurate.

CheckOverdueTicketsCommand already followed the correct pattern — capturing $updated = $query->update(...) on line 54 and reporting $updated on line 56 — so these two commands were inconsistent with the rest of the codebase.

## Fix
Changed both commands to capture the integer returned by $query->delete() into a $deleted variable and use that value in the output message. The dry-run path still reports the pre-computed $count, which is correct since no mutation occurs in that mode.

- PurgeLogsCommand: $deleted = $query->delete() on line 46, reported on line 48
- CleanupDraftsCommand: $deleted = $query->delete() on line 46, reported on line 48

## Verification
- Source review confirming both commands now match the pattern used by CheckOverdueTicketsCommand
- Dry-run paths are unchanged and still report the preview count correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
