### PR TITLE
fix(auth): make legacy auth migrations idempotent

### DIFF
--- a/database/migrations/2026_04_19_000100_create_staff_two_factor_table.php
+++ b/database/migrations/2026_04_19_000100_create_staff_two_factor_table.php
@@ -8,7 +8,13 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::connection('osticket2')->create('staff_two_factor', function (Blueprint $table): void {
+        $schema = Schema::connection('osticket2');
+
+        if ($schema->hasTable('staff_two_factor')) {
+            return;
+        }
+
+        $schema->create('staff_two_factor', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('staff_id')->unique();
             $table->text('two_factor_secret')->nullable();
@@ -20,6 +26,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::connection('osticket2')->dropIfExists('staff_two_factor');
+        // The osTicket-side table may already exist before this migration runs.
+        // Rolling back should not drop shared legacy data.
     }
 };

--- a/database/migrations/2026_04_19_000100_create_staff_two_factor_table.php
+++ b/database/migrations/2026_04_19_000100_create_staff_two_factor_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -10,10 +11,24 @@ return new class extends Migration
     {
         $schema = Schema::connection('osticket2');
 
-        if ($schema->hasTable('staff_two_factor')) {
+        if (! $schema->hasTable('staff_two_factor')) {
+            $this->createTable($schema);
+
             return;
         }
 
+        $this->guardRequiredColumns($schema, 'staff_two_factor', ['id', 'staff_id']);
+        $this->backfillOptionalColumns($schema);
+    }
+
+    public function down(): void
+    {
+        // The osTicket-side table may already exist before this migration runs.
+        // Rolling back should not drop shared legacy data.
+    }
+
+    private function createTable(Builder $schema): void
+    {
         $schema->create('staff_two_factor', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('staff_id')->unique();
@@ -24,9 +39,63 @@ return new class extends Migration
         });
     }
 
-    public function down(): void
+    private function guardRequiredColumns(Builder $schema, string $table, array $requiredColumns): void
     {
-        // The osTicket-side table may already exist before this migration runs.
-        // Rolling back should not drop shared legacy data.
+        $existingColumns = $schema->getColumnListing($table);
+        $missingColumns = array_values(array_diff($requiredColumns, $existingColumns));
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Existing %s table is missing required column(s): %s.',
+            $schema->getConnection()->getTablePrefix().$table,
+            implode(', ', $missingColumns),
+        ));
+    }
+
+    private function backfillOptionalColumns(Builder $schema): void
+    {
+        $table = 'staff_two_factor';
+        $existingColumns = $schema->getColumnListing($table);
+        $needsUniqueIndex = ! $schema->hasIndex($table, ['staff_id'], 'unique');
+
+        if (
+            in_array('two_factor_secret', $existingColumns, true) &&
+            in_array('two_factor_recovery_codes', $existingColumns, true) &&
+            in_array('two_factor_confirmed_at', $existingColumns, true) &&
+            in_array('created_at', $existingColumns, true) &&
+            in_array('updated_at', $existingColumns, true) &&
+            ! $needsUniqueIndex
+        ) {
+            return;
+        }
+
+        $schema->table($table, function (Blueprint $table) use ($existingColumns, $needsUniqueIndex): void {
+            if (! in_array('two_factor_secret', $existingColumns, true)) {
+                $table->text('two_factor_secret')->nullable();
+            }
+
+            if (! in_array('two_factor_recovery_codes', $existingColumns, true)) {
+                $table->text('two_factor_recovery_codes')->nullable();
+            }
+
+            if (! in_array('two_factor_confirmed_at', $existingColumns, true)) {
+                $table->timestamp('two_factor_confirmed_at')->nullable();
+            }
+
+            if (! in_array('created_at', $existingColumns, true)) {
+                $table->timestamp('created_at')->nullable();
+            }
+
+            if (! in_array('updated_at', $existingColumns, true)) {
+                $table->timestamp('updated_at')->nullable();
+            }
+
+            if ($needsUniqueIndex) {
+                $table->unique('staff_id');
+            }
+        });
     }
 };

