### PR TITLE
fix: address flagged issues across console commands, mail pipeline, and 2FA

### DIFF
--- a/app/Console/Commands/CheckOverdueTicketsCommand.php
+++ b/app/Console/Commands/CheckOverdueTicketsCommand.php
@@ -34,7 +34,7 @@ final class CheckOverdueTicketsCommand extends Command
         // can grow to tens of thousands of rows, and loading them all would
         // waste memory and flood the console/log capture. This matches the
         // pattern used by PurgeLogsCommand and CleanupDraftsCommand.
-        $count = (clone $query)->count();
+        $count = $query->count();
 
         if ($count === 0) {
             $this->info('No overdue tickets found.');

--- a/app/Console/Commands/CleanupFilesCommand.php
+++ b/app/Console/Commands/CleanupFilesCommand.php
@@ -51,20 +51,22 @@ final class CleanupFilesCommand extends Command
         }
 
         if (! $dryRun) {
+            $deleted = 0;
+
             (clone $query)
                 ->orderBy('id')
-                ->chunkById(1000, function ($files) {
+                ->chunkById(1000, function ($files) use (&$deleted) {
                     $fileIds = $files->pluck('id');
 
                     FileChunk::whereIn('file_id', $fileIds)->delete();
-                    File::whereIn('id', $fileIds)->delete();
+                    $deleted += File::whereIn('id', $fileIds)->delete();
                 });
 
             FileChunk::query()
                 ->whereNotIn('file_id', File::query()->select('id'))
                 ->delete();
 
-            $this->comment("{$count} file(s) deleted");
+            $this->comment("{$deleted} file(s) deleted");
         } else {
             $this->comment("Would delete {$count} file(s)");
         }

--- a/app/Console/Commands/FetchMailCommand.php
+++ b/app/Console/Commands/FetchMailCommand.php
@@ -55,7 +55,8 @@ final class FetchMailCommand extends Command
             try {
                 $processed = $this->processAccount($account, $parser, $dryRun);
                 $total += $processed;
-                $this->info("Account {$account->email->email}: {$processed} message(s) processed.");
+                $label = $account->email?->email ?? "id:{$account->id}";
+                $this->info("Account {$label}: {$processed} message(s) processed.");
             } catch (\Throwable $e) {
                 $this->error("Account {$account->id} failed: {$e->getMessage()}");
                 Log::error('FetchMailCommand: account error', [
@@ -294,10 +295,20 @@ final class FetchMailCommand extends Command
 
             $this->saveAttachments($attachments, $entry->id);
 
-            Ticket::where('ticket_id', $thread->object_id)
-                ->update(['lastupdate' => now()->format('Y-m-d H:i:s')]);
+            $ticket = Ticket::where('ticket_id', $thread->object_id)->first();
 
-            $this->line("  Appended reply to thread #{$thread->id}");
+            $updates = ['lastupdate' => now()->format('Y-m-d H:i:s')];
+
+            if ($ticket && $ticket->closed !== null) {
+                $updates['status_id'] = 1;
+                $updates['closed'] = null;
+                $updates['isanswered'] = 0;
+            }
+
+            Ticket::where('ticket_id', $thread->object_id)->update($updates);
+
+            $reopened = isset($updates['closed']) ? ' (reopened)' : '';
+            $this->line("  Appended reply to thread #{$thread->id}{$reopened}");
         });
     }
 
@@ -468,7 +479,7 @@ final class FetchMailCommand extends Command
             'host' => $account->host,
             'port' => (int) $account->port,
             'encryption' => $encryption,
-            'validate_cert' => false,
+            'validate_cert' => (bool) env('IMAP_VALIDATE_CERT', false),
             'username' => $account->auth_id,
             'password' => $account->auth_bk,
             'protocol' => strtolower((string) ($account->protocol ?: 'imap')),

--- a/app/Console/Commands/FetchMailCommand.php
+++ b/app/Console/Commands/FetchMailCommand.php
@@ -307,7 +307,7 @@ final class FetchMailCommand extends Command
 
             Ticket::where('ticket_id', $thread->object_id)->update($updates);
 
-            $reopened = isset($updates['closed']) ? ' (reopened)' : '';
+            $reopened = array_key_exists('closed', $updates) ? ' (reopened)' : '';
             $this->line("  Appended reply to thread #{$thread->id}{$reopened}");
         });
     }
@@ -479,7 +479,7 @@ final class FetchMailCommand extends Command
             'host' => $account->host,
             'port' => (int) $account->port,
             'encryption' => $encryption,
-            'validate_cert' => (bool) env('IMAP_VALIDATE_CERT', false),
+            'validate_cert' => (bool) config('services.imap.validate_cert', false),
             'username' => $account->auth_id,
             'password' => $account->auth_bk,
             'protocol' => strtolower((string) ($account->protocol ?: 'imap')),

