### PR TITLE
fix(mail): prevent fetch-mail loops from system addresses

### DIFF
--- a/app/Console/Commands/FetchMailCommand.php
+++ b/app/Console/Commands/FetchMailCommand.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Models\Attachment;
 use App\Models\EmailAccount;
+use App\Models\EmailModel;
 use App\Models\File;
 use App\Models\FileChunk;
 use App\Models\Thread;
@@ -136,6 +137,12 @@ final class FetchMailCommand extends Command
         $fromEmail = trim($headers['from_email']);
         if ($fromEmail === '' || ! filter_var($fromEmail, FILTER_VALIDATE_EMAIL)) {
             $this->warn("  [invalid] Message UID {$message->getUid()} has missing/invalid From address; skipped.");
+
+            return;
+        }
+
+        if ($this->isSystemAddress($fromEmail)) {
+            $this->line("  [loop] Skipped message from system address {$fromEmail}");
 
             return;
         }
@@ -436,6 +443,15 @@ final class FetchMailCommand extends Command
             'References: '.($headers['references'] ?? ''),
             'Date: '.$headers['date'],
         ]);
+    }
+
+    private function isSystemAddress(string $email): bool
+    {
+        $normalizedEmail = mb_strtolower(trim($email));
+
+        return EmailModel::query()
+            ->whereRaw('LOWER(email) = ?', [$normalizedEmail])
+            ->exists();
     }
 
     private function buildClient(EmailAccount $account): Client

--- a/tests/Unit/Commands/FetchMailLoopPreventionTest.php
+++ b/tests/Unit/Commands/FetchMailLoopPreventionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Console\Commands\FetchMailCommand;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    $legacy = Schema::connection('legacy');
+
+    if (! $legacy->hasTable('email')) {
+        $legacy->create('email', function (Blueprint $table) {
+            $table->unsignedInteger('email_id')->primary();
+            $table->unsignedInteger('noautoresp')->default(0);
+            $table->unsignedInteger('priority_id')->default(0);
+            $table->unsignedInteger('dept_id')->default(0);
+            $table->unsignedInteger('topic_id')->default(0);
+            $table->string('email', 255);
+            $table->string('name', 255)->default('');
+            $table->text('notes')->nullable();
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+    }
+
+    DB::connection('legacy')->table('email')->delete();
+});
+
+function commandRecognizesSystemAddress(string $email): bool
+{
+    $command = app(FetchMailCommand::class);
+    $method = new ReflectionMethod($command, 'isSystemAddress');
+    $method->setAccessible(true);
+
+    return $method->invoke($command, $email);
+}
+
+test('configured system email is matched case-insensitively', function () {
+    DB::connection('legacy')->table('email')->insert([
+        'email_id' => 1,
+        'noautoresp' => 0,
+        'priority_id' => 1,
+        'dept_id' => 1,
+        'topic_id' => 0,
+        'email' => 'Support@Example.com',
+        'name' => 'Support',
+        'notes' => '',
+        'created' => now()->format('Y-m-d H:i:s'),
+        'updated' => now()->format('Y-m-d H:i:s'),
+    ]);
+
+    expect(commandRecognizesSystemAddress('support@example.COM'))->toBeTrue();
+});
+
+test('external sender is not treated as a system address', function () {
+    DB::connection('legacy')->table('email')->insert([
+        'email_id' => 1,
+        'noautoresp' => 0,
+        'priority_id' => 1,
+        'dept_id' => 1,
+        'topic_id' => 0,
+        'email' => 'support@example.com',
+        'name' => 'Support',
+        'notes' => '',
+        'created' => now()->format('Y-m-d H:i:s'),
+        'updated' => now()->format('Y-m-d H:i:s'),
+    ]);
+
+    expect(commandRecognizesSystemAddress('customer@elsewhere.org'))->toBeFalse();
+});


### PR DESCRIPTION
## Overview
Teach FetchMailCommand to skip inbound messages whose From address matches one of the configured system mailboxes, and add a focused unit test around the command helper so the loop-prevention guard is covered by command code rather than an incidental raw query.

## Problem
The fetch-mail pipeline already rejected obvious bounce notices and duplicate Message-IDs, but it still accepted mail sent from one of the helpdesk's own configured email addresses.

1. If a mailbox receives a forwarded copy, auto-response, or other delivery path that feeds the application's own outbound mail back into a fetched inbox, FetchMailCommand::processMessage() would treat that message as a legitimate external sender. That can create a self-sustaining mail loop: the system ingests its own mail, creates or appends a ticket entry, sends new notifications, and then ingests those notifications again when they return to the mailbox.

2. The initial implementation of the guard compared EmailModel::email to mb_strtolower($fromEmail) on the PHP side only. That works when the underlying column collation is already case-insensitive and the stored address is normalized, but it fails if legacy data contains mixed-case addresses under a case-sensitive collation. In that scenario support@example.com and Support@Example.com represent the same mailbox operationally, yet the guard would miss the match and still admit the looping message.

3. The first test draft only asserted direct EmailModel::where(...)->exists() behaviour. That did not prove the command's helper or guard path worked, because the test would still pass if the command stopped calling the helper entirely or changed the lookup logic in a way the raw query did not reflect.

## Fix
Added an explicit system-address guard in FetchMailCommand::processMessage() immediately after From-address validation and before duplicate detection or ticket/thread writes. Messages from configured system addresses are now logged with a [loop] marker and skipped before any downstream ticket creation logic runs.

Implemented the lookup in a dedicated isSystemAddress() helper that trims and lowercases the input email, then performs a SQL-side LOWER(email) comparison against the legacy ost_email table via EmailModel. Normalizing both sides of the comparison keeps the safeguard correct even when historical mailbox rows are stored with mixed casing.

Replaced the query-only unit test with a command-focused test file that invokes FetchMailCommand's helper through reflection. The new coverage proves the command recognises a configured system mailbox even when the stored row uses mixed-case email text, and still returns false for unrelated external senders. The test also bootstraps the legacy email table when the sqlite-backed test environment has not created it yet, so it remains self-contained.

## Verification
- `php -l app/Console/Commands/FetchMailCommand.php`
- `php -l tests/Unit/Commands/FetchMailLoopPreventionTest.php`
- Could not run `php artisan test tests/Unit/Commands/FetchMailLoopPreventionTest.php` in this workspace because `vendor/autoload.php` is missing and Laravel cannot boot without installed dependencies
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