--- a/database/migrations/2026_04_19_000200_create_staff_auth_migrations_table.php
+++ b/database/migrations/2026_04_19_000200_create_staff_auth_migrations_table.php
@@ -8,7 +8,13 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::connection('osticket2')->create('staff_auth_migrations', function (Blueprint $table): void {
+        $schema = Schema::connection('osticket2');
+
+        if ($schema->hasTable('staff_auth_migrations')) {
+            return;
+        }
+
+        $schema->create('staff_auth_migrations', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('staff_id')->unique();
             $table->timestamp('migrated_at')->nullable();
@@ -20,6 +26,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::connection('osticket2')->dropIfExists('staff_auth_migrations');
+        // The osTicket-side table may already exist before this migration runs.
+        // Rolling back should not drop shared legacy data.
     }
 };

--- a/database/migrations/2026_04_19_000200_create_staff_auth_migrations_table.php
+++ b/database/migrations/2026_04_19_000200_create_staff_auth_migrations_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -10,10 +11,24 @@ return new class extends Migration
     {
         $schema = Schema::connection('osticket2');
 
-        if ($schema->hasTable('staff_auth_migrations')) {
+        if (! $schema->hasTable('staff_auth_migrations')) {
+            $this->createTable($schema);
+
             return;
         }
 
+        $this->guardRequiredColumns($schema, 'staff_auth_migrations', ['id', 'staff_id']);
+        $this->backfillOptionalColumns($schema);
+    }
+
+    public function down(): void
+    {
+        // The osTicket-side table may already exist before this migration runs.
+        // Rolling back should not drop shared legacy data.
+    }
+
+    private function createTable(Builder $schema): void
+    {
         $schema->create('staff_auth_migrations', function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('staff_id')->unique();
@@ -24,9 +39,63 @@ return new class extends Migration
         });
     }
 
-    public function down(): void
+    private function guardRequiredColumns(Builder $schema, string $table, array $requiredColumns): void
     {
-        // The osTicket-side table may already exist before this migration runs.
-        // Rolling back should not drop shared legacy data.
+        $existingColumns = $schema->getColumnListing($table);
+        $missingColumns = array_values(array_diff($requiredColumns, $existingColumns));
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Existing %s table is missing required column(s): %s.',
+            $schema->getConnection()->getTablePrefix().$table,
+            implode(', ', $missingColumns),
+        ));
+    }
+
+    private function backfillOptionalColumns(Builder $schema): void
+    {
+        $table = 'staff_auth_migrations';
+        $existingColumns = $schema->getColumnListing($table);
+        $needsUniqueIndex = ! $schema->hasIndex($table, ['staff_id'], 'unique');
+
+        if (
+            in_array('migrated_at', $existingColumns, true) &&
+            in_array('must_upgrade_after', $existingColumns, true) &&
+            in_array('upgrade_method', $existingColumns, true) &&
+            in_array('created_at', $existingColumns, true) &&
+            in_array('updated_at', $existingColumns, true) &&
+            ! $needsUniqueIndex
+        ) {
+            return;
+        }
+
+        $schema->table($table, function (Blueprint $table) use ($existingColumns, $needsUniqueIndex): void {
+            if (! in_array('migrated_at', $existingColumns, true)) {
+                $table->timestamp('migrated_at')->nullable();
+            }
+
+            if (! in_array('must_upgrade_after', $existingColumns, true)) {
+                $table->timestamp('must_upgrade_after')->nullable();
+            }
+
+            if (! in_array('upgrade_method', $existingColumns, true)) {
+                $table->string('upgrade_method', 32)->nullable();
+            }
+
+            if (! in_array('created_at', $existingColumns, true)) {
+                $table->timestamp('created_at')->nullable();
+            }
+
+            if (! in_array('updated_at', $existingColumns, true)) {
+                $table->timestamp('updated_at')->nullable();
+            }
+
+            if ($needsUniqueIndex) {
+                $table->unique('staff_id');
+            }
+        });
     }
 };