--- a/app/Http/Controllers/Auth/TwoFactorController.php
+++ b/app/Http/Controllers/Auth/TwoFactorController.php
@@ -53,6 +53,17 @@ class TwoFactorController extends Controller
             ]);
         }
 
+        $staff = Staff::where('staff_id', $staffId)->where('isactive', 1)->first();
+
+        if (! $staff) {
+            $this->twoFactor->clearToken((int) $staffId);
+            $request->session()->forget(['2fa.staff_id', '2fa.remember']);
+
+            return redirect()->route('scp.login')->withErrors([
+                'code' => 'Your account has been deactivated.',
+            ]);
+        }
+
         $remember = (bool) $request->session()->pull('2fa.remember', false);
         $request->session()->forget('2fa.staff_id');
 

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -2,25 +2,31 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
 /**
  * Ticket model for the legacy osTicket ost_ticket table.
  *
- * @property int         $ticket_id
- * @property string      $number
- * @property int         $user_id
- * @property int         $dept_id
- * @property int         $staff_id
- * @property int         $sla_id
- * @property string      $status
- * @property string      $source
- * @property string      $isoverdue
- * @property string      $isanswered
- * @property string      $duedate
- * @property string      $created
- * @property string      $updated
- * @property string      $lastmessage
- * @property string      $lastresponse
- *
+ * @property int $ticket_id
+ * @property string $number
+ * @property int $user_id
+ * @property int $status_id
+ * @property int $dept_id
+ * @property int $staff_id
+ * @property int $sla_id
+ * @property int $email_id
+ * @property string $source
+ * @property string $ip_address
+ * @property int $isoverdue
+ * @property int $isanswered
+ * @property string|null $duedate
+ * @property string|null $closed
+ * @property string $lastupdate
+ * @property string $lastmessage
+ * @property string $lastresponse
+ * @property string $created
+ * @property string $updated
  * @property-read Staff|null      $staff
  * @property-read Department|null $department
  * @property-read Thread|null     $thread
@@ -46,7 +52,7 @@ class Ticket extends LegacyModel
     /**
      * Get the staff member assigned to the ticket.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Staff, $this>
+     * @return BelongsTo<Staff, $this>
      */
     public function staff()
     {
@@ -60,7 +66,7 @@ class Ticket extends LegacyModel
     /**
      * Get the department the ticket belongs to.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Department, $this>
+     * @return BelongsTo<Department, $this>
      */
     public function department()
     {
@@ -76,7 +82,7 @@ class Ticket extends LegacyModel
      *
      * osTicket uses object_type='T' to distinguish ticket threads from task threads.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne<Thread, $this>
+     * @return HasOne<Thread, $this>
      */
     public function thread()
     {
@@ -90,7 +96,7 @@ class Ticket extends LegacyModel
     /**
      * Get the user who created the ticket.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<LegacyUser, $this>
+     * @return BelongsTo<LegacyUser, $this>
      */
     public function user()
     {
@@ -104,7 +110,7 @@ class Ticket extends LegacyModel
     /**
      * Get the ticket's custom field data from ost_ticket__cdata.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne<TicketCdata, $this>
+     * @return HasOne<TicketCdata, $this>
      */
     public function cdata()
     {

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'imap' => [
+        'validate_cert' => env('IMAP_VALIDATE_CERT', false),
+    ],
+
 ];

--- a/tests/Feature/FetchMailCommandTest.php
+++ b/tests/Feature/FetchMailCommandTest.php
@@ -165,6 +165,93 @@ test('createTicket initializes lastupdate for new email tickets', function () {
     expect($email->mid)->toBe('<new-ticket@example.test>');
 });
 
+test('appendToThread marks reopened tickets in command output', function () {
+    Carbon::setTestNow('2026-04-14 13:00:00');
+
+    DB::connection('legacy')->table('ticket')->insert([
+        'ticket_id' => 55,
+        'number' => '9002',
+        'user_id' => 1,
+        'dept_id' => 9,
+        'status_id' => 2,
+        'email_id' => 7,
+        'source' => 'Email',
+        'ip_address' => '',
+        'isanswered' => 1,
+        'closed' => '2026-04-13 09:00:00',
+        'lastupdate' => '2026-04-13 09:00:00',
+        'created' => '2026-04-13 08:00:00',
+        'updated' => '2026-04-13 09:00:00',
+    ]);
+
+    $threadId = DB::connection('legacy')->table('thread')->insertGetId([
+        'object_id' => 55,
+        'object_type' => 'T',
+        'created' => '2026-04-13 08:00:00',
+    ]);
+
+    $account = new EmailAccount([
+        'email_id' => 7,
+    ]);
+
+    [$command, $buffer] = makeFetchMailCommandWithBuffer();
+
+    callFetchMailCommandPrivateMethod(
+        $command,
+        'appendToThread',
+        [
+            new \App\Models\Thread([
+                'id' => $threadId,
+                'object_id' => 55,
+                'object_type' => 'T',
+            ]),
+            $account,
+            [
+                'from_email' => 'sender@example.test',
+                'from_name' => 'Sender',
+                'subject' => 'Re: Existing ticket',
+                'message_id' => '<reply@example.test>',
+                'in_reply_to' => '<ticket@example.test>',
+                'references' => '<ticket@example.test>',
+                'date' => '2026-04-14 12:59:00',
+            ],
+            [
+                'body' => 'Reply body',
+                'format' => 'text',
+            ],
+            [],
+        ]
+    );
+
+    $ticket = DB::connection('legacy')->table('ticket')->where('ticket_id', 55)->first();
+
+    expect($ticket->status_id)->toBe(1);
+    expect($ticket->closed)->toBeNull();
+    expect($ticket->isanswered)->toBe(0);
+    expect($buffer->fetch())->toContain("Appended reply to thread #{$threadId} (reopened)");
+});
+
+test('buildClient reads validate_cert from config', function () {
+    config()->set('services.imap.validate_cert', true);
+
+    $client = callFetchMailCommandPrivateMethod(
+        makeFetchMailCommand(),
+        'buildClient',
+        [
+            new EmailAccount([
+                'host' => 'imap.example.test',
+                'port' => 993,
+                'encryption' => 'ssl',
+                'auth_id' => 'mailbox@example.test',
+                'auth_bk' => 'secret',
+                'protocol' => 'imap',
+            ]),
+        ]
+    );
+
+    expect($client->validate_cert)->toBeTrue();
+});
+
 function ensureFetchMailLegacyTables(): void
 {
     $schema = Schema::connection('legacy');
@@ -215,10 +302,24 @@ function ensureFetchMailLegacyTables(): void
             $table->unsignedInteger('email_id')->default(0);
             $table->string('source')->default('');
             $table->string('ip_address')->default('');
+            $table->unsignedInteger('isanswered')->default(0);
+            $table->dateTime('closed')->nullable();
             $table->dateTime('lastupdate')->nullable();
             $table->dateTime('created')->nullable();
             $table->dateTime('updated')->nullable();
         });
+    } else {
+        if (! $schema->hasColumn('ticket', 'isanswered')) {
+            $schema->table('ticket', function (Blueprint $table) {
+                $table->unsignedInteger('isanswered')->default(0);
+            });
+        }
+
+        if (! $schema->hasColumn('ticket', 'closed')) {
+            $schema->table('ticket', function (Blueprint $table) {
+                $table->dateTime('closed')->nullable();
+            });
+        }
     }
 
     if (! $schema->hasTable('ticket__cdata')) {
@@ -274,4 +375,13 @@ function makeFetchMailCommand(): FetchMailCommand
     $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput()));
 
     return $command;
+}
+
+function makeFetchMailCommandWithBuffer(): array
+{
+    $command = new FetchMailCommand();
+    $buffer = new BufferedOutput();
+    $command->setOutput(new OutputStyle(new ArrayInput([]), $buffer));
+
+    return [$command, $buffer];
 }


