### PR TITLE
fix(auth): dedupe 2fa status messaging

### DIFF
--- a/resources/js/layouts/AuthLayout.tsx
+++ b/resources/js/layouts/AuthLayout.tsx
@@ -60,12 +60,12 @@ export function AuthLayout({
     const year = new Date().getFullYear();
 
     return (
-        <div className="auth-theme relative min-h-screen bg-background text-foreground antialiased">
+        <div className="auth-theme relative flex min-h-screen flex-col bg-background text-foreground antialiased">
             <div className="auth-mesh" aria-hidden />
             <div className="auth-grain" aria-hidden />
 
             {/* Top bar — 3-column grid, uppercase micro meta. */}
-            <header className="relative z-10 mx-auto grid w-full max-w-[1240px] grid-cols-3 items-center gap-4 px-6 py-5 sm:px-10">
+            <header className="relative z-10 mx-auto grid w-full max-w-310 grid-cols-3 items-center gap-4 px-6 py-5 sm:px-10">
                 <span className="auth-caption text-foreground">
                     osTicket<span className="text-muted-foreground"> · Staff Console</span>
                 </span>
@@ -81,19 +81,19 @@ export function AuthLayout({
                 </a>
             </header>
 
-            <div className="relative z-10 mx-auto w-full max-w-[1240px] px-6 sm:px-10">
+            <div className="relative z-10 mx-auto w-full max-w-310 px-6 sm:px-10">
                 <div className="h-px w-full bg-border" />
             </div>
 
             {/* Editorial grid: 12-col on desktop, stacked on mobile. */}
-            <main className="relative z-10 mx-auto grid w-full max-w-[1240px] grid-cols-12 gap-6 px-6 py-12 sm:px-10 sm:py-16 lg:gap-10 lg:py-20">
+            <main className="relative z-10 mx-auto grid w-full max-w-310 flex-1 grid-cols-12 gap-6 px-6 py-12 sm:px-10 sm:py-16 lg:gap-10 lg:py-20">
                 {/* Left rail — section number + meta caption. */}
                 <aside className="col-span-12 lg:col-span-3 lg:pt-4">
                     <div className="auth-rise flex items-start gap-3" style={rise(0)}>
-                        <span className="font-sans text-[10px] font-medium leading-[15px] tracking-[0.1em] text-muted-foreground">
+                        <span className="font-sans text-[10px] font-medium leading-3.75 tracking-widest text-muted-foreground">
                             {sectionIndex}
                         </span>
-                        <div className="mt-[6px] h-px w-6 bg-foreground" />
+                        <div className="mt-1.5 h-px w-6 bg-foreground" />
                         <span className="auth-caption text-muted-foreground">
                             {tag ?? "Authentication"}
                         </span>
@@ -115,8 +115,8 @@ export function AuthLayout({
                     <h1
                         className={cn(
                             "auth-rise mt-5 font-sans font-medium text-foreground",
-                            "text-[44px] leading-[1] tracking-[-0.04em]",
-                            "sm:text-[64px] sm:leading-[1]",
+                            "text-[44px] leading-none tracking-[-0.04em]",
+                            "sm:text-[64px] sm:leading-none",
                             "lg:text-[80px] lg:leading-[0.96] lg:tracking-[-0.05em]",
                         )}
                         style={rise(120)}
@@ -126,14 +126,14 @@ export function AuthLayout({
 
                     {subtitle && (
                         <p
-                            className="auth-rise mt-6 max-w-[560px] font-sans text-sm leading-[22.75px] text-muted-foreground"
+                            className="auth-rise mt-6 max-w-140 font-sans text-sm leading-[22.75px] text-muted-foreground"
                             style={rise(200)}
                         >
                             {subtitle}
                         </p>
                     )}
 
-                    <div className="mt-8 w-full max-w-[560px] space-y-3">
+                    <div className="mt-8 w-full max-w-140 space-y-3">
                         {status && (
                             <Alert
                                 variant="success"
@@ -160,7 +160,7 @@ export function AuthLayout({
 
                     {/* Gradient border shell card */}
                     <div
-                        className="auth-rise mt-6 w-full max-w-[560px]"
+                        className="auth-rise mt-6 w-full max-w-140"
                         style={rise(340)}
                     >
                         <div className="auth-shell">
@@ -177,7 +177,7 @@ export function AuthLayout({
 
                     {footer && (
                         <div
-                            className="auth-rise mt-6 max-w-[560px]"
+                            className="auth-rise mt-6 max-w-140"
                             style={rise(440)}
                         >
                             {footer}
@@ -186,11 +186,11 @@ export function AuthLayout({
                 </section>
             </main>
 
-            <div className="relative z-10 mx-auto w-full max-w-[1240px] px-6 sm:px-10">
+            <div className="relative z-10 mx-auto w-full max-w-310 px-6 sm:px-10">
                 <div className="h-px w-full bg-border" />
             </div>
 
-            <footer className="relative z-10 mx-auto grid w-full max-w-[1240px] grid-cols-3 items-center gap-4 px-6 py-5 sm:px-10">
+            <footer className="relative z-10 mx-auto grid w-full max-w-310 grid-cols-3 items-center gap-4 px-6 py-5 sm:px-10">
                 <span className="auth-caption text-muted-foreground">
                     © {year} · osticket.com
                 </span>

--- a/resources/js/pages/Auth/TwoFactor.tsx
+++ b/resources/js/pages/Auth/TwoFactor.tsx
@@ -16,14 +16,9 @@ import {
     InputOTPSlot,
 } from "@/components/ui/input-otp";
 
-interface Props {
-    status?: string;
-    errors?: { code?: string };
-}
-
 type FormSubmitHandler = NonNullable<React.ComponentProps<"form">["onSubmit"]>;
 
-export default function TwoFactor({ status }: Props) {
+export default function TwoFactor() {
     const { t } = useTranslation();
     const { data, setData, post, processing, errors } = useForm({
         code: "",
@@ -55,25 +50,20 @@ export default function TwoFactor({ status }: Props) {
             eyebrowAccent="indigo"
             sectionIndex="05"
             footer={
-                <div className="flex flex-col gap-4">
-                    {status && (
-                        <p className="auth-caption text-[#15803d]">{status}</p>
-                    )}
-                    <div className="flex flex-wrap items-center justify-between gap-4">
-                        <Link href="/scp/login" className="auth-link-btn">
-                            ← {t("auth.two_factor.back_to_login")}
-                        </Link>
-                        <button
-                            type="button"
-                            onClick={resend}
-                            disabled={processing || isResending}
-                            className="auth-link-btn disabled:opacity-50"
-                        >
-                            {isResending
-                                ? t("auth.two_factor.resending")
-                                : t("auth.two_factor.resend")}
-                        </button>
-                    </div>
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <Link href="/scp/login" className="auth-link-btn">
+                        ← {t("auth.two_factor.back_to_login")}
+                    </Link>
+                    <button
+                        type="button"
+                        onClick={resend}
+                        disabled={processing || isResending}
+                        className="auth-link-btn disabled:opacity-50"
+                    >
+                        {isResending
+                            ? t("auth.two_factor.resending")
+                            : t("auth.two_factor.resend")}
+                    </button>
                 </div>
             }
         >


### PR DESCRIPTION
This updates the staged auth shell so resend success feedback on the manual two-factor page is rendered only once through `AuthLayout` instead of also appearing again in the `TwoFactor` footer.

It also changes `AuthLayout` into a full-height flex column and gives the shared `<main>` region `flex-1`, so the auth body can expand naturally between the header and footer.

The same layout file also carries the current utility-token cleanup already present in this branch, including the `max-w-310`, `max-w-140`, `leading-3.75`, `tracking-widest`, `mt-1.5`, and `leading-none` class substitutions.

Verification is limited to diff review and `git diff --check`; `npx tsc --noEmit` is still blocked in this workspace by the existing `TS2688: Cannot find type definition file for `vite/client`` environment issue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