--- a/tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php
+++ b/tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+function loadMigration(string $filename): object
+{
+    return require database_path("migrations/{$filename}");
+}
+
+function recreateOsticket2Table(string $table, Closure $definition): void
+{
+    $schema = Schema::connection('osticket2');
+
+    $schema->dropIfExists($table);
+    $schema->create($table, $definition);
+}
+
+test('staff two factor migration backfills missing optional columns on an existing shared table', function () {
+    recreateOsticket2Table('staff_two_factor', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('staff_id');
+    });
+
+    loadMigration('2026_04_19_000100_create_staff_two_factor_table.php')->up();
+
+    $schema = Schema::connection('osticket2');
+
+    expect($schema->hasColumns('staff_two_factor', [
+        'id',
+        'staff_id',
+        'two_factor_secret',
+        'two_factor_recovery_codes',
+        'two_factor_confirmed_at',
+        'created_at',
+        'updated_at',
+    ]))->toBeTrue()
+        ->and($schema->hasIndex('staff_two_factor', ['staff_id'], 'unique'))->toBeTrue();
+});
+
+test('staff auth migrations migration backfills missing optional columns on an existing shared table', function () {
+    recreateOsticket2Table('staff_auth_migrations', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('staff_id');
+    });
+
+    loadMigration('2026_04_19_000200_create_staff_auth_migrations_table.php')->up();
+
+    $schema = Schema::connection('osticket2');
+
+    expect($schema->hasColumns('staff_auth_migrations', [
+        'id',
+        'staff_id',
+        'migrated_at',
+        'must_upgrade_after',
+        'upgrade_method',
+        'created_at',
+        'updated_at',
+    ]))->toBeTrue()
+        ->and($schema->hasIndex('staff_auth_migrations', ['staff_id'], 'unique'))->toBeTrue();
+});
+
+test('staff two factor migration fails loudly when the shared table is missing core columns', function () {
+    recreateOsticket2Table('staff_two_factor', function (Blueprint $table): void {
+        $table->unsignedBigInteger('staff_id');
+    });
+
+    try {
+        expect(fn () => loadMigration('2026_04_19_000100_create_staff_two_factor_table.php')->up())
+            ->toThrow(RuntimeException::class, 'Existing scp_staff_two_factor table is missing required column(s): id.');
+    } finally {
+        Schema::connection('osticket2')->dropIfExists('staff_two_factor');
+        loadMigration('2026_04_19_000100_create_staff_two_factor_table.php')->up();
+    }
+});


### PR DESCRIPTION
## Overview
Make the Laravel-owned auth migrations on the `osticket2` connection safe to run against an existing shared osTicket schema. The main change is to treat `scp_staff_two_factor` and `scp_staff_auth_migrations` as pre-existing legacy-side tables when they are already present, instead of blindly attempting to recreate them during setup.

## Problem
`composer setup` currently runs `php artisan migrate --force` against the configured legacy MariaDB. On this workspace, the first new auth migration failed immediately with `SQLSTATE[42S01]: Base table or view already exists` because the `osticket2` connection points at the shared osTicket database with the `scp_` prefix, and `scp_staff_two_factor` already existed there.

That left two concrete issues:

1. Fresh setup runs could not complete once either auth table already existed on the shared legacy database, even if the schema matched what Laravel expected.
2. The paired `down()` methods would drop those prefixed tables on rollback even though they may represent pre-existing shared legacy data rather than tables created by the current migration run.

## Fix
- updated `2026_04_19_000100_create_staff_two_factor_table` to resolve the `osticket2` schema builder once, check `hasTable('staff_two_factor')`, and return early when the prefixed table already exists
- updated `2026_04_19_000200_create_staff_auth_migrations_table` with the same idempotent `hasTable()` guard so it cannot become the next failing migration after `staff_two_factor`
- removed the destructive rollback behavior from both migrations and documented why: these tables live on the shared osTicket-side schema, so rollback should not drop data that may have existed before Laravel recorded the migration locally
- kept the actual table definitions unchanged so new environments that do not already have the `scp_*` tables still create the expected schema

## Verification
- `php artisan migrate --force`
- `vendor/bin/pint --dirty`

Notes from verification:
- `php artisan migrate --force` now records both auth migrations successfully on the current workspace database instead of failing on duplicate-table creation
- formatting checks passed with no further changes required
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database migrations to prevent unintended re-creation of existing tables and improved rollback safety by preserving legacy data during migration reversals.

* **Chores**
  * Updated migration scripts to check for table existence before creation, ensuring idempotent behavior and protecting pre-existing data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->