### PR TITLE
fix: guard 2FA resend against inactive staff and preserve skipped mail

### DIFF
--- a/app/Console/Commands/FetchMailCommand.php
+++ b/app/Console/Commands/FetchMailCommand.php
@@ -88,16 +88,19 @@ final class FetchMailCommand extends Command
             $processed = 0;
             foreach ($messages as $message) {
                 try {
-                    $this->processMessage($message, $account, $parser, $dryRun);
-                    $processed++;
+                    $wasProcessed = $this->processMessage($message, $account, $parser, $dryRun);
 
                     if (! $dryRun) {
                         $message->setFlag('Seen');
 
-                        if ($account->postfetch === 'delete') {
-                            $message->delete();
-                        } elseif ($account->archivefolder) {
-                            $message->move($account->archivefolder);
+                        if ($wasProcessed) {
+                            $processed++;
+
+                            if ($account->postfetch === 'delete') {
+                                $message->delete();
+                            } elseif ($account->archivefolder) {
+                                $message->move($account->archivefolder);
+                            }
                         }
                     }
                 } catch (\Throwable $e) {
@@ -121,16 +124,19 @@ final class FetchMailCommand extends Command
         return $processed;
     }
 
+    /**
+     * @return bool Whether the message was actually processed (not skipped).
+     */
     private function processMessage(
         Message $message,
         EmailAccount $account,
         EmailParser $parser,
         bool $dryRun
-    ): void {
+    ): bool {
         if ($parser->detectBounce($message)) {
             $this->line('  [bounce] Skipped bounce message.');
 
-            return;
+            return false;
         }
 
         $headers = $parser->parseHeaders($message);
@@ -139,20 +145,20 @@ final class FetchMailCommand extends Command
         if ($fromEmail === '' || ! filter_var($fromEmail, FILTER_VALIDATE_EMAIL)) {
             $this->warn("  [invalid] Message UID {$message->getUid()} has missing/invalid From address; skipped.");
 
-            return;
+            return false;
         }
 
         if ($this->isSystemAddress($fromEmail)) {
             $this->line("  [loop] Skipped message from system address {$fromEmail}");
 
-            return;
+            return false;
         }
 
         if (! empty($headers['message_id'])
             && ThreadEntryEmail::where('mid', $headers['message_id'])->exists()) {
             $this->line("  [duplicate] Already processed Message-ID {$headers['message_id']}");
 
-            return;
+            return false;
         }
 
         $body = $parser->parseBody($message);
@@ -165,7 +171,7 @@ final class FetchMailCommand extends Command
             $mode = $thread ? 'reply to thread #'.$thread->id : 'new ticket';
             $this->line("  [dry-run] Would create {$mode}: \"{$headers['subject']}\" from {$headers['from_email']}");
 
-            return;
+            return true;
         }
 
         if ($thread !== null) {
@@ -173,6 +179,8 @@ final class FetchMailCommand extends Command
         } else {
             $this->createTicket($account, $headers, $body, $attachments);
         }
+
+        return true;
     }
 
     private function findExistingThread(array $messageIds): ?Thread

--- a/app/Console/Commands/FetchMailCommand.php
+++ b/app/Console/Commands/FetchMailCommand.php
@@ -102,6 +102,8 @@ final class FetchMailCommand extends Command
                                 $message->move($account->archivefolder);
                             }
                         }
+                    } elseif ($wasProcessed) {
+                        $processed++;
                     }
                 } catch (\Throwable $e) {
                     $this->warn("  Skipped message UID {$message->getUid()}: {$e->getMessage()}");

--- a/app/Http/Controllers/Auth/TwoFactorController.php
+++ b/app/Http/Controllers/Auth/TwoFactorController.php
@@ -91,7 +91,7 @@ class TwoFactorController extends Controller
             ]);
         }
 
-        $staff = Staff::find($staffId);
+        $staff = Staff::where('staff_id', $staffId)->where('isactive', 1)->first();
 
         if (! $staff) {
             $request->session()->forget(['2fa.staff_id', '2fa.remember']);


### PR DESCRIPTION
## Summary
- **TwoFactorController::resend()** now checks `isactive` when looking up staff, matching the existing `verify()` method. Deactivated accounts are redirected to login instead of receiving a new verification code email.
- **FetchMailCommand::processMessage()** now returns a `bool` indicating whether the message was actually processed. Skipped messages (bounces, invalid addresses, system addresses, duplicates) return `false`, which prevents destructive post-fetch actions (delete, archive) from discarding them before an admin can review. The `Seen` flag is still applied to all messages to prevent re-fetch loops.

## Test plan
- [ ] Verify 2FA resend redirects to login for deactivated staff accounts
- [ ] Verify bounced/skipped messages are marked Seen but not deleted or archived
- [ ] Verify successfully processed messages still respect postfetch delete/archive settings
- [ ] Verify `$processed` count only reflects truly processed messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