### PR DESCRIPTION
## Summary
- **CleanupFilesCommand**: report actual deleted row count via `$deleted` accumulator instead of pre-deletion `$count`, matching PurgeLogsCommand/CleanupDraftsCommand convention
- **FetchMailCommand**: reopen closed tickets on email reply by resetting `status_id`, `closed`, and `isanswered`; make IMAP `validate_cert` configurable via `IMAP_VALIDATE_CERT` env var (defaults to `false`); use null-safe operator for account email label
- **CheckOverdueTicketsCommand**: remove unnecessary `clone` before `count()` to match convention used by other cleanup commands
- **TwoFactorController**: verify staff account is still active before completing 2FA authentication
- **Ticket model**: update `@property` annotations to reflect actual schema columns (`status_id`, `email_id`, `ip_address`, `closed`, `lastupdate`) and correct types (`isoverdue`/`isanswered` as `int`, `duedate`/`closed` as nullable)

## Test plan
- [ ] Verify `CleanupFilesCommand` reports accurate deletion count after run
- [ ] Verify email reply to a closed ticket reopens it and logs `(reopened)` in console output
- [ ] Verify `IMAP_VALIDATE_CERT=true` enables certificate validation; unset defaults to disabled
- [ ] Verify deactivated staff cannot complete 2FA and is redirected to login
- [ ] Run `./vendor/bin/pint --test` to confirm code style compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
