### PR TITLE
feat(auth-ui): ship the phase 2 staff auth dashboard shell

### DIFF
--- a/app/Http/Controllers/Account/MigrationBannerController.php
+++ b/app/Http/Controllers/Account/MigrationBannerController.php
@@ -24,6 +24,8 @@ class MigrationBannerController extends Controller
             'dismissed_migration_banner_at' => now(),
         ])->save();
 
+        $request->session()->forget("auth.migration_banner.{$staff->staff_id}");
+
         return back();
     }
 }

--- a/app/Http/Controllers/Account/MigrationBannerController.php
+++ b/app/Http/Controllers/Account/MigrationBannerController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Account;
+
+use App\Http\Controllers\Controller;
+use App\Models\Staff;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class MigrationBannerController extends Controller
+{
+    public function dismiss(Request $request): RedirectResponse
+    {
+        /** @var Staff $staff */
+        $staff = $request->user('staff');
+
+        $migration = $staff->authMigration()->first();
+
+        if (! $migration || is_null($migration->migrated_at)) {
+            return back();
+        }
+
+        $migration->forceFill([
+            'dismissed_migration_banner_at' => now(),
+        ])->save();
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Account/SecurityController.php
+++ b/app/Http/Controllers/Account/SecurityController.php
@@ -24,7 +24,6 @@ class SecurityController extends Controller
                 'confirmedAt' => $staff->two_factor_confirmed_at?->toIso8601String(),
                 'recoveryCodesCount' => count($staff->recoveryCodes()),
                 'qrCodeSvg' => $isPendingTwoFactorSetup ? $staff->twoFactorQrCodeSvg() : null,
-                'qrCodeUrl' => $isPendingTwoFactorSetup ? $staff->twoFactorQrCodeUrl() : null,
                 'setupKey' => $isPendingTwoFactorSetup ? $staff->two_factor_secret : null,
             ],
             'migration' => [

--- a/app/Http/Controllers/Account/TwoFactorSecurityController.php
+++ b/app/Http/Controllers/Account/TwoFactorSecurityController.php
@@ -103,6 +103,7 @@ class TwoFactorSecurityController extends Controller
             [
                 'migrated_at' => null,
                 'upgrade_method' => null,
+                'dismissed_migration_banner_at' => null,
             ],
         );
         $request->session()->forget("auth.migration_banner.{$staff->staff_id}");

--- a/app/Http/Controllers/Account/TwoFactorSecurityController.php
+++ b/app/Http/Controllers/Account/TwoFactorSecurityController.php
@@ -8,7 +8,6 @@ use App\Services\StaffTwoFactorService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Redirector;
 
 class TwoFactorSecurityController extends Controller
 {
@@ -61,6 +60,7 @@ class TwoFactorSecurityController extends Controller
                 'upgrade_method' => 'totp',
             ],
         );
+        $request->session()->forget("auth.migration_banner.{$staff->staff_id}");
 
         return $this->securityRedirect($request, 4)
             ->with('status', 'Two-factor authentication enabled.')
@@ -105,13 +105,14 @@ class TwoFactorSecurityController extends Controller
                 'upgrade_method' => null,
             ],
         );
+        $request->session()->forget("auth.migration_banner.{$staff->staff_id}");
 
         return redirect()
             ->route('scp.account.security')
             ->with('status', 'Two-factor authentication disabled.');
     }
 
-    private function securityRedirect(Request $request, int $wizardStep): Redirector|RedirectResponse
+    private function securityRedirect(Request $request, int $wizardStep): RedirectResponse
     {
         if ($request->boolean('return_to_wizard')) {
             return redirect()->route('scp.account.security.two-factor.show', ['step' => $wizardStep]);

--- a/app/Http/Controllers/Account/TwoFactorSecurityController.php
+++ b/app/Http/Controllers/Account/TwoFactorSecurityController.php
@@ -26,21 +26,6 @@ class TwoFactorSecurityController extends Controller
             ->with('status', 'Two-factor authentication setup started. Scan the QR code and confirm a code to finish.');
     }
 
-    public function qrCode(Request $request): JsonResponse
-    {
-        /** @var Staff $staff */
-        $staff = $request->user('staff');
-
-        if (is_null($staff->two_factor_secret) || ! is_null($staff->two_factor_confirmed_at)) {
-            return response()->json([]);
-        }
-
-        return response()->json([
-            'svg' => $staff->twoFactorQrCodeSvg(),
-            'url' => $staff->twoFactorQrCodeUrl(),
-        ]);
-    }
-
     public function confirm(Request $request): RedirectResponse
     {
         $validated = $request->validate([

--- a/app/Http/Controllers/Account/TwoFactorSecurityController.php
+++ b/app/Http/Controllers/Account/TwoFactorSecurityController.php
@@ -8,6 +8,7 @@ use App\Services\StaffTwoFactorService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Redirector;
 
 class TwoFactorSecurityController extends Controller
 {
@@ -22,8 +23,7 @@ class TwoFactorSecurityController extends Controller
 
         $this->twoFactor->enable($staff, $request->boolean('force'));
 
-        return redirect()
-            ->route('scp.account.security')
+        return $this->securityRedirect($request, 2)
             ->with('status', 'Two-factor authentication setup started. Scan the QR code and confirm a code to finish.');
     }
 
@@ -46,6 +46,7 @@ class TwoFactorSecurityController extends Controller
     {
         $validated = $request->validate([
             'code' => ['required', 'string'],
+            'return_to_wizard' => ['nullable', 'boolean'],
         ]);
 
         /** @var Staff $staff */
@@ -61,8 +62,7 @@ class TwoFactorSecurityController extends Controller
             ],
         );
 
-        return redirect()
-            ->route('scp.account.security')
+        return $this->securityRedirect($request, 4)
             ->with('status', 'Two-factor authentication enabled.')
             ->with('two_factor_recovery_codes', $staff->fresh()->recoveryCodes());
     }
@@ -109,5 +109,14 @@ class TwoFactorSecurityController extends Controller
         return redirect()
             ->route('scp.account.security')
             ->with('status', 'Two-factor authentication disabled.');
+    }
+
+    private function securityRedirect(Request $request, int $wizardStep): Redirector|RedirectResponse
+    {
+        if ($request->boolean('return_to_wizard')) {
+            return redirect()->route('scp.account.security.two-factor.show', ['step' => $wizardStep]);
+        }
+
+        return redirect()->route('scp.account.security');
     }
 }

--- a/app/Http/Controllers/Account/TwoFactorWizardController.php
+++ b/app/Http/Controllers/Account/TwoFactorWizardController.php
@@ -28,7 +28,6 @@ class TwoFactorWizardController extends Controller
                 'pending' => $hasSecret && ! $confirmed,
                 'method' => $staff->hasTotpEnabled() ? 'app' : null,
                 'qrCodeSvg' => $hasSecret && ! $confirmed ? $staff->twoFactorQrCodeSvg() : null,
-                'qrCodeUrl' => $hasSecret && ! $confirmed ? $staff->twoFactorQrCodeUrl() : null,
                 'setupKey' => $hasSecret && ! $confirmed ? $staff->two_factor_secret : null,
                 'recoveryCodes' => $request->session()->get('two_factor_recovery_codes', []),
             ],

--- a/app/Http/Controllers/Account/TwoFactorWizardController.php
+++ b/app/Http/Controllers/Account/TwoFactorWizardController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Account;
+
+use App\Http\Controllers\Controller;
+use App\Models\Staff;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TwoFactorWizardController extends Controller
+{
+    public function show(Request $request): Response
+    {
+        /** @var Staff $staff */
+        $staff = $request->user('staff');
+        $staff->loadMissing('twoFactorCredential');
+
+        $hasSecret = ! is_null($staff->two_factor_secret);
+        $confirmed = ! is_null($staff->two_factor_confirmed_at);
+        $step = (int) $request->query('step', $confirmed ? 5 : ($hasSecret ? 3 : 1));
+        $step = max(1, min(5, $step));
+
+        return Inertia::render('Account/Security/TwoFactorWizard', [
+            'step' => $step,
+            'twoFactor' => [
+                'enabled' => $confirmed,
+                'pending' => $hasSecret && ! $confirmed,
+                'method' => $staff->hasTotpEnabled() ? 'app' : null,
+                'qrCodeSvg' => $hasSecret && ! $confirmed ? $staff->twoFactorQrCodeSvg() : null,
+                'qrCodeUrl' => $hasSecret && ! $confirmed ? $staff->twoFactorQrCodeUrl() : null,
+                'setupKey' => $hasSecret && ! $confirmed ? $staff->two_factor_secret : null,
+                'recoveryCodes' => $request->session()->get('two_factor_recovery_codes', []),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -4,14 +4,15 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\Staff;
-use App\Services\TwoFactorAuthService;
+use App\Services\LegacyTwoFactorMigrationService;
 use App\Services\TwoFactorAppChallengeService;
+use App\Services\TwoFactorAuthService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -25,6 +26,7 @@ class LoginController extends Controller
     public function __construct(
         private readonly TwoFactorAuthService $twoFactor,
         private readonly TwoFactorAppChallengeService $appChallenge,
+        private readonly LegacyTwoFactorMigrationService $legacyMigration,
     ) {}
 
     public function showLogin(): Response
@@ -70,6 +72,7 @@ class LoginController extends Controller
         RateLimiter::clear($throttleKey);
 
         $staff->rehashPasswordIfNeeded($credentials['password']);
+        $this->legacyMigration->migrateIfNeeded($staff);
         $this->ensureDashboardIsTheFallbackIntendedUrl($request);
 
         if ($staff->hasTotpEnabled()) {
@@ -85,7 +88,7 @@ class LoginController extends Controller
 
         Mail::raw(
             "Your osTicket login code is: {$code}\n\nThis code expires in 6 minutes.",
-            fn($message) => $message
+            fn ($message) => $message
                 ->to($staff->email)
                 ->subject('Your Login Verification Code')
         );

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -48,7 +48,7 @@ class HandleInertiaRequests extends Middleware
                         'id' => $staff->staff_id,
                         'name' => trim(($staff->firstname ?? '').' '.($staff->lastname ?? '')) ?: $staff->username,
                         'username' => $staff->username,
-                        'migrationBanner' => $this->shouldShowMigrationBanner($staff),
+                        'migrationBanner' => $this->migrationBannerVisible($request, $staff),
                     ]
                     : null,
                 'throttle' => [
@@ -62,12 +62,31 @@ class HandleInertiaRequests extends Middleware
 
     private function shouldShowMigrationBanner(Staff $staff): bool
     {
-        $migration = $staff->loadMissing('authMigration')->authMigration;
+        $staff->loadMissing(['authMigration', 'twoFactorCredential']);
+        $migration = $staff->authMigration;
 
         if (! $migration || is_null($migration->migrated_at)) {
             return false;
         }
 
         return is_null($migration->dismissed_migration_banner_at) && ! $staff->hasTotpEnabled();
+    }
+
+    private function migrationBannerVisible(Request $request, Staff $staff): bool
+    {
+        if (! $request->routeIs('scp.dashboard')) {
+            return false;
+        }
+
+        $key = "auth.migration_banner.{$staff->staff_id}";
+
+        if ($request->session()->has($key)) {
+            return (bool) $request->session()->get($key);
+        }
+
+        $visible = $this->shouldShowMigrationBanner($staff);
+        $request->session()->put($key, $visible);
+
+        return $visible;
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -8,6 +8,8 @@ use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
 {
+    private const MIGRATION_BANNER_CACHE_TTL_SECONDS = 300;
+
     /**
      * The root template that's loaded on the first page visit.
      *
@@ -79,19 +81,34 @@ class HandleInertiaRequests extends Middleware
         }
 
         $key = "auth.migration_banner.{$staff->staff_id}";
+        $cached = $request->session()->get($key);
 
-        if ($request->session()->has($key)) {
-            return (bool) $request->session()->get($key);
+        if ($this->hasFreshMigrationBannerCache($cached)) {
+            return $cached['visible'];
         }
 
         $visible = $this->shouldShowMigrationBanner($staff);
-
-        if ($visible) {
-            $request->session()->put($key, true);
-        } else {
-            $request->session()->forget($key);
-        }
+        $request->session()->put($key, [
+            'visible' => $visible,
+            'cached_at' => now()->timestamp,
+        ]);
 
         return $visible;
+    }
+
+    /**
+     * @param  mixed  $cached
+     */
+    private function hasFreshMigrationBannerCache(mixed $cached): bool
+    {
+        if (! is_array($cached) || ! array_key_exists('visible', $cached) || ! array_key_exists('cached_at', $cached)) {
+            return false;
+        }
+
+        if (! is_bool($cached['visible']) || ! is_numeric($cached['cached_at'])) {
+            return false;
+        }
+
+        return now()->timestamp - (int) $cached['cached_at'] < self::MIGRATION_BANNER_CACHE_TTL_SECONDS;
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Staff;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -35,16 +36,38 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        /** @var Staff|null $staff */
+        $staff = $request->user('staff');
+
         return [
             ...parent::share($request),
             'status' => fn () => $request->session()->get('status'),
-            'auth' => [
-                'throttle' => fn () => [
+            'auth' => fn () => [
+                'staff' => $staff
+                    ? [
+                        'id' => $staff->staff_id,
+                        'name' => trim(($staff->firstname ?? '').' '.($staff->lastname ?? '')) ?: $staff->username,
+                        'username' => $staff->username,
+                        'migrationBanner' => $this->shouldShowMigrationBanner($staff),
+                    ]
+                    : null,
+                'throttle' => [
                     'attemptsRemaining' => $request->session()->get('throttle.attemptsRemaining'),
                     'secondsUntilRetry' => $request->session()->get('throttle.secondsUntilRetry'),
                     'username' => $request->session()->get('throttle.username'),
                 ],
             ],
         ];
+    }
+
+    private function shouldShowMigrationBanner(Staff $staff): bool
+    {
+        $migration = $staff->loadMissing('authMigration')->authMigration;
+
+        if (! $migration || is_null($migration->migrated_at)) {
+            return false;
+        }
+
+        return is_null($migration->dismissed_migration_banner_at) && ! $staff->hasTotpEnabled();
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -85,7 +85,12 @@ class HandleInertiaRequests extends Middleware
         }
 
         $visible = $this->shouldShowMigrationBanner($staff);
-        $request->session()->put($key, $visible);
+
+        if ($visible) {
+            $request->session()->put($key, true);
+        } else {
+            $request->session()->forget($key);
+        }
 
         return $visible;
     }

--- a/app/Models/StaffAuthMigration.php
+++ b/app/Models/StaffAuthMigration.php
@@ -10,10 +10,17 @@ class StaffAuthMigration extends Model
 
     protected $table = 'staff_auth_migrations';
 
-    protected $guarded = [];
+    protected $fillable = [
+        'staff_id',
+        'migrated_at',
+        'must_upgrade_after',
+        'upgrade_method',
+        'dismissed_migration_banner_at',
+    ];
 
     protected $casts = [
         'migrated_at' => 'immutable_datetime',
         'must_upgrade_after' => 'immutable_datetime',
+        'dismissed_migration_banner_at' => 'immutable_datetime',
     ];
 }

--- a/app/Services/LegacyTwoFactorMigrationService.php
+++ b/app/Services/LegacyTwoFactorMigrationService.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Config;
+use App\Models\Staff;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Laravel\Fortify\RecoveryCode;
+
+class LegacyTwoFactorMigrationService
+{
+    public function migrateIfNeeded(Staff $staff): void
+    {
+        try {
+            if ($this->migrateTotpIfNeeded($staff)) {
+                return;
+            }
+
+            $this->dismissEmailBannerIfNeeded($staff);
+        } catch (\Throwable $exception) {
+            Log::warning('Legacy 2FA migration failed', [
+                'staff_id' => $staff->staff_id,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    private function migrateTotpIfNeeded(Staff $staff): bool
+    {
+        if ($staff->hasTotpEnabled()) {
+            return true;
+        }
+
+        if ($this->hasClearedMigrationRecord($staff)) {
+            return true;
+        }
+
+        $decoded = $this->legacyBackendConfig($staff, 'auth.agent');
+
+        if (! $this->isVerified($decoded)) {
+            return false;
+        }
+
+        $base32 = (string) ($decoded['config']['key'] ?? '');
+
+        if ($base32 === '') {
+            return false;
+        }
+
+        $staff->upsertTwoFactorCredential([
+            'two_factor_secret' => $base32,
+            'two_factor_recovery_codes' => Collection::times(8, fn () => RecoveryCode::generate())->all(),
+            'two_factor_confirmed_at' => now(),
+        ]);
+
+        $staff->authMigration()->updateOrCreate(
+            ['staff_id' => $staff->staff_id],
+            [
+                'migrated_at' => now(),
+                'upgrade_method' => 'totp',
+            ],
+        );
+
+        return true;
+    }
+
+    private function hasClearedMigrationRecord(Staff $staff): bool
+    {
+        $migration = $staff->loadMissing('authMigration')->authMigration;
+
+        // The disable flow leaves a cleared row behind; treat it as an opt-out
+        // so verified legacy TOTP config is not re-imported on later logins.
+        return $migration
+            && is_null($migration->migrated_at)
+            && is_null($migration->upgrade_method)
+            && is_null($migration->dismissed_migration_banner_at);
+    }
+
+    private function dismissEmailBannerIfNeeded(Staff $staff): void
+    {
+        if (! is_null($staff->loadMissing('authMigration')->authMigration?->dismissed_migration_banner_at)) {
+            return;
+        }
+
+        $decoded = $this->legacyBackendConfig($staff, 'email');
+
+        if (! $this->isVerified($decoded)) {
+            return;
+        }
+
+        $staff->authMigration()->updateOrCreate(
+            ['staff_id' => $staff->staff_id],
+            [
+                'migrated_at' => now(),
+                'dismissed_migration_banner_at' => now(),
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function legacyBackendConfig(Staff $staff, string $backend): array
+    {
+        $value = Config::query()
+            ->namespace("staff.{$staff->staff_id}")
+            ->where('key', $backend)
+            ->value('value');
+
+        if (! is_string($value)) {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $decoded
+     */
+    private function isVerified(array $decoded): bool
+    {
+        return (int) ($decoded['verified'] ?? 0) > 0;
+    }
+}

--- a/database/migrations/2026_04_22_140000_add_dismissed_migration_banner_at_to_staff_auth_migrations.php
+++ b/database/migrations/2026_04_22_140000_add_dismissed_migration_banner_at_to_staff_auth_migrations.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $schema = Schema::connection('osticket2');
+
+        if (! $schema->hasTable('staff_auth_migrations')) {
+            return;
+        }
+
+        if ($schema->hasColumn('staff_auth_migrations', 'dismissed_migration_banner_at')) {
+            return;
+        }
+
+        $schema->table('staff_auth_migrations', function (Blueprint $table): void {
+            $table->timestamp('dismissed_migration_banner_at')->nullable()->after('upgrade_method');
+        });
+    }
+
+    public function down(): void
+    {
+        $schema = Schema::connection('osticket2');
+
+        if (! $schema->hasTable('staff_auth_migrations')) {
+            return;
+        }
+
+        if (! $schema->hasColumn('staff_auth_migrations', 'dismissed_migration_banner_at')) {
+            return;
+        }
+
+        $schema->table('staff_auth_migrations', function (Blueprint $table): void {
+            $table->dropColumn('dismissed_migration_banner_at');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "biarritz",
+    "name": "nicosia",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "nicosia",
+    "name": "tyler",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",
                 "react-i18next": "^17.0.2",
+                "recharts": "^3.8.0",
                 "shadcn": "^4.2.0",
                 "tailwind-merge": "^3.5.0",
                 "tw-animate-css": "^1.4.0"
@@ -1171,6 +1172,42 @@
                 "url": "https://github.com/sponsors/Boshen"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+            "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@reduxjs/toolkit/node_modules/immer": {
+            "version": "11.1.4",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+            "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.0.0-rc.15",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -1470,6 +1507,18 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+            "license": "MIT"
         },
         "node_modules/@tailwindcss/node": {
             "version": "4.2.2",
@@ -1777,6 +1826,69 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.1.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+            "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "license": "MIT"
+        },
         "node_modules/@types/react": {
             "version": "19.2.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1801,6 +1913,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
             "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
             "license": "MIT"
         },
         "node_modules/@types/validate-npm-package-name": {
@@ -2482,6 +2600,127 @@
             "devOptional": true,
             "license": "MIT"
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/data-uri-to-buffer": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -2518,6 +2757,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
         },
         "node_modules/dedent": {
             "version": "1.7.2",
@@ -2814,6 +3059,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
         },
         "node_modules/eventsource": {
             "version": "3.0.7",
@@ -3510,6 +3761,16 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+            "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3540,6 +3801,15 @@
             "peerDependencies": {
                 "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
                 "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/ip-address": {
@@ -5039,6 +5309,36 @@
                 }
             }
         },
+        "node_modules/react-is": {
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+            "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/recast": {
             "version": "0.23.11",
             "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -5053,6 +5353,51 @@
             },
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/recharts": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+            "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+            "license": "MIT",
+            "workspaces": [
+                "www"
+            ],
+            "dependencies": {
+                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^10.1.1",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.1.1",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/require-directory": {
@@ -5950,6 +6295,28 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "license": "MIT AND ISC",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "osTicket2.0",
+    "name": "biarritz",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-i18next": "^17.0.2",
+        "recharts": "^3.8.0",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -173,6 +173,7 @@
     --input: #ffffff;
     --ring: #c4a5f3;
     --radius: 0.25rem;
+
     color-scheme: light;
     font-family: "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif;
     font-feature-settings: "ss01", "cv11";
@@ -392,7 +393,7 @@
     cursor: not-allowed;
 }
 
-/* Inputs inside auth-theme — clean cream-bordered with orange focus. */
+/* Inputs inside auth-theme — clean cream-bordered with lavender focus. */
 .auth-theme [data-slot="input"] {
     height: 44px;
     border-radius: 4px;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -149,29 +149,29 @@
     }
 }
 
-/* Editorial light auth theme — scoped to .auth-theme only, does not leak.
- * Palette: warm cream surface on white, black foreground, gradient accents
- * (orange #F97316 → pink #EC4899 → indigo #6366F1). Inter-only typography. */
+/* Helpdesk Dashboard light theme — scoped to .auth-theme only, does not leak.
+ * Palette: slate-to-white surface on white, slate-900 foreground, lavender-purple accent
+ * (#C4A5F3 primary → #5B619D secondary → #22C55E tertiary). Inter typography. */
 .auth-theme {
     --background: #ffffff;
-    --foreground: #18181b;
-    --surface: #f4f2eb;
-    --card: #f4f2eb;
-    --card-foreground: #18181b;
+    --foreground: #0f172a;
+    --surface: #f8fafc;
+    --card: #f8fafc;
+    --card-foreground: #0f172a;
     --popover: #ffffff;
-    --popover-foreground: #18181b;
-    --primary: #18181b;
+    --popover-foreground: #0f172a;
+    --primary: #0f172a;
     --primary-foreground: #ffffff;
-    --secondary: #f4f2eb;
-    --secondary-foreground: #18181b;
-    --muted: #f4f2eb;
-    --muted-foreground: #52525b;
-    --accent: #f97316;
-    --accent-foreground: #18181b;
+    --secondary: #f1f5f9;
+    --secondary-foreground: #0f172a;
+    --muted: #f1f5f9;
+    --muted-foreground: #64748b;
+    --accent: #c4a5f3;
+    --accent-foreground: #0f172a;
     --destructive: #dc2626;
-    --border: #e2e0d8;
+    --border: #f1f5f9;
     --input: #ffffff;
-    --ring: #18181b;
+    --ring: #c4a5f3;
     --radius: 0.25rem;
     color-scheme: light;
     font-family: "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif;
@@ -179,54 +179,50 @@
 }
 
 .auth-theme ::selection {
-    background: rgba(249, 115, 22, 0.28);
-    color: #18181b;
+    background: rgba(196, 165, 243, 0.30);
+    color: #0f172a;
 }
 
-/* Editorial gradient — orange → pink → indigo. Used for border shells,
- * underlines, accent flourishes. */
 .auth-gradient {
     background: linear-gradient(
         to right bottom,
-        #fb923c 0%,
-        #ec4899 55%,
-        #6366f1 100%
+        #c4a5f3 0%,
+        #7c6fbd 55%,
+        #5b619d 100%
     );
 }
 
-/* Horizontal gradient variant — for rules, accent bars. */
 .auth-gradient-h {
     background: linear-gradient(
         to right,
-        #fb923c 0%,
-        #ec4899 55%,
-        #6366f1 100%
+        #c4a5f3 0%,
+        #7c6fbd 55%,
+        #5b619d 100%
     );
 }
 
-/* Gradient border shell — 1px outer + cream inner. Wrap .auth-shell around
+/* Gradient border shell — 1px outer + slate inner. Wrap .auth-shell around
  * a child with class .auth-shell-inner to get a hairline gradient frame. */
 .auth-shell {
     padding: 1px;
-    border-radius: 10px;
+    border-radius: 12px;
     background: linear-gradient(
         to right bottom,
-        #fb923c 0%,
-        #ec4899 55%,
-        #6366f1 100%
+        #c4a5f3 0%,
+        #7c6fbd 55%,
+        #5b619d 100%
     );
     box-shadow:
-        rgba(236, 72, 153, 0.10) 0 10px 15px -3px,
-        rgba(236, 72, 153, 0.10) 0 4px 6px -4px,
+        rgba(196, 165, 243, 0.20) 0 10px 15px -3px,
+        rgba(196, 165, 243, 0.15) 0 4px 6px -4px,
         rgba(0, 0, 0, 0.04) 0 2px 8px -2px;
 }
 
 .auth-shell-inner {
-    border-radius: 9px;
+    border-radius: 11px;
     background: var(--surface);
 }
 
-/* Warm corner gradient mesh — decorative wash behind the hero. */
 .auth-mesh {
     position: absolute;
     inset: 0;
@@ -235,18 +231,18 @@
     background:
         radial-gradient(
             55% 40% at 92% 8%,
-            rgba(249, 115, 22, 0.20) 0%,
-            rgba(249, 115, 22, 0) 70%
+            rgba(196, 165, 243, 0.18) 0%,
+            rgba(196, 165, 243, 0) 70%
         ),
         radial-gradient(
             50% 35% at 8% 100%,
-            rgba(99, 102, 241, 0.14) 0%,
-            rgba(99, 102, 241, 0) 70%
+            rgba(91, 97, 157, 0.12) 0%,
+            rgba(91, 97, 157, 0) 70%
         ),
         radial-gradient(
             40% 30% at 60% 60%,
-            rgba(236, 72, 153, 0.10) 0%,
-            rgba(236, 72, 153, 0) 70%
+            rgba(34, 197, 94, 0.07) 0%,
+            rgba(34, 197, 94, 0) 70%
         );
 }
 
@@ -265,7 +261,6 @@
     background-size: 3px 3px;
 }
 
-/* Ruler — thin border with gradient partial accent. */
 .auth-rule {
     position: relative;
     height: 1px;
@@ -276,7 +271,7 @@
     content: "";
     position: absolute;
     inset: 0 70% 0 0;
-    background: linear-gradient(to right, #fb923c 0%, #ec4899 100%);
+    background: linear-gradient(to right, #c4a5f3 0%, #5b619d 100%);
 }
 
 @keyframes auth-rise {
@@ -296,7 +291,6 @@
     }
 }
 
-/* Eyebrow caption — micro uppercase with dot. */
 .auth-eyebrow {
     display: inline-flex;
     align-items: center;
@@ -319,11 +313,11 @@
     flex-shrink: 0;
 }
 
-.auth-eyebrow[data-accent="orange"]::before { background: #f97316; }
-.auth-eyebrow[data-accent="pink"]::before { background: #ec4899; }
-.auth-eyebrow[data-accent="indigo"]::before { background: #6366f1; }
+.auth-eyebrow[data-accent="purple"]::before { background: #c4a5f3; }
+.auth-eyebrow[data-accent="indigo"]::before { background: #5b619d; }
+.auth-eyebrow[data-accent="emerald"]::before { background: #22c55e; }
 .auth-eyebrow[data-accent="gradient"]::before {
-    background: linear-gradient(135deg, #fb923c, #ec4899, #6366f1);
+    background: linear-gradient(135deg, #c4a5f3, #7c6fbd, #5b619d);
 }
 
 /* Tiny caption — uppercase label, used for metadata. */
@@ -337,7 +331,6 @@
     color: var(--muted-foreground);
 }
 
-/* Secondary button — tracked uppercase underline. */
 .auth-link-btn {
     display: inline-flex;
     align-items: center;
@@ -355,11 +348,10 @@
 }
 
 .auth-link-btn:hover {
-    color: #be185d;
-    border-color: #be185d;
+    color: #5b619d;
+    border-color: #5b619d;
 }
 
-/* Primary submit — black pill with gradient hover accent. */
 .auth-submit {
     display: inline-flex;
     width: 100%;
@@ -378,16 +370,16 @@
     text-transform: uppercase;
     transition: background 200ms ease, transform 150ms ease;
     box-shadow:
-        rgba(24, 24, 27, 0.1) 0 2px 4px -2px,
-        rgba(24, 24, 27, 0.05) 0 1px 2px 0;
+        rgba(15, 23, 42, 0.10) 0 2px 4px -2px,
+        rgba(15, 23, 42, 0.05) 0 1px 2px 0;
 }
 
 .auth-submit:hover:not(:disabled) {
     background: linear-gradient(
         to right,
-        #18181b 0%,
-        #3b1a3d 50%,
-        #18181b 100%
+        #0f172a 0%,
+        #1e1b4b 50%,
+        #0f172a 100%
     );
 }
 
@@ -413,16 +405,30 @@
 }
 
 .auth-theme [data-slot="input"]:hover {
-    border-color: #cbc8bd;
+    border-color: #cbd5e1;
 }
 
 .auth-theme [data-slot="input"]:focus-visible {
     outline: none;
-    border-color: #18181b;
-    box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.18);
+    border-color: #5b619d;
+    box-shadow: 0 0 0 3px rgba(196, 165, 243, 0.25);
 }
 
 .auth-theme [data-slot="input"][aria-invalid="true"] {
     border-color: var(--destructive);
     box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.12);
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+    background: #e2e8f0;
+    border-radius: 9999px;
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -420,6 +420,11 @@
     box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.12);
 }
 
+.custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: #e2e8f0 transparent;
+}
+
 .custom-scrollbar::-webkit-scrollbar {
     width: 4px;
     height: 4px;

--- a/resources/js/components/auth/MigrationBanner.tsx
+++ b/resources/js/components/auth/MigrationBanner.tsx
@@ -1,0 +1,62 @@
+import { router, usePage } from "@inertiajs/react";
+
+import {
+    Alert,
+    AlertAction,
+    AlertDescription,
+    AlertTitle,
+} from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+interface SharedProps extends Record<string, unknown> {
+    auth?: {
+        staff?: {
+            migrationBanner?: boolean;
+        } | null;
+    };
+}
+
+export function MigrationBanner() {
+    const { props } = usePage<SharedProps>();
+    const visible = props.auth?.staff?.migrationBanner;
+
+    if (!visible) {
+        return null;
+    }
+
+    return (
+        <Alert className="mb-6 rounded-2xl border-blue-200 bg-blue-50 text-blue-900">
+            <AlertTitle>Your account moved to the new authentication system</AlertTitle>
+            <AlertDescription>
+                Add an authenticator app now to harden your staff account and complete the migration.
+            </AlertDescription>
+            <AlertAction className="static mt-4 flex flex-wrap gap-2 sm:absolute sm:top-3 sm:right-3 sm:mt-0">
+                <Button
+                    size="sm"
+                    onClick={() =>
+                        router.get(
+                            "/scp/account/security/two-factor",
+                            { step: 1 },
+                            { preserveScroll: true },
+                        )
+                    }
+                >
+                    Enable 2FA
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                        router.post(
+                            "/scp/account/migration-banner/dismiss",
+                            {},
+                            { preserveScroll: true },
+                        )
+                    }
+                >
+                    Dismiss
+                </Button>
+            </AlertAction>
+        </Alert>
+    );
+}

--- a/resources/js/components/ui/card.tsx
+++ b/resources/js/components/ui/card.tsx
@@ -1,0 +1,100 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({
+    className,
+    size = "default",
+    ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+    return (
+        <div
+            data-slot="card"
+            data-size={size}
+            className={cn(
+                "group/card flex flex-col gap-6 overflow-hidden rounded-2xl bg-card py-6 text-sm text-card-foreground ring-1 ring-foreground/10 has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="card-header"
+            className={cn(
+                "group/card-header @container/card-header grid auto-rows-min items-start gap-2 rounded-t-xl px-6 group-data-[size=sm]/card:px-4 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-6 group-data-[size=sm]/card:[.border-b]:pb-4",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="card-title"
+            className={cn("font-heading text-base font-medium", className)}
+            {...props}
+        />
+    );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="card-description"
+            className={cn("text-sm text-muted-foreground", className)}
+            {...props}
+        />
+    );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="card-action"
+            className={cn(
+                "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="card-content"
+            className={cn("px-6 group-data-[size=sm]/card:px-4", className)}
+            {...props}
+        />
+    );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <div
+            data-slot="card-footer"
+            className={cn(
+                "flex items-center rounded-b-xl px-6 group-data-[size=sm]/card:px-4 [.border-t]:pt-6 group-data-[size=sm]/card:[.border-t]:pt-4",
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+export {
+    Card,
+    CardHeader,
+    CardFooter,
+    CardTitle,
+    CardAction,
+    CardDescription,
+    CardContent,
+};

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -8,6 +8,9 @@ import { cn } from "@/lib/utils";
 const THEMES = { light: "", dark: ".dark" } as const;
 
 const INITIAL_DIMENSION = { width: 320, height: 200 } as const;
+const SAFE_CSS_COLOR_VALUE =
+    /^(?:#[\da-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|color-mix)\([a-zA-Z0-9\s.,%#+\-/*()]+\)|var\(--[a-zA-Z0-9_-]+\)|[a-zA-Z]+)$/;
+
 type TooltipNameType = number | string;
 
 export type ChartConfig = Record<
@@ -35,6 +38,21 @@ function useChart() {
     }
 
     return context;
+}
+
+function cssAttributeValue(value: string) {
+    return value
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/[\n\r\f]/g, "");
+}
+
+function cssVariableName(value: string) {
+    return value.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function safeCssColor(value: string | undefined) {
+    return value && SAFE_CSS_COLOR_VALUE.test(value) ? value : null;
 }
 
 function ChartContainer({
@@ -94,13 +112,17 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
                 __html: Object.entries(THEMES)
                     .map(
                         ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
+${prefix} [data-chart="${cssAttributeValue(id)}"] {
 ${colorConfig
     .map(([key, itemConfig]) => {
         const color =
             itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
             itemConfig.color;
-        return color ? `  --color-${key}: ${color};` : null;
+        const colorValue = safeCssColor(color);
+
+        return colorValue
+            ? `  --color-${cssVariableName(key)}: ${colorValue};`
+            : null;
     })
     .join("\n")}
 }
@@ -217,7 +239,7 @@ function ChartTooltipContent({
                             >
                                 {formatter &&
                                 item?.value !== undefined &&
-                                item.name ? (
+                                item.name != null ? (
                                     formatter(
                                         item.value,
                                         item.name,

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -1,0 +1,404 @@
+import * as React from "react";
+import * as RechartsPrimitive from "recharts";
+import type { TooltipValueType } from "recharts";
+
+import { cn } from "@/lib/utils";
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const;
+
+const INITIAL_DIMENSION = { width: 320, height: 200 } as const;
+type TooltipNameType = number | string;
+
+export type ChartConfig = Record<
+    string,
+    {
+        label?: React.ReactNode;
+        icon?: React.ComponentType;
+    } & (
+        | { color?: string; theme?: never }
+        | { color?: never; theme: Record<keyof typeof THEMES, string> }
+    )
+>;
+
+type ChartContextProps = {
+    config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+    const context = React.useContext(ChartContext);
+
+    if (!context) {
+        throw new Error("useChart must be used within a <ChartContainer />");
+    }
+
+    return context;
+}
+
+function ChartContainer({
+    id,
+    className,
+    children,
+    config,
+    initialDimension = INITIAL_DIMENSION,
+    ...props
+}: React.ComponentProps<"div"> & {
+    config: ChartConfig;
+    children: React.ComponentProps<
+        typeof RechartsPrimitive.ResponsiveContainer
+    >["children"];
+    initialDimension?: {
+        width: number;
+        height: number;
+    };
+}) {
+    const uniqueId = React.useId();
+    const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`;
+
+    return (
+        <ChartContext.Provider value={{ config }}>
+            <div
+                data-slot="chart"
+                data-chart={chartId}
+                className={cn(
+                    "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+                    className,
+                )}
+                {...props}
+            >
+                <ChartStyle id={chartId} config={config} />
+                <RechartsPrimitive.ResponsiveContainer
+                    initialDimension={initialDimension}
+                >
+                    {children}
+                </RechartsPrimitive.ResponsiveContainer>
+            </div>
+        </ChartContext.Provider>
+    );
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+    const colorConfig = Object.entries(config).filter(
+        ([, config]) => config.theme ?? config.color,
+    );
+
+    if (!colorConfig.length) {
+        return null;
+    }
+
+    return (
+        <style
+            dangerouslySetInnerHTML={{
+                __html: Object.entries(THEMES)
+                    .map(
+                        ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+    .map(([key, itemConfig]) => {
+        const color =
+            itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
+            itemConfig.color;
+        return color ? `  --color-${key}: ${color};` : null;
+    })
+    .join("\n")}
+}
+`,
+                    )
+                    .join("\n"),
+            }}
+        />
+    );
+};
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+function ChartTooltipContent({
+    active,
+    payload,
+    className,
+    indicator = "dot",
+    hideLabel = false,
+    hideIndicator = false,
+    label,
+    labelFormatter,
+    labelClassName,
+    formatter,
+    color,
+    nameKey,
+    labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<"div"> & {
+        hideLabel?: boolean;
+        hideIndicator?: boolean;
+        indicator?: "line" | "dot" | "dashed";
+        nameKey?: string;
+        labelKey?: string;
+    } & Omit<
+        RechartsPrimitive.DefaultTooltipContentProps<
+            TooltipValueType,
+            TooltipNameType
+        >,
+        "accessibilityLayer"
+    >) {
+    const { config } = useChart();
+
+    const tooltipLabel = React.useMemo(() => {
+        if (hideLabel || !payload?.length) {
+            return null;
+        }
+
+        const [item] = payload;
+        const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`;
+        const itemConfig = getPayloadConfigFromPayload(config, item, key);
+        const value =
+            !labelKey && typeof label === "string"
+                ? (config[label]?.label ?? label)
+                : itemConfig?.label;
+
+        if (labelFormatter) {
+            return (
+                <div className={cn("font-medium", labelClassName)}>
+                    {labelFormatter(value, payload)}
+                </div>
+            );
+        }
+
+        if (!value) {
+            return null;
+        }
+
+        return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+    }, [
+        label,
+        labelFormatter,
+        payload,
+        hideLabel,
+        labelClassName,
+        config,
+        labelKey,
+    ]);
+
+    if (!active || !payload?.length) {
+        return null;
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== "dot";
+
+    return (
+        <div
+            className={cn(
+                "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+                className,
+            )}
+        >
+            {!nestLabel ? tooltipLabel : null}
+            <div className="grid gap-1.5">
+                {payload
+                    .filter((item) => item.type !== "none")
+                    .map((item, index) => {
+                        const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
+                        const itemConfig = getPayloadConfigFromPayload(
+                            config,
+                            item,
+                            key,
+                        );
+                        const indicatorColor =
+                            color ?? item.payload?.fill ?? item.color;
+
+                        return (
+                            <div
+                                key={index}
+                                className={cn(
+                                    "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                                    indicator === "dot" && "items-center",
+                                )}
+                            >
+                                {formatter &&
+                                item?.value !== undefined &&
+                                item.name ? (
+                                    formatter(
+                                        item.value,
+                                        item.name,
+                                        item,
+                                        index,
+                                        item.payload,
+                                    )
+                                ) : (
+                                    <>
+                                        {itemConfig?.icon ? (
+                                            <itemConfig.icon />
+                                        ) : (
+                                            !hideIndicator && (
+                                                <div
+                                                    className={cn(
+                                                        "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                                                        {
+                                                            "h-2.5 w-2.5":
+                                                                indicator ===
+                                                                "dot",
+                                                            "w-1":
+                                                                indicator ===
+                                                                "line",
+                                                            "w-0 border-[1.5px] border-dashed bg-transparent":
+                                                                indicator ===
+                                                                "dashed",
+                                                            "my-0.5":
+                                                                nestLabel &&
+                                                                indicator ===
+                                                                    "dashed",
+                                                        },
+                                                    )}
+                                                    style={
+                                                        {
+                                                            "--color-bg":
+                                                                indicatorColor,
+                                                            "--color-border":
+                                                                indicatorColor,
+                                                        } as React.CSSProperties
+                                                    }
+                                                />
+                                            )
+                                        )}
+                                        <div
+                                            className={cn(
+                                                "flex flex-1 justify-between leading-none",
+                                                nestLabel
+                                                    ? "items-end"
+                                                    : "items-center",
+                                            )}
+                                        >
+                                            <div className="grid gap-1.5">
+                                                {nestLabel
+                                                    ? tooltipLabel
+                                                    : null}
+                                                <span className="text-muted-foreground">
+                                                    {itemConfig?.label ??
+                                                        item.name}
+                                                </span>
+                                            </div>
+                                            {item.value != null && (
+                                                <span className="font-mono font-medium text-foreground tabular-nums">
+                                                    {typeof item.value ===
+                                                    "number"
+                                                        ? item.value.toLocaleString()
+                                                        : String(item.value)}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+                        );
+                    })}
+            </div>
+        </div>
+    );
+}
+
+const ChartLegend = RechartsPrimitive.Legend;
+
+function ChartLegendContent({
+    className,
+    hideIcon = false,
+    payload,
+    verticalAlign = "bottom",
+    nameKey,
+}: React.ComponentProps<"div"> & {
+    hideIcon?: boolean;
+    nameKey?: string;
+} & RechartsPrimitive.DefaultLegendContentProps) {
+    const { config } = useChart();
+
+    if (!payload?.length) {
+        return null;
+    }
+
+    return (
+        <div
+            className={cn(
+                "flex items-center justify-center gap-4",
+                verticalAlign === "top" ? "pb-3" : "pt-3",
+                className,
+            )}
+        >
+            {payload
+                .filter((item) => item.type !== "none")
+                .map((item, index) => {
+                    const key = `${nameKey ?? item.dataKey ?? "value"}`;
+                    const itemConfig = getPayloadConfigFromPayload(
+                        config,
+                        item,
+                        key,
+                    );
+
+                    return (
+                        <div
+                            key={index}
+                            className={cn(
+                                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground",
+                            )}
+                        >
+                            {itemConfig?.icon && !hideIcon ? (
+                                <itemConfig.icon />
+                            ) : (
+                                <div
+                                    className="h-2 w-2 shrink-0 rounded-[2px]"
+                                    style={{
+                                        backgroundColor: item.color,
+                                    }}
+                                />
+                            )}
+                            {itemConfig?.label}
+                        </div>
+                    );
+                })}
+        </div>
+    );
+}
+
+function getPayloadConfigFromPayload(
+    config: ChartConfig,
+    payload: unknown,
+    key: string,
+) {
+    if (typeof payload !== "object" || payload === null) {
+        return undefined;
+    }
+
+    const payloadPayload =
+        "payload" in payload &&
+        typeof payload.payload === "object" &&
+        payload.payload !== null
+            ? payload.payload
+            : undefined;
+
+    let configLabelKey: string = key;
+
+    if (
+        key in payload &&
+        typeof payload[key as keyof typeof payload] === "string"
+    ) {
+        configLabelKey = payload[key as keyof typeof payload] as string;
+    } else if (
+        payloadPayload &&
+        key in payloadPayload &&
+        typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+    ) {
+        configLabelKey = payloadPayload[
+            key as keyof typeof payloadPayload
+        ] as string;
+    }
+
+    return configLabelKey in config ? config[configLabelKey] : config[key];
+}
+
+export {
+    ChartContainer,
+    ChartTooltip,
+    ChartTooltipContent,
+    ChartLegend,
+    ChartLegendContent,
+    ChartStyle,
+};

--- a/resources/js/components/ui/input-group.tsx
+++ b/resources/js/components/ui/input-group.tsx
@@ -1,0 +1,155 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex h-9 w-full min-w-0 items-center rounded-4xl border border-input bg-input/30 transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-data-[align=block-end]:rounded-2xl has-data-[align=block-start]:rounded-2xl has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-[3px] has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[textarea]:rounded-xl has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-2 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 **:data-[slot=kbd]:rounded-4xl **:data-[slot=kbd]:bg-muted-foreground/10 **:data-[slot=kbd]:px-1.5 [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-3 has-[>button]:-ml-1 has-[>kbd]:ml-[-0.15rem]",
+        "inline-end":
+          "order-last pr-3 has-[>button]:-mr-1 has-[>kbd]:mr-[-0.15rem]",
+        "block-start":
+          "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-3 [.border-b]:pb-3",
+        "block-end":
+          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-3 [.border-t]:pt-3",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 rounded-4xl text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "",
+        "icon-xs": "size-6 p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
+  VariantProps<typeof inputGroupButtonVariants> & {
+    type?: "button" | "submit" | "reset"
+  }) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/resources/js/components/ui/input-group.tsx
+++ b/resources/js/components/ui/input-group.tsx
@@ -44,6 +44,7 @@ const inputGroupAddonVariants = cva(
 function InputGroupAddon({
   className,
   align = "inline-start",
+  onClick,
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
   return (
@@ -53,10 +54,19 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
+        onClick?.(e)
+
+        if (e.defaultPrevented) {
+          return
+        }
+
         if ((e.target as HTMLElement).closest("button")) {
           return
         }
-        e.currentTarget.parentElement?.querySelector("input")?.focus()
+
+        e.currentTarget.parentElement
+          ?.querySelector<HTMLInputElement | HTMLTextAreaElement>("input, textarea")
+          ?.focus()
       }}
       {...props}
     />

--- a/resources/js/components/ui/kbd.tsx
+++ b/resources/js/components/ui/kbd.tsx
@@ -13,7 +13,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       data-slot="kbd-group"

--- a/resources/js/components/ui/kbd.tsx
+++ b/resources/js/components/ui/kbd.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils"
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 [&_svg:not([class*='size-'])]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+export { Kbd, KbdGroup }

--- a/resources/js/components/ui/select.tsx
+++ b/resources/js/components/ui/select.tsx
@@ -1,0 +1,201 @@
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { UnfoldMoreIcon, Tick02Icon, ArrowUp01Icon, ArrowDown01Icon } from "@hugeicons/core-free-icons"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-4xl border border-input bg-input/30 px-3 py-2 text-sm whitespace-nowrap transition-colors outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <HugeiconsIcon icon={UnfoldMoreIcon} strokeWidth={2} className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-2xl bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/5 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-3 py-2.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2.5 rounded-xl py-2 pr-8 pl-3 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn(
+        "pointer-events-none -mx-1 my-1 h-px bg-border/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <HugeiconsIcon icon={ArrowUp01Icon} strokeWidth={2} />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/resources/js/components/ui/textarea.tsx
+++ b/resources/js/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full resize-none rounded-xl border border-input bg-input/30 px-3 py-3 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/resources/js/components/ui/tooltip.tsx
+++ b/resources/js/components/ui/tooltip.tsx
@@ -1,0 +1,64 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-2xl bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-4xl data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:translate-x-[1.5px] data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:translate-x-[-1.5px] data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:translate-x-[-1.5px] data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:translate-x-[1.5px] data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/resources/js/layouts/AuthLayout.tsx
+++ b/resources/js/layouts/AuthLayout.tsx
@@ -67,7 +67,11 @@ export function AuthLayout({
             {/* Top bar — 3-column grid, uppercase micro meta. */}
             <header className="relative z-10 mx-auto grid w-full max-w-310 grid-cols-3 items-center gap-4 px-6 py-5 sm:px-10">
                 <span className="auth-caption text-foreground">
-                    osTicket<span className="text-muted-foreground"> · Staff Console</span>
+                    osTicket
+                    <span className="text-muted-foreground">
+                        {" "}
+                        · Staff Console
+                    </span>
                 </span>
                 <span className="auth-caption hidden justify-self-center text-muted-foreground sm:inline-flex">
                     Secure Session · Encrypted
@@ -89,7 +93,10 @@ export function AuthLayout({
             <main className="relative z-10 mx-auto grid w-full max-w-310 flex-1 grid-cols-12 gap-6 px-6 py-12 sm:px-10 sm:py-16 lg:gap-10 lg:py-20">
                 {/* Left rail — section number + meta caption. */}
                 <aside className="col-span-12 lg:col-span-3 lg:pt-4">
-                    <div className="auth-rise flex items-start gap-3" style={rise(0)}>
+                    <div
+                        className="auth-rise flex items-start gap-3"
+                        style={rise(0)}
+                    >
                         <span className="font-sans text-[10px] font-medium leading-3.75 tracking-widest text-muted-foreground">
                             {sectionIndex}
                         </span>

--- a/resources/js/layouts/AuthLayout.tsx
+++ b/resources/js/layouts/AuthLayout.tsx
@@ -4,7 +4,7 @@ import { usePage } from "@inertiajs/react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
 
-type EyebrowAccent = "orange" | "pink" | "indigo" | "gradient";
+type EyebrowAccent = "purple" | "indigo" | "emerald" | "gradient";
 
 interface AuthLayoutProps {
     title: string;
@@ -48,7 +48,7 @@ export function AuthLayout({
     title,
     subtitle,
     tag,
-    eyebrowAccent = "orange",
+    eyebrowAccent = "purple",
     sectionIndex = "01",
     children,
     footer,

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -93,19 +93,27 @@ function DefaultHeaderActions() {
             <Button
                 variant="outline"
                 size="icon"
-                className="rounded-md border-[#E2E8F0] bg-white text-[#64748B] hover:bg-[#F8FAFC]"
+                disabled
+                aria-disabled="true"
+                className="rounded-md border-[#E2E8F0] bg-white text-[#64748B] hover:bg-white"
                 aria-label="Open dashboard actions"
             >
                 <span className="text-lg leading-none">•••</span>
             </Button>
 
             <div className="flex overflow-hidden rounded-md shadow-[0_10px_25px_-20px_rgba(91,97,157,0.7)]">
-                <Button className="rounded-none rounded-l-md bg-[#5B619D] px-4 text-sm text-white hover:bg-[#4F5486]">
+                <Button
+                    disabled
+                    aria-disabled="true"
+                    className="rounded-none rounded-l-md bg-[#5B619D] px-4 text-sm text-white hover:bg-[#5B619D]"
+                >
                     Export CSV
                 </Button>
                 <Button
                     size="icon"
-                    className="rounded-none rounded-r-md border-l border-white/15 bg-[#5B619D] text-white hover:bg-[#4F5486]"
+                    disabled
+                    aria-disabled="true"
+                    className="rounded-none rounded-r-md border-l border-white/15 bg-[#5B619D] text-white hover:bg-[#5B619D]"
                     aria-label="Open export options"
                 >
                     <HugeiconsIcon icon={ArrowRight01Icon} size={14} className="rotate-90" />
@@ -223,13 +231,18 @@ export default function DashboardLayout({
                                 <div className="space-y-2">
                                     {CONVERSATION_ITEMS.map(({ id, label, subtitle, icon, badge, badgeActive }) => (
                                         <Card key={id} className={cn(
-                                            'rounded-xl border py-0 ring-0 shadow-none transition-colors',
+                                            'rounded-xl border py-0 opacity-70 ring-0 shadow-none transition-colors',
                                             id === 'side-conversation'
                                                 ? 'border-[#E2E8F0] bg-white shadow-sm shadow-[#0F172A]/[0.03]'
-                                                : 'border-transparent bg-transparent hover:border-[#E2E8F0] hover:bg-white/80',
+                                                : 'border-transparent bg-transparent',
                                         )}>
                                             <CardContent className="px-4 py-3">
-                                                <button type="button" className="flex w-full items-center justify-between gap-3 text-left">
+                                                <button
+                                                    type="button"
+                                                    disabled
+                                                    aria-disabled="true"
+                                                    className="flex w-full cursor-not-allowed items-center justify-between gap-3 text-left"
+                                                >
                                                     <div className="flex items-center gap-3">
                                                         <div className={cn(
                                                             'flex h-9 w-9 items-center justify-center rounded-lg',
@@ -265,7 +278,13 @@ export default function DashboardLayout({
                             <section className="mt-7 px-6">
                                 <div className="mb-3 flex items-center justify-between gap-3">
                                     <div className="auth-caption">Pinned Tickets</div>
-                                    <Button variant="ghost" size="xs" className="h-auto rounded-md px-0 text-[11px] text-[#94A3B8] hover:bg-transparent hover:text-[#0F172A]">
+                                    <Button
+                                        variant="ghost"
+                                        size="xs"
+                                        disabled
+                                        aria-disabled="true"
+                                        className="h-auto rounded-md px-0 text-[11px] text-[#94A3B8] hover:bg-transparent hover:text-[#94A3B8]"
+                                    >
                                         Unpin all
                                     </Button>
                                 </div>
@@ -276,7 +295,7 @@ export default function DashboardLayout({
                                             type="button"
                                             disabled
                                             aria-disabled="true"
-                                            className="group flex w-full cursor-not-allowed items-center justify-between gap-3 text-left opacity-70"
+                                            className="flex w-full cursor-not-allowed items-center justify-between gap-3 text-left opacity-70"
                                         >
                                             <div className="flex min-w-0 items-center gap-2">
                                                 <div className={cn(
@@ -285,15 +304,20 @@ export default function DashboardLayout({
                                                 )}>
                                                     <span className="text-[9px] leading-none">•</span>
                                                 </div>
-                                                <span className="truncate font-body text-sm font-medium text-[#64748B] transition-colors group-hover:text-[#0F172A]">
+                                                <span className="truncate font-body text-sm font-medium text-[#64748B] transition-colors">
                                                     {label}
                                                 </span>
                                             </div>
-                                            <span className="text-xs text-[#CBD5E1] transition-colors group-hover:text-[#5B619D]">⌁</span>
+                                            <span className="text-xs text-[#CBD5E1] transition-colors">⌁</span>
                                         </button>
                                     ))}
 
-                                    <Button variant="ghost" className="mt-1 h-auto justify-start rounded-md px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#0F172A]">
+                                    <Button
+                                        variant="ghost"
+                                        disabled
+                                        aria-disabled="true"
+                                        className="mt-1 h-auto justify-start rounded-md px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#64748B]"
+                                    >
                                         <span className="text-lg leading-none">+</span>
                                         Add new
                                     </Button>
@@ -304,7 +328,12 @@ export default function DashboardLayout({
                         <Separator className="bg-[#E2E8F0]" />
 
                         <div className="mt-auto px-5 py-5">
-                            <Button variant="ghost" className="mb-4 h-auto justify-start rounded-md px-0 text-sm text-[#64748B] hover:bg-transparent hover:text-[#0F172A]">
+                            <Button
+                                variant="ghost"
+                                disabled
+                                aria-disabled="true"
+                                className="mb-4 h-auto justify-start rounded-md px-0 text-sm text-[#64748B] hover:bg-transparent hover:text-[#64748B]"
+                            >
                                 <HugeiconsIcon icon={HelpCircleIcon} size={18} color="#94A3B8" />
                                 <span>Help &amp; Support</span>
                             </Button>

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -65,9 +65,9 @@ const CONVERSATION_ITEMS = [
 ] as const;
 
 const PINNED_TICKETS = [
-    { href: '#', label: '#TC-192 product inquiry...' },
-    { href: '#', label: '#TC-191 payment issue...' },
-    { href: '#', label: '+1 678-908-78...' },
+    { label: '#TC-192 product inquiry...' },
+    { label: '#TC-191 payment issue...' },
+    { label: '+1 678-908-78...' },
 ] as const;
 
 const navBaseClass = 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium font-body transition-colors duration-150';
@@ -270,8 +270,14 @@ export default function DashboardLayout({
                                     </Button>
                                 </div>
                                 <div className="space-y-3">
-                                    {PINNED_TICKETS.map(({ href, label }, index) => (
-                                        <a key={label} href={href} className="group flex items-center justify-between gap-3">
+                                    {PINNED_TICKETS.map(({ label }, index) => (
+                                        <button
+                                            key={label}
+                                            type="button"
+                                            disabled
+                                            aria-disabled="true"
+                                            className="group flex w-full cursor-not-allowed items-center justify-between gap-3 text-left opacity-70"
+                                        >
                                             <div className="flex min-w-0 items-center gap-2">
                                                 <div className={cn(
                                                     'flex h-4 w-4 items-center justify-center rounded-full',
@@ -284,7 +290,7 @@ export default function DashboardLayout({
                                                 </span>
                                             </div>
                                             <span className="text-xs text-[#CBD5E1] transition-colors group-hover:text-[#5B619D]">⌁</span>
-                                        </a>
+                                        </button>
                                     ))}
 
                                     <Button variant="ghost" className="mt-1 h-auto justify-start rounded-md px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#0F172A]">

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -1,0 +1,325 @@
+import { Children, type ReactNode } from 'react';
+import { Link, router } from '@inertiajs/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import {
+    ArrowRight01Icon,
+    BarChartIcon,
+    BookOpen01Icon,
+    CustomerService01Icon,
+    DashboardSquare01Icon,
+    HelpCircleIcon,
+    InboxIcon,
+    LogoutSquare01Icon,
+    Message01Icon,
+    Notification01Icon,
+    Search01Icon,
+    ShieldCheck,
+    Ticket01Icon,
+} from '@hugeicons/core-free-icons';
+
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+} from '@/components/ui/card';
+import {
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+} from '@/components/ui/input-group';
+import { Kbd } from '@/components/ui/kbd';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+
+interface DashboardLayoutProps {
+    title: string;
+    subtitle?: string;
+    eyebrow?: string;
+    activeNav?: string;
+    headerActions?: ReactNode;
+    contentClassName?: string;
+    children: ReactNode;
+}
+
+interface NavItem {
+    id: string;
+    label: string;
+    icon: typeof DashboardSquare01Icon;
+    href?: string;
+}
+
+const NAV_ITEMS: NavItem[] = [
+    { id: 'dashboard', label: 'Dashboard', icon: DashboardSquare01Icon, href: '/scp' },
+    { id: 'inbox', label: 'Inbox', icon: InboxIcon },
+    { id: 'notifications', label: 'Notifications', icon: Notification01Icon },
+    { id: 'tickets', label: 'Tickets', icon: Ticket01Icon },
+    { id: 'knowledge', label: 'Knowledge Base', icon: BookOpen01Icon },
+    { id: 'customers', label: 'Customers', icon: CustomerService01Icon },
+    { id: 'forum', label: 'Forum', icon: Message01Icon },
+    { id: 'reports', label: 'Reports', icon: BarChartIcon },
+];
+
+const CONVERSATION_ITEMS = [
+    { id: 'call', label: 'Call', subtitle: '(123) 45678...', icon: CustomerService01Icon, badge: '1', badgeActive: true },
+    { id: 'side-conversation', label: 'Side Conversation', subtitle: 'No new replies', icon: Message01Icon, badge: '0', badgeActive: false },
+] as const;
+
+const PINNED_TICKETS = [
+    { href: '#', label: '#TC-192 product inquiry...' },
+    { href: '#', label: '#TC-191 payment issue...' },
+    { href: '#', label: '+1 678-908-78...' },
+] as const;
+
+const navBaseClass = 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium font-body transition-colors duration-150';
+const navActiveClass = `${navBaseClass} bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
+const navInactiveClass = `${navBaseClass} text-[#64748B] hover:bg-white hover:text-[#0F172A]`;
+
+function getNavClasses(activeNav: string | undefined, navItem: string): string {
+    return activeNav === navItem ? navActiveClass : navInactiveClass;
+}
+
+function getNavIconColor(activeNav: string | undefined, navItem: string): string {
+    return activeNav === navItem ? '#5B619D' : '#94A3B8';
+}
+
+function DefaultHeaderActions() {
+    return (
+        <>
+            <Button
+                variant="outline"
+                size="icon"
+                className="rounded-md border-[#E2E8F0] bg-white text-[#64748B] hover:bg-[#F8FAFC]"
+                aria-label="Open dashboard actions"
+            >
+                <span className="text-lg leading-none">•••</span>
+            </Button>
+
+            <div className="flex overflow-hidden rounded-md shadow-[0_10px_25px_-20px_rgba(91,97,157,0.7)]">
+                <Button className="rounded-none rounded-l-md bg-[#5B619D] px-4 text-sm text-white hover:bg-[#4F5486]">
+                    Export CSV
+                </Button>
+                <Button
+                    size="icon"
+                    className="rounded-none rounded-r-md border-l border-white/15 bg-[#5B619D] text-white hover:bg-[#4F5486]"
+                    aria-label="Open export options"
+                >
+                    <HugeiconsIcon icon={ArrowRight01Icon} size={14} className="rotate-90" />
+                </Button>
+            </div>
+        </>
+    );
+}
+
+function SearchField() {
+    return (
+        <InputGroup>
+            <InputGroupAddon align="inline-start">
+                <HugeiconsIcon icon={Search01Icon} size={16} />
+            </InputGroupAddon>
+            <InputGroupInput aria-label="Search dashboard" placeholder="Search..." />
+            <InputGroupAddon align="inline-end">
+                <Kbd>⌘</Kbd>
+                <Kbd>K</Kbd>
+            </InputGroupAddon>
+        </InputGroup>
+    );
+}
+
+export default function DashboardLayout({
+    title,
+    subtitle,
+    eyebrow,
+    activeNav = 'dashboard',
+    headerActions,
+    contentClassName = 'w-full',
+    children,
+}: DashboardLayoutProps) {
+    const resolvedHeaderActions = headerActions === undefined
+        ? <DefaultHeaderActions />
+        : (Children.count(headerActions) > 0 ? headerActions : null);
+
+    return (
+        <div className="auth-theme relative flex h-screen overflow-hidden bg-[#E9ECEF] text-[#0F172A]">
+            <div className="auth-mesh pointer-events-none absolute inset-0"></div>
+            <div className="auth-grain pointer-events-none absolute inset-0"></div>
+
+            <main className="relative z-10 flex h-full w-full">
+                <div className="flex h-full w-full overflow-hidden bg-white">
+                    <aside className="flex w-72 shrink-0 flex-col border-r border-[#E2E8F0] bg-[#F8FAFC]/90">
+                        <div className="px-5 py-5 transition-colors hover:bg-white/70">
+                            <div className="flex items-center justify-between gap-3">
+                                <div className="flex items-center gap-3">
+                                    <div className="auth-gradient flex h-10 w-10 items-center justify-center rounded-full text-xs font-semibold tracking-[0.14em] text-white shadow-[0_12px_24px_-18px_rgba(91,97,157,0.9)]">
+                                        SCP
+                                    </div>
+                                    <div>
+                                        <div className="font-body text-sm font-semibold leading-none text-[#0F172A]">osTicket SCP</div>
+                                        <div className="mt-1 text-xs text-[#94A3B8]">Agent Admin</div>
+                                    </div>
+                                </div>
+                                <HugeiconsIcon icon={ArrowRight01Icon} size={16} color="#94A3B8" className="rotate-90" />
+                            </div>
+                        </div>
+
+                        <Separator className="bg-[#E2E8F0]" />
+
+                        <div className="px-5 py-4">
+                            <SearchField />
+                        </div>
+
+                        <div className="custom-scrollbar flex-1 overflow-y-auto pb-6">
+                            <nav className="space-y-0.5 px-3">
+                                {NAV_ITEMS.map(({ id, label, icon, href }) => {
+                                    const content = (
+                                        <>
+                                            <HugeiconsIcon icon={icon} size={18} color={getNavIconColor(activeNav, id)} />
+                                            <span>{label}</span>
+                                        </>
+                                    );
+
+                                    return href ? (
+                                        <Link key={id} href={href} className={getNavClasses(activeNav, id)}>
+                                            {content}
+                                        </Link>
+                                    ) : (
+                                        <button key={id} type="button" className={`${getNavClasses(activeNav, id)} w-full text-left`}>
+                                            {content}
+                                        </button>
+                                    );
+                                })}
+                            </nav>
+
+                            <section className="mt-7 px-6">
+                                <div className="auth-caption mb-3">Conversation</div>
+                                <div className="space-y-2">
+                                    {CONVERSATION_ITEMS.map(({ id, label, subtitle, icon, badge, badgeActive }) => (
+                                        <Card key={id} className={cn(
+                                            'rounded-xl border py-0 ring-0 shadow-none transition-colors',
+                                            id === 'side-conversation'
+                                                ? 'border-[#E2E8F0] bg-white shadow-sm shadow-[#0F172A]/[0.03]'
+                                                : 'border-transparent bg-transparent hover:border-[#E2E8F0] hover:bg-white/80',
+                                        )}>
+                                            <CardContent className="px-4 py-3">
+                                                <button type="button" className="flex w-full items-center justify-between gap-3 text-left">
+                                                    <div className="flex items-center gap-3">
+                                                        <div className={cn(
+                                                            'flex h-9 w-9 items-center justify-center rounded-lg',
+                                                            id === 'side-conversation' ? 'bg-[#F1F5F9]' : 'border border-[#E2E8F0] bg-white',
+                                                        )}>
+                                                            <HugeiconsIcon icon={icon} size={18} color={id === 'side-conversation' ? '#64748B' : '#5B619D'} />
+                                                        </div>
+                                                        <div>
+                                                            <div className="font-body text-sm font-medium text-[#0F172A]">{label}</div>
+                                                            <div className="text-xs text-[#94A3B8]">{subtitle}</div>
+                                                        </div>
+                                                    </div>
+                                                    <span className={cn(
+                                                        'inline-flex min-w-5 items-center justify-center rounded-full px-1.5 py-1 text-[10px] font-semibold leading-none',
+                                                        badgeActive ? 'bg-[#C4A5F3] text-[#0F172A]' : 'bg-[#E2E8F0] text-[#64748B]',
+                                                    )}>
+                                                        {badge}
+                                                    </span>
+                                                </button>
+                                            </CardContent>
+                                        </Card>
+                                    ))}
+                                </div>
+                            </section>
+
+                            <section className="mt-7 px-6">
+                                <div className="auth-caption mb-2">Favorites</div>
+                                <p className="max-w-47.5 text-xs leading-5 text-[#94A3B8]">
+                                    Hover over any table and click the star to add it here.
+                                </p>
+                            </section>
+
+                            <section className="mt-7 px-6">
+                                <div className="mb-3 flex items-center justify-between gap-3">
+                                    <div className="auth-caption">Pinned Tickets</div>
+                                    <Button variant="ghost" size="xs" className="h-auto rounded-md px-0 text-[11px] text-[#94A3B8] hover:bg-transparent hover:text-[#0F172A]">
+                                        Unpin all
+                                    </Button>
+                                </div>
+                                <div className="space-y-3">
+                                    {PINNED_TICKETS.map(({ href, label }, index) => (
+                                        <a key={label} href={href} className="group flex items-center justify-between gap-3">
+                                            <div className="flex min-w-0 items-center gap-2">
+                                                <div className={cn(
+                                                    'flex h-4 w-4 items-center justify-center rounded-full',
+                                                    index < 2 ? 'bg-[#22C55E] text-white' : 'bg-[#F1F5F9] text-[#64748B]',
+                                                )}>
+                                                    <span className="text-[9px] leading-none">•</span>
+                                                </div>
+                                                <span className="truncate font-body text-sm font-medium text-[#64748B] transition-colors group-hover:text-[#0F172A]">
+                                                    {label}
+                                                </span>
+                                            </div>
+                                            <span className="text-xs text-[#CBD5E1] transition-colors group-hover:text-[#5B619D]">⌁</span>
+                                        </a>
+                                    ))}
+
+                                    <Button variant="ghost" className="mt-1 h-auto justify-start rounded-md px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#0F172A]">
+                                        <span className="text-lg leading-none">+</span>
+                                        Add new
+                                    </Button>
+                                </div>
+                            </section>
+                        </div>
+
+                        <Separator className="bg-[#E2E8F0]" />
+
+                        <div className="mt-auto px-5 py-5">
+                            <Button variant="ghost" className="mb-4 h-auto justify-start rounded-md px-0 text-sm text-[#64748B] hover:bg-transparent hover:text-[#0F172A]">
+                                <HugeiconsIcon icon={HelpCircleIcon} size={18} color="#94A3B8" />
+                                <span>Help &amp; Support</span>
+                            </Button>
+
+                            <Card className="mb-4 rounded-xl border-[#E2E8F0] py-0 shadow-sm shadow-[#0F172A]/[0.03] ring-0">
+                                <CardContent className="flex items-center justify-between gap-3 px-3 py-3">
+                                    <div>
+                                        <div className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">Powered by</div>
+                                        <div className="mt-1 font-display text-lg font-medium tracking-tight text-[#0F172A]">osTicket 2.0</div>
+                                    </div>
+                                    <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#F1F5F9] text-[#5B619D]">
+                                        <HugeiconsIcon icon={DashboardSquare01Icon} size={18} color="#5B619D" />
+                                    </div>
+                                </CardContent>
+                            </Card>
+
+                            <div className="grid grid-cols-2 gap-2">
+                                <Link href="/scp/account/security" className="inline-flex items-center justify-center gap-2 rounded-md border border-[#E2E8F0] bg-white px-3 py-2 text-xs font-medium text-[#64748B] transition-colors hover:text-[#0F172A]">
+                                    <HugeiconsIcon icon={ShieldCheck} size={14} color="#94A3B8" />
+                                    Security
+                                </Link>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => router.post('/scp/logout')}
+                                    className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:text-red-600"
+                                >
+                                    <HugeiconsIcon icon={LogoutSquare01Icon} size={14} color="#94A3B8" />
+                                    Sign out
+                                </Button>
+                            </div>
+                        </div>
+                    </aside>
+
+                    <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
+                        <header className="relative z-10 flex shrink-0 items-center justify-between gap-6 border-b border-[#E2E8F0] bg-white px-8 py-5 xl:px-10">
+                            <div>
+                                {eyebrow && <div className="auth-eyebrow mb-2 text-[#94A3B8]">{eyebrow}</div>}
+                                <h1 className="font-display text-[28px] font-medium tracking-tight text-[#0F172A]">{title}</h1>
+                                {subtitle && <p className="mt-1 font-body text-sm text-[#94A3B8]">{subtitle}</p>}
+                            </div>
+                            <div className="flex items-center gap-3">{resolvedHeaderActions}</div>
+                        </header>
+
+                        <main className="custom-scrollbar relative flex-1 overflow-y-auto bg-white px-6 py-6 lg:px-8 xl:px-10 xl:py-8">
+                            <div className={contentClassName}>{children}</div>
+                        </main>
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -74,6 +74,9 @@ const navBaseClass = 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm fon
 const navActiveClass = `${navBaseClass} bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
 const navInactiveClass = `${navBaseClass} text-[#64748B] hover:bg-white hover:text-[#0F172A]`;
 const navDisabledClass = `${navBaseClass} cursor-not-allowed text-[#94A3B8] opacity-50`;
+const footerActionBaseClass = 'inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-xs font-medium transition-colors';
+const footerActionActiveClass = `${footerActionBaseClass} border-[#CBD5E1] bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
+const footerActionInactiveClass = `${footerActionBaseClass} border-[#E2E8F0] bg-white text-[#64748B] hover:text-[#0F172A]`;
 
 function getNavClasses(activeNav: string | undefined, navItem: string, disabled = false): string {
     if (disabled) return navDisabledClass;
@@ -84,6 +87,14 @@ function getNavClasses(activeNav: string | undefined, navItem: string, disabled 
 function getNavIconColor(activeNav: string | undefined, navItem: string, disabled = false): string {
     if (disabled) return '#CBD5E1';
 
+    return activeNav === navItem ? '#5B619D' : '#94A3B8';
+}
+
+function getFooterActionClasses(activeNav: string | undefined, navItem: string): string {
+    return activeNav === navItem ? footerActionActiveClass : footerActionInactiveClass;
+}
+
+function getFooterActionIconColor(activeNav: string | undefined, navItem: string): string {
     return activeNav === navItem ? '#5B619D' : '#94A3B8';
 }
 
@@ -351,8 +362,12 @@ export default function DashboardLayout({
                             </Card>
 
                             <div className="grid grid-cols-2 gap-2">
-                                <Link href="/scp/account/security" className="inline-flex items-center justify-center gap-2 rounded-md border border-[#E2E8F0] bg-white px-3 py-2 text-xs font-medium text-[#64748B] transition-colors hover:text-[#0F172A]">
-                                    <HugeiconsIcon icon={ShieldCheck} size={14} color="#94A3B8" />
+                                <Link
+                                    href="/scp/account/security"
+                                    className={getFooterActionClasses(activeNav, 'security')}
+                                    aria-current={activeNav === 'security' ? 'page' : undefined}
+                                >
+                                    <HugeiconsIcon icon={ShieldCheck} size={14} color={getFooterActionIconColor(activeNav, 'security')} />
                                     Security
                                 </Link>
                                 <Button

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import { Children, type ReactNode } from 'react';
+import { Children, useRef, useState, type ReactNode } from 'react';
 import { Link, router } from '@inertiajs/react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
@@ -73,12 +73,17 @@ const PINNED_TICKETS = [
 const navBaseClass = 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium font-body transition-colors duration-150';
 const navActiveClass = `${navBaseClass} bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
 const navInactiveClass = `${navBaseClass} text-[#64748B] hover:bg-white hover:text-[#0F172A]`;
+const navDisabledClass = `${navBaseClass} cursor-not-allowed text-[#94A3B8] opacity-50`;
 
-function getNavClasses(activeNav: string | undefined, navItem: string): string {
+function getNavClasses(activeNav: string | undefined, navItem: string, disabled = false): string {
+    if (disabled) return navDisabledClass;
+
     return activeNav === navItem ? navActiveClass : navInactiveClass;
 }
 
-function getNavIconColor(activeNav: string | undefined, navItem: string): string {
+function getNavIconColor(activeNav: string | undefined, navItem: string, disabled = false): string {
+    if (disabled) return '#CBD5E1';
+
     return activeNav === navItem ? '#5B619D' : '#94A3B8';
 }
 
@@ -137,13 +142,31 @@ export default function DashboardLayout({
     const resolvedHeaderActions = headerActions === undefined
         ? <DefaultHeaderActions />
         : (Children.count(headerActions) > 0 ? headerActions : null);
+    const [isLoggingOut, setIsLoggingOut] = useState(false);
+    const isLoggingOutRef = useRef(false);
+
+    function logout() {
+        if (isLoggingOutRef.current) {
+            return;
+        }
+
+        isLoggingOutRef.current = true;
+        setIsLoggingOut(true);
+
+        router.post('/scp/logout', {}, {
+            onFinish: () => {
+                isLoggingOutRef.current = false;
+                setIsLoggingOut(false);
+            },
+        });
+    }
 
     return (
         <div className="auth-theme relative flex h-screen overflow-hidden bg-[#E9ECEF] text-[#0F172A]">
             <div className="auth-mesh pointer-events-none absolute inset-0"></div>
             <div className="auth-grain pointer-events-none absolute inset-0"></div>
 
-            <main className="relative z-10 flex h-full w-full">
+            <div className="relative z-10 flex h-full w-full">
                 <div className="flex h-full w-full overflow-hidden bg-white">
                     <aside className="flex w-72 shrink-0 flex-col border-r border-[#E2E8F0] bg-[#F8FAFC]/90">
                         <div className="px-5 py-5 transition-colors hover:bg-white/70">
@@ -172,7 +195,7 @@ export default function DashboardLayout({
                                 {NAV_ITEMS.map(({ id, label, icon, href }) => {
                                     const content = (
                                         <>
-                                            <HugeiconsIcon icon={icon} size={18} color={getNavIconColor(activeNav, id)} />
+                                            <HugeiconsIcon icon={icon} size={18} color={getNavIconColor(activeNav, id, !href)} />
                                             <span>{label}</span>
                                         </>
                                     );
@@ -182,7 +205,13 @@ export default function DashboardLayout({
                                             {content}
                                         </Link>
                                     ) : (
-                                        <button key={id} type="button" className={`${getNavClasses(activeNav, id)} w-full text-left`}>
+                                        <button
+                                            key={id}
+                                            type="button"
+                                            disabled
+                                            aria-disabled="true"
+                                            className={`${getNavClasses(activeNav, id, true)} w-full text-left`}
+                                        >
                                             {content}
                                         </button>
                                     );
@@ -294,8 +323,9 @@ export default function DashboardLayout({
                                 <Button
                                     variant="outline"
                                     size="sm"
-                                    onClick={() => router.post('/scp/logout')}
-                                    className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:text-red-600"
+                                    disabled={isLoggingOut}
+                                    onClick={logout}
+                                    className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:text-red-600 cursor-pointer"
                                 >
                                     <HugeiconsIcon icon={LogoutSquare01Icon} size={14} color="#94A3B8" />
                                     Sign out
@@ -319,7 +349,7 @@ export default function DashboardLayout({
                         </main>
                     </div>
                 </div>
-            </main>
+            </div>
         </div>
     );
 }

--- a/resources/js/pages/Account/Security/Index.tsx
+++ b/resources/js/pages/Account/Security/Index.tsx
@@ -13,7 +13,6 @@ interface TwoFactorState {
     confirmedAt: string | null;
     recoveryCodesCount: number;
     qrCodeSvg: string | null;
-    qrCodeUrl: string | null;
     setupKey: string | null;
 }
 

--- a/resources/js/pages/Account/Security/Index.tsx
+++ b/resources/js/pages/Account/Security/Index.tsx
@@ -1,4 +1,9 @@
-import { Link, useForm, usePage } from '@inertiajs/react';
+import { Link, router, useForm, usePage } from '@inertiajs/react';
+
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import Sessions from '@/pages/Account/Security/Sessions';
 
 interface TwoFactorState {
     enabled: boolean;
@@ -27,20 +32,8 @@ type FormSubmitHandler = NonNullable<React.ComponentProps<"form">["onSubmit"]>;
 
 export default function SecurityIndex({ twoFactor, migration, revealedRecoveryCodes }: PageProps) {
     const { props } = usePage<PageProps>();
-    const enableForm = useForm({ force: false });
-    const confirmForm = useForm({ code: '' });
     const regenerateForm = useForm({});
     const disableForm = useForm({});
-
-    const enableTwoFactor: FormSubmitHandler = (event) => {
-        event.preventDefault();
-        enableForm.post('/scp/account/security/two-factor/enable');
-    };
-
-    const confirmTwoFactor: FormSubmitHandler = (event) => {
-        event.preventDefault();
-        confirmForm.post('/scp/account/security/two-factor/confirm');
-    };
 
     const regenerateCodes: FormSubmitHandler = (event) => {
         event.preventDefault();
@@ -68,123 +61,101 @@ export default function SecurityIndex({ twoFactor, migration, revealedRecoveryCo
                 </div>
 
                 {props.status && (
-                    <div className="rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-                        {props.status}
-                    </div>
+                    <Alert className="rounded-xl border-green-200 bg-green-50 text-green-700">
+                        <AlertDescription className="text-green-700">
+                            {props.status}
+                        </AlertDescription>
+                    </Alert>
                 )}
 
                 <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
                     <section className="rounded-2xl bg-white p-6 shadow-sm">
-                        <div className="flex items-start justify-between gap-4">
-                            <div>
-                                <h2 className="text-lg font-semibold text-gray-900">Authenticator app</h2>
-                                <p className="mt-1 text-sm text-gray-500">
-                                    {twoFactor.enabled
-                                        ? 'App-based two-factor authentication is enabled for your account.'
-                                        : 'Enable TOTP to finish your Laravel-native authentication upgrade.'}
-                                </p>
-                            </div>
-                            <span className={`rounded-full px-3 py-1 text-xs font-semibold ${twoFactor.enabled ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'}`}>
-                                {twoFactor.enabled ? 'Enabled' : twoFactor.pending ? 'Pending confirmation' : 'Not enabled'}
-                            </span>
-                        </div>
+                        <Tabs defaultValue="two-factor" className="gap-6">
+                            <TabsList variant="line" className="w-full justify-start gap-6 border-b border-border p-0">
+                                <TabsTrigger value="two-factor" className="px-0 pb-3">
+                                    Two-factor
+                                </TabsTrigger>
+                                <TabsTrigger value="sessions" className="px-0 pb-3">
+                                    Sessions
+                                </TabsTrigger>
+                            </TabsList>
 
-                        {!twoFactor.pending && !twoFactor.enabled && (
-                            <form onSubmit={enableTwoFactor} className="mt-6">
-                                <button
-                                    type="submit"
-                                    disabled={enableForm.processing}
-                                    className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
-                                >
-                                    {enableForm.processing ? 'Starting…' : 'Enable two-factor'}
-                                </button>
-                            </form>
-                        )}
-
-                        {(twoFactor.pending || twoFactor.enabled) && (
-                            <div className="mt-6 space-y-5">
-                                {twoFactor.qrCodeSvg && (
-                                    <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
-                                        <p className="text-sm font-medium text-gray-700">Scan this QR code with your authenticator app.</p>
-                                        <div
-                                            className="mt-4 flex justify-center rounded-lg bg-white p-4"
-                                            dangerouslySetInnerHTML={{ __html: twoFactor.qrCodeSvg }}
-                                        />
-                                    </div>
-                                )}
-
-                                {twoFactor.setupKey && (
-                                    <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
-                                        <p className="text-sm font-medium text-gray-700">Manual setup key</p>
-                                        <p className="mt-2 break-all font-mono text-sm text-gray-900">{twoFactor.setupKey}</p>
-                                    </div>
-                                )}
-
-                                {!twoFactor.enabled && (
-                                    <form onSubmit={confirmTwoFactor} className="space-y-3">
-                                        <div>
-                                            <label htmlFor="code" className="block text-sm font-medium text-gray-700">
-                                                Confirm with a code from your app
-                                            </label>
-                                             <input
-                                                 id="code"
-                                                 type="text"
-                                                 inputMode="numeric"
-                                                 pattern="[0-9]*"
-                                                 maxLength={6}
-                                                 autoComplete="one-time-code"
-                                                 aria-invalid={!!confirmForm.errors.code}
-                                                 value={confirmForm.data.code}
-                                                 onChange={(event) => confirmForm.setData('code', event.target.value)}
-                                                 className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                                             />
-                                             {confirmForm.errors.code && (
-                                                 <p role="alert" className="mt-1 text-xs text-red-600">{confirmForm.errors.code}</p>
-                                             )}
+                            <TabsContent value="two-factor" className="mt-0">
+                                <div className="space-y-4">
+                                    <div className="rounded-xl border border-gray-200 p-4">
+                                        <div className="flex items-start justify-between gap-4">
+                                            <div>
+                                                <h2 className="text-lg font-semibold text-gray-900">Authenticator app</h2>
+                                                <p className="mt-1 text-sm text-gray-500">
+                                                    {twoFactor.enabled
+                                                        ? 'App-based two-factor authentication is enabled for your account.'
+                                                        : twoFactor.pending
+                                                          ? 'Setup started. Return to the wizard to finish verifying your app.'
+                                                          : 'Enable TOTP to finish your Laravel-native authentication upgrade.'}
+                                                </p>
+                                            </div>
+                                            <span className={`rounded-full px-3 py-1 text-xs font-semibold ${twoFactor.enabled ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'}`}>
+                                                {twoFactor.enabled ? 'Enabled' : twoFactor.pending ? 'Pending confirmation' : 'Not enabled'}
+                                            </span>
                                         </div>
 
-                                        <button
-                                            type="submit"
-                                            disabled={confirmForm.processing}
-                                            className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800 disabled:opacity-50"
-                                        >
-                                            {confirmForm.processing ? 'Confirming…' : 'Confirm setup'}
-                                        </button>
-                                    </form>
-                                )}
-
-                                {twoFactor.enabled && (
-                                    <div className="flex flex-wrap gap-3">
-                                        <Link
-                                            href="/scp/account/security/confirm-password"
-                                            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                                        >
-                                            Confirm password
-                                        </Link>
-
-                                        <form onSubmit={regenerateCodes}>
-                                            <button
-                                                type="submit"
-                                                disabled={regenerateForm.processing}
-                                                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-                                            >
-                                                {regenerateForm.processing ? 'Regenerating…' : 'Regenerate recovery codes'}
-                                            </button>
-                                        </form>
-
-                                        <form onSubmit={disableTwoFactor}>
-                                            <button
-                                                type="submit"
-                                                disabled={disableForm.processing}
-                                                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:opacity-50"
-                                            >
-                                                {disableForm.processing ? 'Disabling…' : 'Disable two-factor'}
-                                            </button>
-                                        </form>
+                                        {twoFactor.confirmedAt && (
+                                            <p className="mt-3 text-xs text-gray-500">
+                                                Confirmed {new Date(twoFactor.confirmedAt).toLocaleString()}
+                                            </p>
+                                        )}
+                                        <p className="mt-1 text-xs text-gray-500">
+                                            {twoFactor.recoveryCodesCount} recovery codes remaining
+                                        </p>
                                     </div>
-                                )}
-                            </div>
-                        )}
+
+                                    {revealedRecoveryCodes.length > 0 && (
+                                        <Alert variant="warning" className="rounded-xl border-amber-200 bg-amber-50">
+                                            <AlertDescription className="text-amber-900">
+                                                New recovery codes: <span className="font-mono">{revealedRecoveryCodes.join(' · ')}</span>. Save them somewhere safe.
+                                            </AlertDescription>
+                                        </Alert>
+                                    )}
+
+                                    <div className="flex flex-wrap gap-3">
+                                        <Button
+                                            type="button"
+                                            onClick={() => router.get('/scp/account/security/two-factor')}
+                                        >
+                                            {twoFactor.enabled || twoFactor.pending ? 'Manage 2FA' : 'Enable 2FA'}
+                                        </Button>
+
+                                        {twoFactor.enabled && (
+                                            <>
+                                                <form onSubmit={regenerateCodes}>
+                                                    <Button
+                                                        variant="outline"
+                                                        type="submit"
+                                                        disabled={regenerateForm.processing}
+                                                    >
+                                                        {regenerateForm.processing ? 'Regenerating…' : 'Regenerate recovery codes'}
+                                                    </Button>
+                                                </form>
+
+                                                <form onSubmit={disableTwoFactor}>
+                                                    <Button
+                                                        variant="destructive"
+                                                        type="submit"
+                                                        disabled={disableForm.processing}
+                                                    >
+                                                        {disableForm.processing ? 'Disabling…' : 'Disable 2FA'}
+                                                    </Button>
+                                                </form>
+                                            </>
+                                        )}
+                                    </div>
+                                </div>
+                            </TabsContent>
+
+                            <TabsContent value="sessions" className="mt-0">
+                                <Sessions />
+                            </TabsContent>
+                        </Tabs>
                     </section>
 
                     <aside className="space-y-6">

--- a/resources/js/pages/Account/Security/Index.tsx
+++ b/resources/js/pages/Account/Security/Index.tsx
@@ -208,7 +208,11 @@ export default function SecurityIndex({ twoFactor, migration, revealedRecoveryCo
     );
 }
 
-SecurityIndex.layout = (page: ReactElement) => (
+type SecurityPageComponent = typeof SecurityIndex & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(SecurityIndex as SecurityPageComponent).layout = (page: ReactElement) => (
     <DashboardLayout
         title="Account Security"
         subtitle="Manage two-factor authentication and active sessions."
@@ -219,9 +223,3 @@ SecurityIndex.layout = (page: ReactElement) => (
         {page}
     </DashboardLayout>
 );
-
-type SecurityPageComponent = typeof SecurityIndex & {
-    layout?: (page: ReactElement) => ReactNode;
-};
-
-(SecurityIndex as SecurityPageComponent).layout = SecurityIndex.layout;

--- a/resources/js/pages/Account/Security/Index.tsx
+++ b/resources/js/pages/Account/Security/Index.tsx
@@ -188,7 +188,7 @@ export default function SecurityIndex({ twoFactor, migration, revealedRecoveryCo
 
                     {revealedRecoveryCodes.length > 0 && (
                         <section className="rounded-md border border-amber-200 bg-amber-50 p-5">
-                            <div className="auth-eyebrow !text-amber-900 mb-2">RECOVERY CODES</div>
+                            <div className="auth-eyebrow text-amber-900! mb-2">RECOVERY CODES</div>
                             <p className="text-xs text-amber-800 mb-3">
                                 Store these codes securely. Each code can be used once.
                             </p>

--- a/resources/js/pages/Account/Security/Index.tsx
+++ b/resources/js/pages/Account/Security/Index.tsx
@@ -1,8 +1,10 @@
-import { Link, router, useForm, usePage } from '@inertiajs/react';
+import { router, useForm, usePage } from '@inertiajs/react';
+import { type ReactElement, type ReactNode } from 'react';
 
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import DashboardLayout from '@/layouts/DashboardLayout';
 import Sessions from '@/pages/Account/Security/Sessions';
 
 interface TwoFactorState {
@@ -30,6 +32,24 @@ interface PageProps extends Record<string, unknown> {
 
 type FormSubmitHandler = NonNullable<React.ComponentProps<"form">["onSubmit"]>;
 
+function twoFactorBadgeClass(twoFactor: TwoFactorState): string {
+    if (twoFactor.enabled) return 'bg-emerald-50 text-emerald-700 border border-emerald-200';
+    if (twoFactor.pending) return 'bg-amber-50 text-amber-700 border border-amber-200';
+    return 'bg-[#F1F5F9] text-[#94A3B8] border border-[#E2E8F0]';
+}
+
+function twoFactorBadgeLabel(twoFactor: TwoFactorState): string {
+    if (twoFactor.enabled) return 'Enabled';
+    if (twoFactor.pending) return 'Pending';
+    return 'Not enabled';
+}
+
+function twoFactorDescription(twoFactor: TwoFactorState): string {
+    if (twoFactor.enabled) return 'App-based two-factor authentication is enabled for your account.';
+    if (twoFactor.pending) return 'Setup started. Return to the wizard to finish verifying your app.';
+    return 'Enable TOTP to finish your Laravel-native authentication upgrade.';
+}
+
 export default function SecurityIndex({ twoFactor, migration, revealedRecoveryCodes }: PageProps) {
     const { props } = usePage<PageProps>();
     const regenerateForm = useForm({});
@@ -45,31 +65,27 @@ export default function SecurityIndex({ twoFactor, migration, revealedRecoveryCo
         disableForm.delete('/scp/account/security/two-factor');
     };
 
+    const migrationBadgeClass = migration.isMigrated
+        ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+        : 'bg-amber-50 text-amber-700 border border-amber-200';
+
+    const migrationStatusRows = [
+        { label: 'Status', value: migration.isMigrated ? 'Migrated' : 'Legacy flow' },
+        { label: 'Recovery codes', value: String(twoFactor.recoveryCodesCount) },
+        { label: 'Confirmed at', value: twoFactor.confirmedAt ?? 'Not confirmed' },
+    ];
+
     return (
-        <div className="min-h-screen bg-gray-50 px-4 py-10">
-            <div className="mx-auto max-w-4xl space-y-6">
-                <div className="flex items-center justify-between">
-                    <div>
-                        <h1 className="text-3xl font-bold tracking-tight text-gray-900">Account security</h1>
-                        <p className="mt-2 text-sm text-gray-500">
-                            Enroll app-based two-factor authentication without changing the legacy SCP login flow.
-                        </p>
-                    </div>
-                    <Link href="/scp" className="text-sm font-medium text-blue-600 hover:underline">
-                        Back to dashboard
-                    </Link>
+        <>
+            {props.status && (
+                <div className="rounded-md border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-3 text-sm text-[#0F172A] mb-6">
+                    {props.status}
                 </div>
+            )}
 
-                {props.status && (
-                    <Alert className="rounded-xl border-green-200 bg-green-50 text-green-700">
-                        <AlertDescription className="text-green-700">
-                            {props.status}
-                        </AlertDescription>
-                    </Alert>
-                )}
-
-                <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
-                    <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="grid gap-6 lg:grid-cols-[1.4fr_0.6fr] pb-12">
+                <section className="auth-shell">
+                    <div className="auth-shell-inner p-6">
                         <Tabs defaultValue="two-factor" className="gap-6">
                             <TabsList variant="line" className="w-full justify-start gap-6 border-b border-border p-0">
                                 <TabsTrigger value="two-factor" className="px-0 pb-3">
@@ -80,126 +96,132 @@ export default function SecurityIndex({ twoFactor, migration, revealedRecoveryCo
                                 </TabsTrigger>
                             </TabsList>
 
-                            <TabsContent value="two-factor" className="mt-0">
-                                <div className="space-y-4">
-                                    <div className="rounded-xl border border-gray-200 p-4">
-                                        <div className="flex items-start justify-between gap-4">
-                                            <div>
-                                                <h2 className="text-lg font-semibold text-gray-900">Authenticator app</h2>
-                                                <p className="mt-1 text-sm text-gray-500">
-                                                    {twoFactor.enabled
-                                                        ? 'App-based two-factor authentication is enabled for your account.'
-                                                        : twoFactor.pending
-                                                          ? 'Setup started. Return to the wizard to finish verifying your app.'
-                                                          : 'Enable TOTP to finish your Laravel-native authentication upgrade.'}
-                                                </p>
-                                            </div>
-                                            <span className={`rounded-full px-3 py-1 text-xs font-semibold ${twoFactor.enabled ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'}`}>
-                                                {twoFactor.enabled ? 'Enabled' : twoFactor.pending ? 'Pending confirmation' : 'Not enabled'}
-                                            </span>
-                                        </div>
-
-                                        {twoFactor.confirmedAt && (
-                                            <p className="mt-3 text-xs text-gray-500">
-                                                Confirmed {new Date(twoFactor.confirmedAt).toLocaleString()}
+                            <TabsContent value="two-factor" className="mt-6 space-y-4">
+                                <div className="rounded-md border border-[#E2E8F0] bg-white p-5">
+                                    <div className="flex items-start justify-between gap-4">
+                                        <div>
+                                            <h2 className="text-lg font-semibold text-gray-900">Authenticator app</h2>
+                                            <p className="mt-1 text-sm text-gray-500">
+                                                {twoFactorDescription(twoFactor)}
                                             </p>
-                                        )}
-                                        <p className="mt-1 text-xs text-gray-500">
-                                            {twoFactor.recoveryCodesCount} recovery codes remaining
+                                        </div>
+                                        <span className={`inline-flex items-center gap-1.5 rounded-sm px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${twoFactorBadgeClass(twoFactor)}`}>
+                                            {twoFactorBadgeLabel(twoFactor)}
+                                        </span>
+                                    </div>
+
+                                    {twoFactor.confirmedAt && (
+                                        <p className="mt-3 text-xs text-gray-500">
+                                            Confirmed {new Date(twoFactor.confirmedAt).toLocaleString()}
                                         </p>
-                                    </div>
-
-                                    {revealedRecoveryCodes.length > 0 && (
-                                        <Alert variant="warning" className="rounded-xl border-amber-200 bg-amber-50">
-                                            <AlertDescription className="text-amber-900">
-                                                New recovery codes: <span className="font-mono">{revealedRecoveryCodes.join(' · ')}</span>. Save them somewhere safe.
-                                            </AlertDescription>
-                                        </Alert>
                                     )}
+                                    <p className="mt-1 text-xs text-gray-500">
+                                        {twoFactor.recoveryCodesCount} recovery codes remaining
+                                    </p>
+                                </div>
 
-                                    <div className="flex flex-wrap gap-3">
-                                        <Button
-                                            type="button"
-                                            onClick={() => router.get('/scp/account/security/two-factor')}
-                                        >
-                                            {twoFactor.enabled || twoFactor.pending ? 'Manage 2FA' : 'Enable 2FA'}
-                                        </Button>
+                                {revealedRecoveryCodes.length > 0 && (
+                                    <Alert variant="warning" className="rounded-md border-amber-200 bg-amber-50">
+                                        <AlertDescription className="text-amber-900">
+                                            New recovery codes: <span className="font-mono">{revealedRecoveryCodes.join(' · ')}</span>. Save them somewhere safe.
+                                        </AlertDescription>
+                                    </Alert>
+                                )}
 
-                                        {twoFactor.enabled && (
-                                            <>
-                                                <form onSubmit={regenerateCodes}>
-                                                    <Button
-                                                        variant="outline"
-                                                        type="submit"
-                                                        disabled={regenerateForm.processing}
-                                                    >
-                                                        {regenerateForm.processing ? 'Regenerating…' : 'Regenerate recovery codes'}
-                                                    </Button>
-                                                </form>
+                                <div className="flex flex-wrap gap-3">
+                                    <Button
+                                        type="button"
+                                        onClick={() => router.get('/scp/account/security/two-factor')}
+                                    >
+                                        {twoFactor.enabled || twoFactor.pending ? 'Manage 2FA' : 'Enable 2FA'}
+                                    </Button>
 
-                                                <form onSubmit={disableTwoFactor}>
-                                                    <Button
-                                                        variant="destructive"
-                                                        type="submit"
-                                                        disabled={disableForm.processing}
-                                                    >
-                                                        {disableForm.processing ? 'Disabling…' : 'Disable 2FA'}
-                                                    </Button>
-                                                </form>
-                                            </>
-                                        )}
-                                    </div>
+                                    {twoFactor.enabled && (
+                                        <>
+                                            <form onSubmit={regenerateCodes}>
+                                                <Button
+                                                    variant="outline"
+                                                    type="submit"
+                                                    disabled={regenerateForm.processing}
+                                                >
+                                                    {regenerateForm.processing ? 'Regenerating…' : 'Regenerate recovery codes'}
+                                                </Button>
+                                            </form>
+
+                                            <form onSubmit={disableTwoFactor}>
+                                                <Button
+                                                    variant="destructive"
+                                                    type="submit"
+                                                    disabled={disableForm.processing}
+                                                >
+                                                    {disableForm.processing ? 'Disabling…' : 'Disable 2FA'}
+                                                </Button>
+                                            </form>
+                                        </>
+                                    )}
                                 </div>
                             </TabsContent>
 
-                            <TabsContent value="sessions" className="mt-0">
+                            <TabsContent value="sessions" className="mt-6">
                                 <Sessions />
                             </TabsContent>
                         </Tabs>
+                    </div>
+                </section>
+
+                <aside className="space-y-6">
+                    <section className="rounded-md border border-[#E2E8F0] bg-[#F8FAFC] p-5">
+                        <div className="auth-eyebrow mb-3">MIGRATION STATUS</div>
+                        <div className="mb-4">
+                            <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-sm text-[10px] font-medium uppercase tracking-wider ${migrationBadgeClass}`}>
+                                {migration.isMigrated ? 'Migrated' : 'Legacy flow'}
+                            </span>
+                        </div>
+                        <dl>
+                            {migrationStatusRows.map(({ label, value }) => (
+                                <div key={label} className="flex items-center justify-between py-2 border-b border-[#E2E8F0] last:border-b-0">
+                                    <dt className="font-body text-xs text-[#94A3B8]">{label}</dt>
+                                    <dd className="font-body text-xs font-medium text-[#0F172A]">{value}</dd>
+                                </div>
+                            ))}
+                        </dl>
                     </section>
 
-                    <aside className="space-y-6">
-                        <section className="rounded-2xl bg-white p-6 shadow-sm">
-                            <h2 className="text-lg font-semibold text-gray-900">Migration status</h2>
-                            <p className="mt-2 text-sm text-gray-500">
-                                {migration.isMigrated
-                                    ? `Marked migrated via ${migration.upgradeMethod ?? 'totp'}.`
-                                    : 'Your account is still using the legacy email OTP path.'}
+                    {revealedRecoveryCodes.length > 0 && (
+                        <section className="rounded-md border border-amber-200 bg-amber-50 p-5">
+                            <div className="auth-eyebrow !text-amber-900 mb-2">RECOVERY CODES</div>
+                            <p className="text-xs text-amber-800 mb-3">
+                                Store these codes securely. Each code can be used once.
                             </p>
-                            <dl className="mt-4 space-y-3 text-sm">
-                                <div className="flex items-center justify-between">
-                                    <dt className="text-gray-500">Status</dt>
-                                    <dd className="font-medium text-gray-900">{migration.isMigrated ? 'Migrated' : 'Legacy flow'}</dd>
-                                </div>
-                                <div className="flex items-center justify-between">
-                                    <dt className="text-gray-500">Recovery codes</dt>
-                                    <dd className="font-medium text-gray-900">{twoFactor.recoveryCodesCount}</dd>
-                                </div>
-                                <div className="flex items-center justify-between">
-                                    <dt className="text-gray-500">Confirmed at</dt>
-                                    <dd className="font-medium text-gray-900">{twoFactor.confirmedAt ?? 'Not confirmed'}</dd>
-                                </div>
-                            </dl>
+                            <div className="grid gap-2 sm:grid-cols-2">
+                                {revealedRecoveryCodes.map((code) => (
+                                    <div key={code} className="rounded-md bg-white px-2 py-1.5 font-mono text-xs text-gray-900 border border-amber-100">
+                                        {code}
+                                    </div>
+                                ))}
+                            </div>
                         </section>
-
-                        {revealedRecoveryCodes.length > 0 && (
-                            <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6 shadow-sm">
-                                <h2 className="text-lg font-semibold text-amber-900">Recovery codes</h2>
-                                <p className="mt-2 text-sm text-amber-800">
-                                    Store these codes securely. Each code can be used once.
-                                </p>
-                                <div className="mt-4 grid gap-2 sm:grid-cols-2">
-                                    {revealedRecoveryCodes.map((code) => (
-                                        <div key={code} className="rounded-lg bg-white px-3 py-2 font-mono text-sm text-gray-900">
-                                            {code}
-                                        </div>
-                                    ))}
-                                </div>
-                            </section>
-                        )}
-                    </aside>
-                </div>
+                    )}
+                </aside>
             </div>
-        </div>
+        </>
     );
 }
+
+SecurityIndex.layout = (page: ReactElement) => (
+    <DashboardLayout
+        title="Account Security"
+        subtitle="Manage two-factor authentication and active sessions."
+        eyebrow="Security Settings"
+        activeNav="security"
+        headerActions={null}
+    >
+        {page}
+    </DashboardLayout>
+);
+
+type SecurityPageComponent = typeof SecurityIndex & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(SecurityIndex as SecurityPageComponent).layout = SecurityIndex.layout;

--- a/resources/js/pages/Account/Security/Sessions.tsx
+++ b/resources/js/pages/Account/Security/Sessions.tsx
@@ -1,12 +1,94 @@
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+    ComputerIcon,
+    SmartPhone01Icon,
+    MapPinIcon,
+} from "@hugeicons/core-free-icons";
+
+type DeviceIcon = typeof ComputerIcon | typeof SmartPhone01Icon;
+
+interface OtherSession {
+    icon: DeviceIcon;
+    device: string;
+    ip: string;
+    location: string;
+    lastSeen: string;
+}
+
+const OTHER_SESSIONS: OtherSession[] = [
+    { icon: SmartPhone01Icon, device: 'iOS • Chrome', ip: '10.0.0.25', location: 'Tokyo, JP', lastSeen: '3 days ago' },
+    { icon: ComputerIcon, device: 'Windows 11 • Edge', ip: '172.16.0.4', location: 'London, UK', lastSeen: '1 week ago' },
+];
 
 export default function Sessions() {
     return (
-        <Alert className="rounded-2xl border-dashed border-border bg-muted/30">
-            <AlertTitle>Sessions are coming next</AlertTitle>
-            <AlertDescription>
-                Phase 3 adds active session visibility, single-session revocation, and a sign-out-everywhere flow.
-            </AlertDescription>
-        </Alert>
+        <div className="space-y-6">
+            <div className="space-y-4">
+                <h3 className="auth-eyebrow text-muted-foreground">Current Session</h3>
+
+                <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 rounded-md border border-[#C4A5F3]/30 bg-[#F5F0FE] p-4 relative overflow-hidden">
+                    <div className="absolute left-0 top-0 bottom-0 w-1 bg-[#C4A5F3]"></div>
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white border border-[#C4A5F3]/20 text-[#5B619D]">
+                        <HugeiconsIcon icon={ComputerIcon} className="size-5" />
+                    </div>
+
+                    <div className="flex-1 space-y-1">
+                        <div className="flex items-center gap-2">
+                            <span className="font-display font-medium text-foreground">Mac OS • Safari</span>
+                            <span className="inline-flex items-center rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+                                Active now
+                            </span>
+                        </div>
+                        <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 font-mono text-xs text-muted-foreground">
+                            <span>192.168.1.1</span>
+                            <span className="hidden sm:inline">•</span>
+                            <span className="flex items-center gap-1 font-body">
+                                <HugeiconsIcon icon={MapPinIcon} className="size-3" />
+                                Ho Chi Minh City, VN
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div className="space-y-4">
+                <h3 className="auth-eyebrow text-muted-foreground">Other Sessions</h3>
+
+                <div className="space-y-3">
+                    {OTHER_SESSIONS.map(({ icon, device, ip, location, lastSeen }) => (
+                        <div key={device} className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 rounded-md border border-[#E2E8F0] bg-white p-4">
+                            <div className="flex items-center gap-4">
+                                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted/50 border border-border text-muted-foreground">
+                                    <HugeiconsIcon icon={icon} className="size-5" />
+                                </div>
+                                <div className="space-y-1">
+                                    <div className="font-display font-medium text-foreground">{device}</div>
+                                    <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 font-mono text-xs text-muted-foreground">
+                                        <span>{ip}</span>
+                                        <span className="hidden sm:inline">•</span>
+                                        <span className="flex items-center gap-1 font-body">
+                                            <HugeiconsIcon icon={MapPinIcon} className="size-3" />
+                                            {location}
+                                        </span>
+                                        <span className="hidden sm:inline">•</span>
+                                        <span className="font-body text-muted-foreground/80">{lastSeen}</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <Button variant="outline" size="sm" onClick={() => console.log("revoke")} className="w-full sm:w-auto shrink-0 font-body">
+                                Revoke
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div className="pt-2 border-t border-[#E2E8F0]">
+                <Button variant="destructive" onClick={() => console.log("sign out all")} className="font-body w-full sm:w-auto">
+                    Sign out of all other sessions
+                </Button>
+            </div>
+        </div>
     );
 }

--- a/resources/js/pages/Account/Security/Sessions.tsx
+++ b/resources/js/pages/Account/Security/Sessions.tsx
@@ -2,24 +2,8 @@ import { Button } from "@/components/ui/button";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
     ComputerIcon,
-    SmartPhone01Icon,
     MapPinIcon,
 } from "@hugeicons/core-free-icons";
-
-type DeviceIcon = typeof ComputerIcon | typeof SmartPhone01Icon;
-
-interface OtherSession {
-    icon: DeviceIcon;
-    device: string;
-    ip: string;
-    location: string;
-    lastSeen: string;
-}
-
-const OTHER_SESSIONS: OtherSession[] = [
-    { icon: SmartPhone01Icon, device: 'iOS • Chrome', ip: '10.0.0.25', location: 'Tokyo, JP', lastSeen: '3 days ago' },
-    { icon: ComputerIcon, device: 'Windows 11 • Edge', ip: '172.16.0.4', location: 'London, UK', lastSeen: '1 week ago' },
-];
 
 export default function Sessions() {
     return (
@@ -35,17 +19,17 @@ export default function Sessions() {
 
                     <div className="flex-1 space-y-1">
                         <div className="flex items-center gap-2">
-                            <span className="font-display font-medium text-foreground">Mac OS • Safari</span>
-                            <span className="inline-flex items-center rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
-                                Active now
+                            <span className="font-display font-medium text-foreground">Current browser session</span>
+                            <span className="inline-flex items-center rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20">
+                                Details unavailable
                             </span>
                         </div>
                         <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 font-mono text-xs text-muted-foreground">
-                            <span>192.168.1.1</span>
+                            <span>Session metadata is not connected yet.</span>
                             <span className="hidden sm:inline">•</span>
                             <span className="flex items-center gap-1 font-body">
                                 <HugeiconsIcon icon={MapPinIcon} className="size-3" />
-                                Ho Chi Minh City, VN
+                                Location unavailable
                             </span>
                         </div>
                     </div>
@@ -55,37 +39,13 @@ export default function Sessions() {
             <div className="space-y-4">
                 <h3 className="auth-eyebrow text-muted-foreground">Other Sessions</h3>
 
-                <div className="space-y-3">
-                    {OTHER_SESSIONS.map(({ icon, device, ip, location, lastSeen }) => (
-                        <div key={device} className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 rounded-md border border-[#E2E8F0] bg-white p-4">
-                            <div className="flex items-center gap-4">
-                                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted/50 border border-border text-muted-foreground">
-                                    <HugeiconsIcon icon={icon} className="size-5" />
-                                </div>
-                                <div className="space-y-1">
-                                    <div className="font-display font-medium text-foreground">{device}</div>
-                                    <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 font-mono text-xs text-muted-foreground">
-                                        <span>{ip}</span>
-                                        <span className="hidden sm:inline">•</span>
-                                        <span className="flex items-center gap-1 font-body">
-                                            <HugeiconsIcon icon={MapPinIcon} className="size-3" />
-                                            {location}
-                                        </span>
-                                        <span className="hidden sm:inline">•</span>
-                                        <span className="font-body text-muted-foreground/80">{lastSeen}</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <Button variant="outline" size="sm" onClick={() => console.log("revoke")} className="w-full sm:w-auto shrink-0 font-body">
-                                Revoke
-                            </Button>
-                        </div>
-                    ))}
+                <div className="rounded-md border border-dashed border-[#E2E8F0] bg-white p-5 text-sm text-muted-foreground">
+                    Session listing and revocation require backend session-management endpoints before they can be enabled.
                 </div>
             </div>
 
             <div className="pt-2 border-t border-[#E2E8F0]">
-                <Button variant="destructive" onClick={() => console.log("sign out all")} className="font-body w-full sm:w-auto">
+                <Button variant="destructive" disabled className="font-body w-full sm:w-auto">
                     Sign out of all other sessions
                 </Button>
             </div>

--- a/resources/js/pages/Account/Security/Sessions.tsx
+++ b/resources/js/pages/Account/Security/Sessions.tsx
@@ -1,0 +1,12 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export default function Sessions() {
+    return (
+        <Alert className="rounded-2xl border-dashed border-border bg-muted/30">
+            <AlertTitle>Sessions are coming next</AlertTitle>
+            <AlertDescription>
+                Phase 3 adds active session visibility, single-session revocation, and a sign-out-everywhere flow.
+            </AlertDescription>
+        </Alert>
+    );
+}

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -45,18 +45,34 @@ function go(step: number) {
     );
 }
 
+function getAllowedStep(step: number, twoFactor: PageProps["twoFactor"]): number {
+    let maxStep = 1;
+
+    if (twoFactor.enabled) {
+        maxStep = 5;
+    } else if (twoFactor.pending) {
+        maxStep = 3;
+    }
+
+    const requestedStep = Number.isFinite(step) ? step : 1;
+
+    return Math.min(Math.max(requestedStep, 1), maxStep);
+}
+
 export default function TwoFactorWizard({ step, twoFactor }: PageProps) {
+    const currentStep = getAllowedStep(step, twoFactor);
+
     return (
         <section className="auth-shell mt-2">
             <div className="auth-shell-inner p-6 sm:p-8">
-                <Stepper steps={STEPS} current={step - 1} className="flex-wrap mb-8" />
+                <Stepper steps={STEPS} current={currentStep - 1} className="flex-wrap mb-8" />
 
                 <StepPanel>
-                    {step === 1 && <ChooseMethod />}
-                    {step === 2 && <SetUp twoFactor={twoFactor} />}
-                    {step === 3 && <Verify />}
-                    {step === 4 && <Recovery codes={twoFactor.recoveryCodes} />}
-                    {step === 5 && <Done />}
+                    {currentStep === 1 && <ChooseMethod />}
+                    {currentStep === 2 && <SetUp twoFactor={twoFactor} />}
+                    {currentStep === 3 && <Verify />}
+                    {currentStep === 4 && <Recovery codes={twoFactor.recoveryCodes} />}
+                    {currentStep === 5 && <Done />}
                 </StepPanel>
             </div>
         </section>
@@ -124,7 +140,7 @@ function ChooseMethod() {
 function SetUp({ twoFactor }: { twoFactor: PageProps["twoFactor"] }) {
     const { copied, copy } = useClipboard();
 
-    if (!twoFactor.pending || !twoFactor.qrCodeSvg) {
+    if (!twoFactor.pending || !twoFactor.qrCodeUrl) {
         return (
             <Alert variant="warning">
                 <AlertDescription>
@@ -141,7 +157,14 @@ function SetUp({ twoFactor }: { twoFactor: PageProps["twoFactor"] }) {
             </p>
 
             <div className="rounded-md border border-[#E2E8F0] bg-[#F8FAFC] p-6 flex justify-center">
-                <div dangerouslySetInnerHTML={{ __html: twoFactor.qrCodeSvg }} />
+                <img
+                    src={twoFactor.qrCodeUrl}
+                    alt="Two-factor authentication QR code"
+                    width={220}
+                    height={220}
+                    loading="lazy"
+                    className="h-auto w-[220px]"
+                />
             </div>
 
             {twoFactor.setupKey && (

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -63,7 +63,11 @@ export default function TwoFactorWizard({ step, twoFactor }: PageProps) {
     );
 }
 
-TwoFactorWizard.layout = (page: ReactElement) => (
+type TwoFactorWizardPageComponent = typeof TwoFactorWizard & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(TwoFactorWizard as TwoFactorWizardPageComponent).layout = (page: ReactElement) => (
     <DashboardLayout
         title="Secure Your Account"
         subtitle="Add an authenticator app to complete your migration."
@@ -75,12 +79,6 @@ TwoFactorWizard.layout = (page: ReactElement) => (
         {page}
     </DashboardLayout>
 );
-
-type TwoFactorWizardPageComponent = typeof TwoFactorWizard & {
-    layout?: (page: ReactElement) => ReactNode;
-};
-
-(TwoFactorWizard as TwoFactorWizardPageComponent).layout = TwoFactorWizard.layout;
 
 function ChooseMethod() {
     const form = useForm({ force: true, return_to_wizard: true });
@@ -180,9 +178,7 @@ function Verify() {
         return_to_wizard: true,
     });
 
-    const submit = (code: string) => {
-        setData("code", code);
-        setData("return_to_wizard", true);
+    const submit = () => {
         post("/scp/account/security/two-factor/confirm", {
             preserveScroll: true,
         });
@@ -227,7 +223,7 @@ function Verify() {
                 <Button
                     type="button"
                     disabled={processing || data.code.length < 6}
-                    onClick={() => submit(data.code)}
+                    onClick={submit}
                 >
                     {processing ? "Verifying…" : "Verify"}
                 </Button>

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -59,6 +59,10 @@ function getAllowedStep(step: number, twoFactor: PageProps["twoFactor"]): number
     return Math.min(Math.max(requestedStep, 1), maxStep);
 }
 
+function getQrCodeImageSrc(svg: string): string {
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
 export default function TwoFactorWizard({ step, twoFactor }: PageProps) {
     const currentStep = getAllowedStep(step, twoFactor);
 
@@ -140,7 +144,7 @@ function ChooseMethod() {
 function SetUp({ twoFactor }: { twoFactor: PageProps["twoFactor"] }) {
     const { copied, copy } = useClipboard();
 
-    if (!twoFactor.pending || !twoFactor.qrCodeUrl) {
+    if (!twoFactor.pending || !twoFactor.qrCodeSvg) {
         return (
             <Alert variant="warning">
                 <AlertDescription>
@@ -158,7 +162,7 @@ function SetUp({ twoFactor }: { twoFactor: PageProps["twoFactor"] }) {
 
             <div className="rounded-md border border-[#E2E8F0] bg-[#F8FAFC] p-6 flex justify-center">
                 <img
-                    src={twoFactor.qrCodeUrl}
+                    src={getQrCodeImageSrc(twoFactor.qrCodeSvg)}
                     alt="Two-factor authentication QR code"
                     width={220}
                     height={220}

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -23,7 +23,6 @@ interface PageProps {
         pending: boolean;
         method: "app" | null;
         qrCodeSvg: string | null;
-        qrCodeUrl: string | null;
         setupKey: string | null;
         recoveryCodes: string[];
     };

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -1,0 +1,314 @@
+import { Link, router, useForm } from "@inertiajs/react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+    InputOTP,
+    InputOTPGroup,
+    InputOTPSlot,
+} from "@/components/ui/input-otp";
+import { Label } from "@/components/ui/label";
+import { StepPanel, Stepper } from "@/components/ui/stepper";
+import { useClipboard } from "@/hooks/use-clipboard";
+
+interface PageProps {
+    step: number;
+    twoFactor: {
+        enabled: boolean;
+        pending: boolean;
+        method: "app" | null;
+        qrCodeSvg: string | null;
+        qrCodeUrl: string | null;
+        setupKey: string | null;
+        recoveryCodes: string[];
+    };
+}
+
+const STEPS = [
+    { key: "method", label: "Choose method" },
+    { key: "setup", label: "Set up" },
+    { key: "verify", label: "Verify" },
+    { key: "recovery", label: "Recovery codes" },
+    { key: "done", label: "Done" },
+];
+
+function go(step: number) {
+    router.get(
+        "/scp/account/security/two-factor",
+        { step },
+        { preserveScroll: true, preserveState: true, replace: true },
+    );
+}
+
+export default function TwoFactorWizard({ step, twoFactor }: PageProps) {
+    return (
+        <div className="min-h-screen bg-gray-50 px-4 py-10">
+            <div className="mx-auto max-w-4xl space-y-6">
+                <div className="flex items-center justify-between gap-4">
+                    <div>
+                        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+                            Two-factor authentication
+                        </h1>
+                        <p className="mt-2 text-sm text-gray-500">
+                            Add an authenticator app to harden your account and finish the migration.
+                        </p>
+                    </div>
+                    <Link
+                        href="/scp/account/security"
+                        className="text-sm font-medium text-blue-600 hover:underline"
+                    >
+                        Back to security settings
+                    </Link>
+                </div>
+
+                <section className="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
+                    <Stepper steps={STEPS} current={step - 1} className="flex-wrap" />
+
+                    <StepPanel>
+                        {step === 1 && <ChooseMethod />}
+                        {step === 2 && <SetUp twoFactor={twoFactor} />}
+                        {step === 3 && <Verify />}
+                        {step === 4 && <Recovery codes={twoFactor.recoveryCodes} />}
+                        {step === 5 && <Done />}
+                    </StepPanel>
+                </section>
+            </div>
+        </div>
+    );
+}
+
+function ChooseMethod() {
+    const form = useForm({ force: true, return_to_wizard: true });
+
+    return (
+        <div className="space-y-4">
+            <p className="text-sm text-gray-600">
+                Choose how you want to receive verification codes. We recommend an authenticator app for the strongest protection.
+            </p>
+
+            <div className="grid gap-3">
+                <button
+                    type="button"
+                    onClick={() =>
+                        form.post("/scp/account/security/two-factor/enable", {
+                            preserveScroll: true,
+                        })
+                    }
+                    disabled={form.processing}
+                    className="flex items-start gap-3 rounded-lg border border-gray-300 p-4 text-left transition hover:border-blue-500 hover:bg-blue-50 disabled:opacity-50"
+                >
+                    <span className="text-xl" aria-hidden="true">
+                        📱
+                    </span>
+                    <span>
+                        <span className="block font-medium text-gray-900">
+                            Authenticator app
+                        </span>
+                        <span className="block text-sm text-gray-500">
+                            Use Google Authenticator, 1Password, Authy, or another TOTP app.
+                        </span>
+                    </span>
+                </button>
+
+                <div className="rounded-lg border border-dashed border-gray-300 p-4 text-sm text-gray-500">
+                    Email login codes remain available for the legacy sign-in path while you finish this upgrade.
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function SetUp({ twoFactor }: { twoFactor: PageProps["twoFactor"] }) {
+    const { copied, copy } = useClipboard();
+
+    if (!twoFactor.pending || !twoFactor.qrCodeSvg) {
+        return (
+            <Alert variant="warning">
+                <AlertDescription>
+                    Setup has not started yet. Go back to step 1 and begin the authenticator app flow.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <p className="text-sm text-gray-600">
+                Scan this QR code with your authenticator app, or enter the setup key manually if scanning is unavailable.
+            </p>
+
+            <div className="flex justify-center rounded-lg border border-gray-200 bg-gray-50 p-4">
+                <div dangerouslySetInnerHTML={{ __html: twoFactor.qrCodeSvg }} />
+            </div>
+
+            {twoFactor.setupKey && (
+                <div className="space-y-2">
+                    <Label htmlFor="setup-key">Setup key</Label>
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                        <Input id="setup-key" value={twoFactor.setupKey} readOnly />
+                        <Button
+                            variant="outline"
+                            type="button"
+                            onClick={() => copy(twoFactor.setupKey ?? "")}
+                        >
+                            {copied ? "Copied!" : "Copy"}
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            <div className="flex justify-end gap-2">
+                <Button variant="ghost" type="button" onClick={() => go(1)}>
+                    Back
+                </Button>
+                <Button type="button" onClick={() => go(3)}>
+                    Next: verify
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+function Verify() {
+    const { data, setData, post, processing, errors } = useForm({
+        code: "",
+        return_to_wizard: true,
+    });
+
+    const submit = (code: string) => {
+        setData("code", code);
+        setData("return_to_wizard", true);
+        post("/scp/account/security/two-factor/confirm", {
+            preserveScroll: true,
+        });
+    };
+
+    return (
+        <div className="space-y-4">
+            <p className="text-sm text-gray-600">
+                Enter the 6-digit code from your authenticator app to confirm setup.
+            </p>
+
+            <InputOTP
+                maxLength={6}
+                value={data.code}
+                onChange={(value) => setData("code", value)}
+                disabled={processing}
+                autoFocus
+                aria-invalid={!!errors.code}
+                containerClassName="justify-center"
+            >
+                <InputOTPGroup className="gap-1.5">
+                    {[0, 1, 2, 3, 4, 5].map((index) => (
+                        <InputOTPSlot
+                            key={index}
+                            index={index}
+                            className="size-12 rounded border border-border bg-background text-lg text-foreground first:rounded-l last:rounded-r"
+                        />
+                    ))}
+                </InputOTPGroup>
+            </InputOTP>
+
+            {errors.code && (
+                <p className="text-center text-xs text-red-600" role="alert">
+                    {errors.code}
+                </p>
+            )}
+
+            <div className="flex justify-end gap-2">
+                <Button variant="ghost" type="button" onClick={() => go(2)}>
+                    Back
+                </Button>
+                <Button
+                    type="button"
+                    disabled={processing || data.code.length < 6}
+                    onClick={() => submit(data.code)}
+                >
+                    {processing ? "Verifying…" : "Verify"}
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+function Recovery({ codes }: { codes: string[] }) {
+    const { copy, copied } = useClipboard();
+    const text = codes.join("\n");
+
+    function download() {
+        const blob = new Blob([text], { type: "text/plain" });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
+
+        anchor.href = url;
+        anchor.download = "osticket-recovery-codes.txt";
+        anchor.click();
+        URL.revokeObjectURL(url);
+    }
+
+    if (codes.length === 0) {
+        return (
+            <Alert variant="warning">
+                <AlertDescription>
+                    Recovery codes were not revealed in this session. Return to the security page to regenerate them.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <Alert variant="warning">
+                <AlertDescription>
+                    Save these recovery codes somewhere safe. Each code can be used once if you lose access to your authenticator app.
+                </AlertDescription>
+            </Alert>
+
+            <ul className="grid gap-2 rounded-lg border border-gray-200 bg-gray-50 p-4 font-mono text-sm text-gray-900 sm:grid-cols-2">
+                {codes.map((code) => (
+                    <li key={code} className="select-all rounded bg-white px-3 py-2">
+                        {code}
+                    </li>
+                ))}
+            </ul>
+
+            <div className="flex flex-wrap gap-2">
+                <Button variant="outline" type="button" onClick={() => copy(text)}>
+                    {copied ? "Copied!" : "Copy all"}
+                </Button>
+                <Button variant="outline" type="button" onClick={download}>
+                    Download .txt
+                </Button>
+                <Button variant="outline" type="button" onClick={() => window.print()}>
+                    Print
+                </Button>
+            </div>
+
+            <div className="flex justify-end">
+                <Button type="button" onClick={() => go(5)}>
+                    I&apos;ve saved them
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+function Done() {
+    return (
+        <div className="space-y-4 text-center">
+            <p className="text-4xl" aria-hidden="true">
+                ✅
+            </p>
+            <p className="text-sm text-gray-700">
+                Two-factor authentication is now enabled for your staff account.
+            </p>
+            <Link
+                href="/scp/account/security"
+                className="inline-block text-sm font-medium text-blue-600 hover:underline"
+            >
+                Return to security settings
+            </Link>
+        </div>
+    );
+}

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -1,8 +1,10 @@
 import { Link, router, useForm } from "@inertiajs/react";
+import { type ReactElement, type ReactNode } from 'react';
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import DashboardLayout from '@/layouts/DashboardLayout';
 import {
     InputOTP,
     InputOTPGroup,
@@ -11,6 +13,8 @@ import {
 import { Label } from "@/components/ui/label";
 import { StepPanel, Stepper } from "@/components/ui/stepper";
 import { useClipboard } from "@/hooks/use-clipboard";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ShieldCheck } from "@hugeicons/core-free-icons";
 
 interface PageProps {
     step: number;
@@ -37,46 +41,46 @@ function go(step: number) {
     router.get(
         "/scp/account/security/two-factor",
         { step },
-        { preserveScroll: true, preserveState: true, replace: true },
+        { preserveScroll: true, preserveState: true },
     );
 }
 
 export default function TwoFactorWizard({ step, twoFactor }: PageProps) {
     return (
-        <div className="min-h-screen bg-gray-50 px-4 py-10">
-            <div className="mx-auto max-w-4xl space-y-6">
-                <div className="flex items-center justify-between gap-4">
-                    <div>
-                        <h1 className="text-3xl font-bold tracking-tight text-gray-900">
-                            Two-factor authentication
-                        </h1>
-                        <p className="mt-2 text-sm text-gray-500">
-                            Add an authenticator app to harden your account and finish the migration.
-                        </p>
-                    </div>
-                    <Link
-                        href="/scp/account/security"
-                        className="text-sm font-medium text-blue-600 hover:underline"
-                    >
-                        Back to security settings
-                    </Link>
-                </div>
+        <section className="auth-shell mt-2">
+            <div className="auth-shell-inner p-6 sm:p-8">
+                <Stepper steps={STEPS} current={step - 1} className="flex-wrap mb-8" />
 
-                <section className="rounded-2xl bg-white p-6 shadow-sm sm:p-8">
-                    <Stepper steps={STEPS} current={step - 1} className="flex-wrap" />
-
-                    <StepPanel>
-                        {step === 1 && <ChooseMethod />}
-                        {step === 2 && <SetUp twoFactor={twoFactor} />}
-                        {step === 3 && <Verify />}
-                        {step === 4 && <Recovery codes={twoFactor.recoveryCodes} />}
-                        {step === 5 && <Done />}
-                    </StepPanel>
-                </section>
+                <StepPanel>
+                    {step === 1 && <ChooseMethod />}
+                    {step === 2 && <SetUp twoFactor={twoFactor} />}
+                    {step === 3 && <Verify />}
+                    {step === 4 && <Recovery codes={twoFactor.recoveryCodes} />}
+                    {step === 5 && <Done />}
+                </StepPanel>
             </div>
-        </div>
+        </section>
     );
 }
+
+TwoFactorWizard.layout = (page: ReactElement) => (
+    <DashboardLayout
+        title="Secure Your Account"
+        subtitle="Add an authenticator app to complete your migration."
+        eyebrow="Two-Factor Authentication"
+        activeNav="security"
+        contentClassName="max-w-4xl mx-auto"
+        headerActions={null}
+    >
+        {page}
+    </DashboardLayout>
+);
+
+type TwoFactorWizardPageComponent = typeof TwoFactorWizard & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(TwoFactorWizard as TwoFactorWizardPageComponent).layout = TwoFactorWizard.layout;
 
 function ChooseMethod() {
     const form = useForm({ force: true, return_to_wizard: true });
@@ -96,7 +100,7 @@ function ChooseMethod() {
                         })
                     }
                     disabled={form.processing}
-                    className="flex items-start gap-3 rounded-lg border border-gray-300 p-4 text-left transition hover:border-blue-500 hover:bg-blue-50 disabled:opacity-50"
+                    className="flex items-start gap-3 rounded-md border border-[#E2E8F0] bg-[#F8FAFC] p-4 text-left transition duration-150 hover:border-[#C4A5F3] hover:bg-white cursor-pointer disabled:opacity-50"
                 >
                     <span className="text-xl" aria-hidden="true">
                         📱
@@ -111,7 +115,7 @@ function ChooseMethod() {
                     </span>
                 </button>
 
-                <div className="rounded-lg border border-dashed border-gray-300 p-4 text-sm text-gray-500">
+                <div className="rounded-md border border-dashed border-[#E2E8F0] bg-white p-4 text-xs text-[#94A3B8]">
                     Email login codes remain available for the legacy sign-in path while you finish this upgrade.
                 </div>
             </div>
@@ -138,7 +142,7 @@ function SetUp({ twoFactor }: { twoFactor: PageProps["twoFactor"] }) {
                 Scan this QR code with your authenticator app, or enter the setup key manually if scanning is unavailable.
             </p>
 
-            <div className="flex justify-center rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <div className="rounded-md border border-[#E2E8F0] bg-[#F8FAFC] p-6 flex justify-center">
                 <div dangerouslySetInnerHTML={{ __html: twoFactor.qrCodeSvg }} />
             </div>
 
@@ -265,7 +269,7 @@ function Recovery({ codes }: { codes: string[] }) {
                 </AlertDescription>
             </Alert>
 
-            <ul className="grid gap-2 rounded-lg border border-gray-200 bg-gray-50 p-4 font-mono text-sm text-gray-900 sm:grid-cols-2">
+            <ul className="grid gap-2 rounded-md border border-[#E2E8F0] bg-[#F8FAFC] p-4 font-mono text-sm text-[#0F172A] sm:grid-cols-2">
                 {codes.map((code) => (
                     <li key={code} className="select-all rounded bg-white px-3 py-2">
                         {code}
@@ -297,15 +301,15 @@ function Recovery({ codes }: { codes: string[] }) {
 function Done() {
     return (
         <div className="space-y-4 text-center">
-            <p className="text-4xl" aria-hidden="true">
-                ✅
-            </p>
+            <div className="w-10 h-10 rounded-full bg-emerald-50 border border-emerald-200 flex items-center justify-center mx-auto mb-4">
+                <HugeiconsIcon icon={ShieldCheck} size={20} color="#059669" />
+            </div>
             <p className="text-sm text-gray-700">
                 Two-factor authentication is now enabled for your staff account.
             </p>
             <Link
                 href="/scp/account/security"
-                className="inline-block text-sm font-medium text-blue-600 hover:underline"
+                className="inline-block text-sm font-medium text-[#5B619D] hover:underline mt-2"
             >
                 Return to security settings
             </Link>

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -243,8 +243,11 @@ function Recovery({ codes }: { codes: string[] }) {
 
         anchor.href = url;
         anchor.download = "osticket-recovery-codes.txt";
+        anchor.rel = "noopener";
+        document.body.append(anchor);
         anchor.click();
-        URL.revokeObjectURL(url);
+        anchor.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 0);
     }
 
     if (codes.length === 0) {

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -1,4 +1,4 @@
-import { Link, router, useForm } from "@inertiajs/react";
+import { Link, router, useForm, usePage } from "@inertiajs/react";
 import { type ReactElement, type ReactNode } from 'react';
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -16,8 +16,9 @@ import { useClipboard } from "@/hooks/use-clipboard";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ShieldCheck } from "@hugeicons/core-free-icons";
 
-interface PageProps {
+interface PageProps extends Record<string, unknown> {
     step: number;
+    status?: string;
     twoFactor: {
         enabled: boolean;
         pending: boolean;
@@ -63,15 +64,22 @@ function getQrCodeImageSrc(svg: string): string {
 }
 
 export default function TwoFactorWizard({ step, twoFactor }: PageProps) {
+    const { props } = usePage<PageProps>();
     const currentStep = getAllowedStep(step, twoFactor);
 
     return (
         <section className="auth-shell mt-2">
             <div className="auth-shell-inner p-6 sm:p-8">
+                {props.status && (
+                    <div className="mb-6 rounded-md border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-3 text-sm text-[#0F172A]">
+                        {props.status}
+                    </div>
+                )}
+
                 <Stepper steps={STEPS} current={currentStep - 1} className="flex-wrap mb-8" />
 
                 <StepPanel>
-                    {currentStep === 1 && <ChooseMethod />}
+                    {currentStep === 1 && <ChooseMethod twoFactor={twoFactor} />}
                     {currentStep === 2 && <SetUp twoFactor={twoFactor} />}
                     {currentStep === 3 && <Verify />}
                     {currentStep === 4 && <Recovery codes={twoFactor.recoveryCodes} />}
@@ -99,23 +107,32 @@ type TwoFactorWizardPageComponent = typeof TwoFactorWizard & {
     </DashboardLayout>
 );
 
-function ChooseMethod() {
-    const form = useForm({ force: true, return_to_wizard: true });
+function ChooseMethod({ twoFactor }: { twoFactor: PageProps["twoFactor"] }) {
+    const form = useForm({ force: !twoFactor.pending, return_to_wizard: true });
+
+    const startSetup = () => {
+        if (twoFactor.pending) {
+            go(2);
+            return;
+        }
+
+        form.post("/scp/account/security/two-factor/enable", {
+            preserveScroll: true,
+        });
+    };
 
     return (
         <div className="space-y-4">
             <p className="text-sm text-gray-600">
-                Choose how you want to receive verification codes. We recommend an authenticator app for the strongest protection.
+                {twoFactor.pending
+                    ? 'Your authenticator app setup is already in progress. Continue without generating a new secret.'
+                    : 'Choose how you want to receive verification codes. We recommend an authenticator app for the strongest protection.'}
             </p>
 
             <div className="grid gap-3">
                 <button
                     type="button"
-                    onClick={() =>
-                        form.post("/scp/account/security/two-factor/enable", {
-                            preserveScroll: true,
-                        })
-                    }
+                    onClick={startSetup}
                     disabled={form.processing}
                     className="flex items-start gap-3 rounded-md border border-[#E2E8F0] bg-[#F8FAFC] p-4 text-left transition duration-150 hover:border-[#C4A5F3] hover:bg-white cursor-pointer disabled:opacity-50"
                 >
@@ -124,10 +141,12 @@ function ChooseMethod() {
                     </span>
                     <span>
                         <span className="block font-medium text-gray-900">
-                            Authenticator app
+                            {twoFactor.pending ? 'Continue authenticator setup' : 'Authenticator app'}
                         </span>
                         <span className="block text-sm text-gray-500">
-                            Use Google Authenticator, 1Password, Authy, or another TOTP app.
+                            {twoFactor.pending
+                                ? 'Resume scanning your existing QR code and finish verification.'
+                                : 'Use Google Authenticator, 1Password, Authy, or another TOTP app.'}
                         </span>
                     </span>
                 </button>

--- a/resources/js/pages/Auth/ConfirmPassword.tsx
+++ b/resources/js/pages/Auth/ConfirmPassword.tsx
@@ -27,7 +27,7 @@ export default function ConfirmPassword() {
             title="Confirm your password."
             subtitle="Re-enter your password to continue to two-factor authentication settings."
             tag="Security · Re-auth"
-            eyebrowAccent="orange"
+            eyebrowAccent="purple"
             sectionIndex="04"
             footer={
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/resources/js/pages/Auth/ForgotPassword.tsx
+++ b/resources/js/pages/Auth/ForgotPassword.tsx
@@ -27,7 +27,7 @@ export default function ForgotPassword() {
             title="Recover your access."
             subtitle="Enter the email on file and we'll send a secure, single-use link to reset your password."
             tag="Recovery · Email"
-            eyebrowAccent="pink"
+            eyebrowAccent="emerald"
             sectionIndex="02"
             footer={
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/resources/js/pages/Auth/Login.tsx
+++ b/resources/js/pages/Auth/Login.tsx
@@ -56,7 +56,7 @@ export default function Login() {
             title="Sign in to the console."
             subtitle="Access the osTicket staff support panel with your credentials. Two-factor authentication may be required."
             tag="Login · Staff"
-            eyebrowAccent="orange"
+            eyebrowAccent="purple"
             sectionIndex="01"
             footer={
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -128,6 +128,14 @@ const replyTimeInteractiveChartConfig = {
     ),
 } satisfies ChartConfig;
 
+function getStatCardBorderClass(index: number) {
+    return cn(
+        index > 0 && 'border-t border-[#E2E8F0] md:border-t-0',
+        index % 2 === 1 && 'md:border-l md:border-[#E2E8F0] xl:border-l',
+        index >= 2 && 'xl:border-l xl:border-t-0',
+    );
+}
+
 function StatCard({ label, value, suffix, trend, positive }: StatCardItem) {
     return (
         <Card className="rounded-none border-0 py-0 shadow-none ring-0">
@@ -213,12 +221,12 @@ function ReplyTimeInteractiveChart() {
                             <SelectValue placeholder="Select segment" />
                         </SelectTrigger>
                         <SelectContent align="end" className="rounded-xl">
-                            {REPLY_TIME_DATA.map(({ name }) => (
+                            {REPLY_TIME_DATA.map(({ fill, name }) => (
                                 <SelectItem key={name} value={name} className="rounded-lg [&_span]:flex">
                                     <div className="flex items-center gap-2 text-xs">
                                         <span
                                             className="flex h-3 w-3 shrink-0 rounded-[2px]"
-                                            style={{ backgroundColor: `var(--color-${name})` }}
+                                            style={{ backgroundColor: fill }}
                                         />
                                         {name}
                                     </div>
@@ -294,10 +302,20 @@ export default function Dashboard() {
             <MigrationBanner />
 
             <div className="space-y-6 xl:space-y-8">
+                <div className="flex flex-wrap items-center justify-between gap-3 rounded-[14px] border border-dashed border-[#C4A5F3]/50 bg-[#F8FAFC] px-4 py-3">
+                    <div>
+                        <p className="font-body text-sm font-medium text-[#0F172A]">Analytics preview</p>
+                        <p className="mt-0.5 text-xs text-[#64748B]">Dashboard metrics are sample values until live reporting endpoints are connected.</p>
+                    </div>
+                    <span className="rounded-full bg-[#F3ECFF] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#5B619D]">
+                        Sample data
+                    </span>
+                </div>
+
                 <SectionFrame>
                     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4">
                         {STAT_CARDS.map((card, index) => (
-                            <div key={card.label} className={cn(index > 0 && 'border-t border-[#E2E8F0] md:border-t-0', index % 2 === 1 && 'md:border-l md:border-[#E2E8F0] xl:border-l', index >= 2 && 'xl:border-l xl:border-t-0')}>
+                            <div key={card.label} className={getStatCardBorderClass(index)}>
                                 <StatCard {...card} />
                             </div>
                         ))}

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -1,33 +1,452 @@
-import { Link, router } from '@inertiajs/react';
+import * as React from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import {
+    ArrowDown01Icon,
+    ArrowUp01Icon,
+} from '@hugeicons/core-free-icons';
+import {
+    Bar,
+    BarChart,
+    Label,
+    CartesianGrid,
+    Cell,
+    Pie,
+    PieChart,
+    Sector,
+    XAxis,
+    YAxis,
+} from 'recharts';
+import type { PieSectorDataItem, PieSectorShapeProps } from 'recharts/types/polar/Pie';
 
 import { MigrationBanner } from '@/components/auth/MigrationBanner';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import {
+    ChartContainer,
+    type ChartConfig,
+    ChartLegend,
+    ChartLegendContent,
+    ChartStyle,
+    ChartTooltip,
+    ChartTooltipContent,
+} from '@/components/ui/chart';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+import DashboardLayout from '@/layouts/DashboardLayout';
+import { cn } from '@/lib/utils';
 
-export default function Dashboard() {
+type StatCardItem = {
+    label: string;
+    value: string;
+    suffix?: string;
+    trend: string;
+    positive: boolean;
+};
+
+type BarChartDatum = {
+    day: string;
+    created: number;
+    solved: number;
+    highlighted?: boolean;
+};
+
+const STAT_CARDS: StatCardItem[] = [
+    { label: 'Created Tickets', value: '24,208', trend: '-5%', positive: false },
+    { label: 'Unsolved Tickets', value: '4,564', trend: '+2%', positive: true },
+    { label: 'Solved Tickets', value: '18,208', trend: '+8%', positive: true },
+    { label: 'Average First Time Reply', value: '12:01', suffix: 'min', trend: '+8', positive: true },
+];
+
+const BAR_CHART_DATA: BarChartDatum[] = [
+    { day: 'Dec 1', created: 4120, solved: 3100 },
+    { day: 'Dec 2', created: 3450, solved: 2890 },
+    { day: 'Dec 3', created: 3890, solved: 2950 },
+    { day: 'Dec 4', created: 4300, solved: 3800, highlighted: true },
+    { day: 'Dec 5', created: 3650, solved: 2400 },
+    { day: 'Dec 6', created: 3520, solved: 2860 },
+    { day: 'Dec 7', created: 3780, solved: 3010 },
+];
+
+const REPLY_TIME_DATA = [
+    { name: '0-1 Hours', value: 81, fill: '#22C55E' },
+    { name: '1-8 Hours', value: 9, fill: '#C4A5F3' },
+    { name: '8-24 Hours', value: 4, fill: '#5B619D' },
+    { name: '> 24 Hours', value: 4, fill: '#94A3B8' },
+    { name: 'No Replies', value: 2, fill: '#F43F5E' },
+] as const;
+
+type ReplyTimeName = (typeof REPLY_TIME_DATA)[number]['name'];
+
+const CHANNEL_DATA = [
+    { name: 'Email', value: 940, fill: '#5B619D' },
+    { name: 'Live Chat', value: 720, fill: '#C4A5F3' },
+    { name: 'Contact Form', value: 610, fill: '#22C55E' },
+    { name: 'Messenger', value: 420, fill: '#94A3B8' },
+    { name: 'WhatsApp', value: 312, fill: '#CBD5E1' },
+] as const;
+
+const SATISFACTION_ROWS = [
+    { icon: '👍', label: 'Positive', percent: '80%', helper: '72%', fill: '80%', tone: 'bg-emerald-500', iconTone: 'bg-emerald-50' },
+    { icon: '✋', label: 'Neutral', percent: '15%', helper: '24%', fill: '15%', tone: 'bg-[#C4A5F3]', iconTone: 'bg-[#F3ECFF]' },
+    { icon: '👎', label: 'Negative', percent: '5%', helper: '4%', fill: '5%', tone: 'bg-rose-500', iconTone: 'bg-rose-50' },
+] as const;
+
+const ticketChartConfig = {
+    created: { label: 'Avg. Ticket Create', color: '#C4A5F3' },
+    solved: { label: 'Avg. Ticket Solved', color: '#5B619D' },
+} satisfies ChartConfig;
+
+const DATE_RANGE_OPTIONS = [
+    { value: 'dec-1-7', label: 'Dec 1 - 7' },
+    { value: 'dec-8-14', label: 'Dec 8 - 14' },
+    { value: 'dec-15-21', label: 'Dec 15 - 21' },
+] as const;
+
+const channelChartConfig = Object.fromEntries(
+    CHANNEL_DATA.map(({ name, fill }) => [name, { label: name, color: fill }]),
+) satisfies ChartConfig;
+
+const replyTimeInteractiveChartConfig = {
+    visitors: {
+        label: 'Tickets',
+    },
+    ...Object.fromEntries(
+        REPLY_TIME_DATA.map(({ name, fill }) => [name, { label: name, color: fill }]),
+    ),
+} satisfies ChartConfig;
+
+function StatCard({ label, value, suffix, trend, positive }: StatCardItem) {
     return (
-        <div className="min-h-screen bg-gray-50 px-4 py-10">
-            <div className="mx-auto max-w-4xl space-y-6">
-                <MigrationBanner />
-
-                <div className="rounded-2xl bg-white p-10 text-center shadow-sm">
-                    <h1 className="text-3xl font-bold text-gray-900">osTicket Staff Control Panel</h1>
-                    <p className="mt-2 text-gray-500">Welcome back.</p>
-                    <div className="mt-6 flex items-center justify-center gap-3">
-                    <Link
-                        href="/scp/account/security"
-                        className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-white"
-                    >
-                        Security settings
-                    </Link>
-                    <button
-                        type="button"
-                        onClick={() => router.post('/scp/logout')}
-                        className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700"
-                    >
-                        Sign out
-                    </button>
-                    </div>
+        <Card className="rounded-none border-0 py-0 shadow-none ring-0">
+            <CardContent className="flex min-h-[150px] flex-col p-6 xl:p-8">
+                <div className="font-body text-[13px] font-medium text-[#64748B]">{label}</div>
+                <div className="mt-3 flex items-baseline gap-3">
+                    <div className="font-display text-[30px] font-medium tracking-tight text-[#0F172A] xl:text-[34px]">{value}</div>
+                    {suffix && <span className="font-body text-base font-medium text-[#0F172A]">{suffix}</span>}
+                    <span className={cn(
+                        'inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-semibold',
+                        positive ? 'bg-emerald-50 text-emerald-600' : 'bg-rose-50 text-rose-600',
+                    )}>
+                        {trend}
+                        <HugeiconsIcon icon={positive ? ArrowUp01Icon : ArrowDown01Icon} size={12} />
+                    </span>
                 </div>
-            </div>
-        </div>
+                <p className="mt-auto pt-3 text-xs text-[#94A3B8]">Compare to last month</p>
+            </CardContent>
+        </Card>
     );
 }
+
+function SectionFrame({ children, className }: { children: ReactNode; className?: string }) {
+    return <Card className={cn('overflow-hidden rounded-[18px] border-[#E2E8F0] py-0 shadow-none ring-0', className)}>{children}</Card>;
+}
+
+function TicketChartFooter() {
+    return (
+        <CardFooter className="flex-col items-start gap-2 border-t border-[#E2E8F0] px-6 py-4 text-sm xl:px-8">
+            <div className="flex items-center gap-2 leading-none font-medium text-[#0F172A]">
+                Ticket creation remains ahead of resolutions this week
+                <HugeiconsIcon icon={ArrowUp01Icon} size={14} />
+            </div>
+            <div className="leading-none text-[#94A3B8]">
+                Showing created versus solved tickets for Dec 1 - 7
+            </div>
+        </CardFooter>
+    );
+}
+
+function ReplyTimeInteractiveChart() {
+    const chartId = 'reply-time-interactive';
+    const [activeSegment, setActiveSegment] = React.useState<ReplyTimeName>(REPLY_TIME_DATA[0].name);
+
+    const activeIndex = React.useMemo(
+        () => REPLY_TIME_DATA.findIndex((item) => item.name === activeSegment),
+        [activeSegment],
+    );
+
+    const activeItem = REPLY_TIME_DATA[activeIndex] ?? REPLY_TIME_DATA[0];
+
+    const renderPieShape = React.useCallback(
+        ({ index, outerRadius = 0, ...props }: PieSectorDataItem & PieSectorShapeProps) => {
+            if (index === activeIndex) {
+                return (
+                    <g>
+                        <Sector {...props} outerRadius={outerRadius + 10} />
+                        <Sector {...props} outerRadius={outerRadius + 25} innerRadius={outerRadius + 12} />
+                    </g>
+                );
+            }
+
+            return <Sector {...props} outerRadius={outerRadius} />;
+        },
+        [activeIndex],
+    );
+
+    return (
+        <Card data-chart={chartId} className="flex min-h-[430px] flex-col rounded-none border-0 py-0 shadow-none ring-0">
+            <ChartStyle id={chartId} config={replyTimeInteractiveChartConfig} />
+            <CardHeader className="px-6 pt-6 pb-0 xl:px-8 xl:pt-8">
+                <div className="flex items-start">
+                    <div className="grid gap-1">
+                        <CardTitle className="font-body text-base font-medium text-[#0F172A]">Ticket By First Reply Time</CardTitle>
+                        <CardDescription className="text-sm text-[#94A3B8]">Interactive reply-time breakdown</CardDescription>
+                    </div>
+                    <Select value={activeSegment} onValueChange={(value) => value && setActiveSegment(value as ReplyTimeName)}>
+                        <SelectTrigger
+                            size="sm"
+                            className="ml-auto h-7 w-[130px] rounded-lg border-[#E2E8F0] bg-white pl-2.5 text-xs text-[#64748B]"
+                            aria-label="Select reply time segment"
+                        >
+                            <SelectValue placeholder="Select segment" />
+                        </SelectTrigger>
+                        <SelectContent align="end" className="rounded-xl">
+                            {REPLY_TIME_DATA.map(({ name }) => (
+                                <SelectItem key={name} value={name} className="rounded-lg [&_span]:flex">
+                                    <div className="flex items-center gap-2 text-xs">
+                                        <span
+                                            className="flex h-3 w-3 shrink-0 rounded-[2px]"
+                                            style={{ backgroundColor: `var(--color-${name})` }}
+                                        />
+                                        {name}
+                                    </div>
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col items-center justify-center gap-8 p-6 pt-4 xl:p-8 xl:pt-4 2xl:flex-row 2xl:justify-between">
+                <ChartContainer
+                    id={chartId}
+                    config={replyTimeInteractiveChartConfig}
+                    className="mx-auto aspect-square w-full max-w-[300px]"
+                >
+                    <PieChart>
+                        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel formatter={(value) => `${value}%`} />} />
+                        <Pie
+                            data={REPLY_TIME_DATA}
+                            dataKey="value"
+                            nameKey="name"
+                            innerRadius={58}
+                            strokeWidth={5}
+                            shape={renderPieShape}
+                        >
+                            {REPLY_TIME_DATA.map((entry) => (
+                                <Cell key={entry.name} fill={entry.fill} />
+                            ))}
+                            <Label
+                                content={({ viewBox }) => {
+                                    if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
+                                        return (
+                                            <text
+                                                x={viewBox.cx}
+                                                y={viewBox.cy}
+                                                textAnchor="middle"
+                                                dominantBaseline="middle"
+                                            >
+                                                <tspan
+                                                    x={viewBox.cx}
+                                                    y={viewBox.cy}
+                                                    className="fill-foreground text-3xl font-bold"
+                                                >
+                                                    {activeItem.value}%
+                                                </tspan>
+                                                <tspan
+                                                    x={viewBox.cx}
+                                                    y={(viewBox.cy || 0) + 24}
+                                                    className="fill-muted-foreground"
+                                                >
+                                                    {activeItem.name}
+                                                </tspan>
+                                            </text>
+                                        );
+                                    }
+
+                                    return null;
+                                }}
+                            />
+                        </Pie>
+                    </PieChart>
+                </ChartContainer>
+            </CardContent>
+        </Card>
+    );
+}
+
+export default function Dashboard() {
+    const [dateRange, setDateRange] = React.useState<(typeof DATE_RANGE_OPTIONS)[number]['value']>('dec-1-7');
+
+    return (
+        <>
+            <MigrationBanner />
+
+            <div className="space-y-6 xl:space-y-8">
+                <SectionFrame>
+                    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4">
+                        {STAT_CARDS.map((card, index) => (
+                            <div key={card.label} className={cn(index > 0 && 'border-t border-[#E2E8F0] md:border-t-0', index % 2 === 1 && 'md:border-l md:border-[#E2E8F0] xl:border-l', index >= 2 && 'xl:border-l xl:border-t-0')}>
+                                <StatCard {...card} />
+                            </div>
+                        ))}
+                    </div>
+                </SectionFrame>
+
+                <div className="grid grid-cols-1 gap-6 xl:grid-cols-3 xl:gap-0">
+                    <SectionFrame className="xl:col-span-2 xl:rounded-r-none xl:border-r-0">
+                        <CardHeader className="px-6 pt-6 xl:px-8 xl:pt-8">
+                            <div className="flex items-center justify-between gap-4">
+                                <div>
+                                    <CardTitle className="font-body text-base font-medium text-[#0F172A]">Average Tickets Created</CardTitle>
+                                    <CardDescription className="mt-1 text-sm text-[#94A3B8]">Dec 1 - 7</CardDescription>
+                                </div>
+                                <Select value={dateRange} onValueChange={(value) => value && setDateRange(value as (typeof DATE_RANGE_OPTIONS)[number]['value'])}>
+                                    <SelectTrigger
+                                        size="sm"
+                                        className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B]"
+                                        aria-label="Select ticket date range"
+                                    >
+                                        <SelectValue placeholder="Select date range" />
+                                    </SelectTrigger>
+                                    <SelectContent align="end" className="rounded-xl">
+                                        {DATE_RANGE_OPTIONS.map(({ value, label }) => (
+                                            <SelectItem key={value} value={value} className="rounded-lg text-xs">
+                                                {label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </CardHeader>
+                        <CardContent className="px-6 pb-6 xl:px-8 xl:pb-8">
+                            <ChartContainer config={ticketChartConfig} className="h-[360px] min-h-0 w-full !aspect-auto">
+                                <BarChart accessibilityLayer data={BAR_CHART_DATA} margin={{ top: 16, right: 8, left: 0, bottom: 8 }}>
+                                    <CartesianGrid vertical={false} strokeDasharray="3 5" />
+                                    <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={10} />
+                                    <YAxis tickLine={false} axisLine={false} tickMargin={12} domain={[0, 5000]} ticks={[0, 1000, 2000, 3000, 4000, 5000]} />
+                                    <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+                                    <ChartLegend content={<ChartLegendContent />} />
+                                    <Bar dataKey="solved" stackId="a" radius={[0, 0, 4, 4]} maxBarSize={32}>
+                                        {BAR_CHART_DATA.map((item) => (
+                                            <Cell key={`solved-${item.day}`} fill="var(--color-solved)" fillOpacity={item.highlighted ? 1 : 0.92} />
+                                        ))}
+                                    </Bar>
+                                    <Bar dataKey="created" stackId="a" radius={[4, 4, 0, 0]} maxBarSize={32}>
+                                        {BAR_CHART_DATA.map((item) => (
+                                            <Cell key={`created-${item.day}`} fill={item.highlighted ? '#C4A5F3' : 'var(--color-created)'} fillOpacity={item.highlighted ? 1 : 0.9} />
+                                        ))}
+                                    </Bar>
+                                </BarChart>
+                            </ChartContainer>
+                        </CardContent>
+                        <TicketChartFooter />
+                    </SectionFrame>
+
+                    <SectionFrame className="xl:rounded-l-none">
+                        <ReplyTimeInteractiveChart />
+                    </SectionFrame>
+                </div>
+
+                <div className="grid grid-cols-1 gap-6 xl:grid-cols-2 xl:gap-0">
+                    <SectionFrame className="xl:rounded-r-none xl:border-r-0">
+                        <CardHeader className="px-6 pt-6 pb-0 xl:px-8 xl:pt-8">
+                            <CardTitle className="font-body text-base font-medium text-[#0F172A]">Ticket by Channels</CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex flex-col items-center p-6 xl:p-8">
+                            <div className="relative mb-8 h-40 w-72 max-w-full">
+                                <ChartContainer config={channelChartConfig} className="h-full w-full !aspect-auto">
+                                    <PieChart>
+                                        <ChartTooltip content={<ChartTooltipContent hideLabel formatter={(value) => value?.toLocaleString?.() ?? String(value)} />} />
+                                        <Pie data={CHANNEL_DATA} dataKey="value" nameKey="name" startAngle={180} endAngle={0} innerRadius={72} outerRadius={96} cx="50%" cy="100%" stroke="transparent" paddingAngle={2}>
+                                            {CHANNEL_DATA.map((entry) => (
+                                                <Cell key={entry.name} fill={entry.fill} />
+                                            ))}
+                                        </Pie>
+                                    </PieChart>
+                                </ChartContainer>
+
+                                <div className="absolute bottom-0 left-1/2 w-full -translate-x-1/2 text-center">
+                                    <p className="text-[11px] text-[#94A3B8]">Total Active ticket</p>
+                                    <p className="font-display text-[30px] font-medium tracking-tight text-[#0F172A]">3002</p>
+                                </div>
+                            </div>
+
+                            <div className="flex flex-wrap justify-center gap-x-6 gap-y-3 text-xs text-[#64748B]">
+                                {CHANNEL_DATA.map(({ fill, name }) => (
+                                    <div key={name} className="flex items-center gap-2">
+                                        <div className="h-2 w-2 rounded-sm" style={{ backgroundColor: fill }}></div>
+                                        {name}
+                                    </div>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </SectionFrame>
+
+                    <SectionFrame className="xl:rounded-l-none">
+                        <CardHeader className="px-6 pt-6 pb-0 xl:px-8 xl:pt-8">
+                            <CardTitle className="font-body text-base font-medium text-[#0F172A]">Customer Satisfaction</CardTitle>
+                        </CardHeader>
+                        <CardContent className="p-6 xl:p-8">
+                            <div className="grid gap-8 lg:grid-cols-2 lg:gap-6">
+                                <div className="flex items-center lg:pr-8">
+                                    <div className="w-full">
+                                        <p className="mb-2 text-sm text-[#64748B]">Responses Received</p>
+                                        <p className="font-display text-[30px] font-medium tracking-tight text-[#0F172A]">156 Customers</p>
+                                    </div>
+                                    <Separator orientation="vertical" className="ml-8 hidden bg-[#E2E8F0] lg:block" />
+                                </div>
+
+                                <div className="space-y-6">
+                                    {SATISFACTION_ROWS.map(({ icon, label, percent, helper, fill, tone, iconTone }) => (
+                                        <div key={label}>
+                                            <div className="mb-2 flex items-center gap-3">
+                                                <div className={cn('flex h-11 w-11 items-center justify-center rounded-full text-xl', iconTone)}>
+                                                    <span>{icon}</span>
+                                                </div>
+                                                <div>
+                                                    <p className="text-xs text-[#64748B]">{label}</p>
+                                                    <p className="mt-0.5 text-xl font-semibold leading-none text-[#0F172A]">{percent}</p>
+                                                </div>
+                                            </div>
+
+                                            <div className="flex items-center gap-3">
+                                                <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[#E2E8F0]">
+                                                    <div className={cn('h-full rounded-full', tone)} style={{ width: fill }}></div>
+                                                </div>
+                                                <span className="text-[10px] font-medium text-[#94A3B8]">{helper}</span>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        </CardContent>
+                    </SectionFrame>
+                </div>
+            </div>
+        </>
+    );
+}
+
+Dashboard.layout = (page: ReactElement) => (
+    <DashboardLayout title="Dashboard" activeNav="dashboard" contentClassName="w-full">
+        {page}
+    </DashboardLayout>
+);
+
+type DashboardPageComponent = typeof Dashboard & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(Dashboard as DashboardPageComponent).layout = Dashboard.layout;

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -439,14 +439,12 @@ export default function Dashboard() {
     );
 }
 
-Dashboard.layout = (page: ReactElement) => (
-    <DashboardLayout title="Dashboard" activeNav="dashboard" contentClassName="w-full">
-        {page}
-    </DashboardLayout>
-);
-
 type DashboardPageComponent = typeof Dashboard & {
     layout?: (page: ReactElement) => ReactNode;
 };
 
-(Dashboard as DashboardPageComponent).layout = Dashboard.layout;
+(Dashboard as DashboardPageComponent).layout = (page: ReactElement) => (
+    <DashboardLayout title="Dashboard" activeNav="dashboard" contentClassName="w-full">
+        {page}
+    </DashboardLayout>
+);

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -63,22 +63,50 @@ type BarChartDatum = {
     highlighted?: boolean;
 };
 
+const DATE_RANGE_OPTIONS = [
+    { value: 'dec-1-7', label: 'Dec 1 - 7' },
+    { value: 'dec-8-14', label: 'Dec 8 - 14' },
+    { value: 'dec-15-21', label: 'Dec 15 - 21' },
+] as const;
+
+type DateRangeValue = (typeof DATE_RANGE_OPTIONS)[number]['value'];
+
 const STAT_CARDS: StatCardItem[] = [
     { label: 'Created Tickets', value: '24,208', trend: '-5%', positive: false },
-    { label: 'Unsolved Tickets', value: '4,564', trend: '+2%', positive: true },
+    { label: 'Unsolved Tickets', value: '4,564', trend: '+2%', positive: false },
     { label: 'Solved Tickets', value: '18,208', trend: '+8%', positive: true },
-    { label: 'Average First Time Reply', value: '12:01', suffix: 'min', trend: '+8', positive: true },
+    { label: 'Average First Time Reply', value: '12:01', suffix: 'min', trend: '+8 min', positive: false },
 ];
 
-const BAR_CHART_DATA: BarChartDatum[] = [
-    { day: 'Dec 1', created: 4120, solved: 3100 },
-    { day: 'Dec 2', created: 3450, solved: 2890 },
-    { day: 'Dec 3', created: 3890, solved: 2950 },
-    { day: 'Dec 4', created: 4300, solved: 3800, highlighted: true },
-    { day: 'Dec 5', created: 3650, solved: 2400 },
-    { day: 'Dec 6', created: 3520, solved: 2860 },
-    { day: 'Dec 7', created: 3780, solved: 3010 },
-];
+const BAR_CHART_DATA: Record<DateRangeValue, BarChartDatum[]> = {
+    'dec-1-7': [
+        { day: 'Dec 1', created: 4120, solved: 3100 },
+        { day: 'Dec 2', created: 3450, solved: 2890 },
+        { day: 'Dec 3', created: 3890, solved: 2950 },
+        { day: 'Dec 4', created: 4300, solved: 3800, highlighted: true },
+        { day: 'Dec 5', created: 3650, solved: 2400 },
+        { day: 'Dec 6', created: 3520, solved: 2860 },
+        { day: 'Dec 7', created: 3780, solved: 3010 },
+    ],
+    'dec-8-14': [
+        { day: 'Dec 8', created: 3840, solved: 3180 },
+        { day: 'Dec 9', created: 4020, solved: 3370 },
+        { day: 'Dec 10', created: 4210, solved: 3620 },
+        { day: 'Dec 11', created: 3960, solved: 3510 },
+        { day: 'Dec 12', created: 4380, solved: 3890, highlighted: true },
+        { day: 'Dec 13', created: 3670, solved: 3040 },
+        { day: 'Dec 14', created: 3540, solved: 2980 },
+    ],
+    'dec-15-21': [
+        { day: 'Dec 15', created: 3310, solved: 2840 },
+        { day: 'Dec 16', created: 3750, solved: 3290 },
+        { day: 'Dec 17', created: 3920, solved: 3460 },
+        { day: 'Dec 18', created: 4480, solved: 4020, highlighted: true },
+        { day: 'Dec 19', created: 4160, solved: 3710 },
+        { day: 'Dec 20', created: 3580, solved: 3120 },
+        { day: 'Dec 21', created: 3420, solved: 3060 },
+    ],
+};
 
 const REPLY_TIME_DATA = [
     { name: '0-1 Hours', value: 81, fill: '#22C55E' },
@@ -109,12 +137,6 @@ const ticketChartConfig = {
     solved: { label: 'Avg. Ticket Solved', color: '#5B619D' },
 } satisfies ChartConfig;
 
-const DATE_RANGE_OPTIONS = [
-    { value: 'dec-1-7', label: 'Dec 1 - 7' },
-    { value: 'dec-8-14', label: 'Dec 8 - 14' },
-    { value: 'dec-15-21', label: 'Dec 15 - 21' },
-] as const;
-
 const channelChartConfig = Object.fromEntries(
     CHANNEL_DATA.map(({ name, fill }) => [name, { label: name, color: fill }]),
 ) satisfies ChartConfig;
@@ -128,12 +150,23 @@ const replyTimeInteractiveChartConfig = {
     ),
 } satisfies ChartConfig;
 
-function getStatCardBorderClass(index: number) {
+function getStatCardBorderClass(index: number): string {
     return cn(
         index > 0 && 'border-t border-[#E2E8F0] md:border-t-0',
         index % 2 === 1 && 'md:border-l md:border-[#E2E8F0] xl:border-l',
         index >= 2 && 'xl:border-l xl:border-t-0',
     );
+}
+
+function getDateRangeLabel(dateRange: DateRangeValue): string {
+    return (
+        DATE_RANGE_OPTIONS.find((option) => option.value === dateRange)?.label ??
+        DATE_RANGE_OPTIONS[0].label
+    );
+}
+
+function getBarChartDataForRange(dateRange: DateRangeValue): BarChartDatum[] {
+    return BAR_CHART_DATA[dateRange];
 }
 
 function StatCard({ label, value, suffix, trend, positive }: StatCardItem) {
@@ -162,15 +195,15 @@ function SectionFrame({ children, className }: { children: ReactNode; className?
     return <Card className={cn('overflow-hidden rounded-[18px] border-[#E2E8F0] py-0 shadow-none ring-0', className)}>{children}</Card>;
 }
 
-function TicketChartFooter() {
+function TicketChartFooter({ dateRangeLabel }: { dateRangeLabel: string }) {
     return (
         <CardFooter className="flex-col items-start gap-2 border-t border-[#E2E8F0] px-6 py-4 text-sm xl:px-8">
             <div className="flex items-center gap-2 leading-none font-medium text-[#0F172A]">
-                Ticket creation remains ahead of resolutions this week
+                Ticket creation remains ahead of resolutions for this range
                 <HugeiconsIcon icon={ArrowUp01Icon} size={14} />
             </div>
             <div className="leading-none text-[#94A3B8]">
-                Showing created versus solved tickets for Dec 1 - 7
+                Showing created versus solved tickets for {dateRangeLabel}
             </div>
         </CardFooter>
     );
@@ -295,7 +328,9 @@ function ReplyTimeInteractiveChart() {
 }
 
 export default function Dashboard() {
-    const [dateRange, setDateRange] = React.useState<(typeof DATE_RANGE_OPTIONS)[number]['value']>('dec-1-7');
+    const [dateRange, setDateRange] = React.useState<DateRangeValue>('dec-1-7');
+    const dateRangeLabel = getDateRangeLabel(dateRange);
+    const ticketChartData = getBarChartDataForRange(dateRange);
 
     return (
         <>
@@ -328,9 +363,9 @@ export default function Dashboard() {
                             <div className="flex items-center justify-between gap-4">
                                 <div>
                                     <CardTitle className="font-body text-base font-medium text-[#0F172A]">Average Tickets Created</CardTitle>
-                                    <CardDescription className="mt-1 text-sm text-[#94A3B8]">Dec 1 - 7</CardDescription>
+                                    <CardDescription className="mt-1 text-sm text-[#94A3B8]">{dateRangeLabel}</CardDescription>
                                 </div>
-                                <Select value={dateRange} onValueChange={(value) => value && setDateRange(value as (typeof DATE_RANGE_OPTIONS)[number]['value'])}>
+                                <Select value={dateRange} onValueChange={(value) => value && setDateRange(value as DateRangeValue)}>
                                     <SelectTrigger
                                         size="sm"
                                         className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B]"
@@ -349,27 +384,27 @@ export default function Dashboard() {
                             </div>
                         </CardHeader>
                         <CardContent className="px-6 pb-6 xl:px-8 xl:pb-8">
-                            <ChartContainer config={ticketChartConfig} className="h-[360px] min-h-0 w-full !aspect-auto">
-                                <BarChart accessibilityLayer data={BAR_CHART_DATA} margin={{ top: 16, right: 8, left: 0, bottom: 8 }}>
+                            <ChartContainer config={ticketChartConfig} className="h-[360px] min-h-0 w-full aspect-auto!">
+                                <BarChart accessibilityLayer data={ticketChartData} margin={{ top: 16, right: 8, left: 0, bottom: 8 }}>
                                     <CartesianGrid vertical={false} strokeDasharray="3 5" />
                                     <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={10} />
                                     <YAxis tickLine={false} axisLine={false} tickMargin={12} domain={[0, 5000]} ticks={[0, 1000, 2000, 3000, 4000, 5000]} />
                                     <ChartTooltip content={<ChartTooltipContent hideLabel />} />
                                     <ChartLegend content={<ChartLegendContent />} />
                                     <Bar dataKey="solved" stackId="a" radius={[0, 0, 4, 4]} maxBarSize={32}>
-                                        {BAR_CHART_DATA.map((item) => (
+                                        {ticketChartData.map((item) => (
                                             <Cell key={`solved-${item.day}`} fill="var(--color-solved)" fillOpacity={item.highlighted ? 1 : 0.92} />
                                         ))}
                                     </Bar>
                                     <Bar dataKey="created" stackId="a" radius={[4, 4, 0, 0]} maxBarSize={32}>
-                                        {BAR_CHART_DATA.map((item) => (
+                                        {ticketChartData.map((item) => (
                                             <Cell key={`created-${item.day}`} fill={item.highlighted ? '#C4A5F3' : 'var(--color-created)'} fillOpacity={item.highlighted ? 1 : 0.9} />
                                         ))}
                                     </Bar>
                                 </BarChart>
                             </ChartContainer>
                         </CardContent>
-                        <TicketChartFooter />
+                        <TicketChartFooter dateRangeLabel={dateRangeLabel} />
                     </SectionFrame>
 
                     <SectionFrame className="xl:rounded-l-none">
@@ -384,7 +419,7 @@ export default function Dashboard() {
                         </CardHeader>
                         <CardContent className="flex flex-col items-center p-6 xl:p-8">
                             <div className="relative mb-8 h-40 w-72 max-w-full">
-                                <ChartContainer config={channelChartConfig} className="h-full w-full !aspect-auto">
+                                <ChartContainer config={channelChartConfig} className="h-full w-full aspect-auto!">
                                     <PieChart>
                                         <ChartTooltip content={<ChartTooltipContent hideLabel formatter={(value) => value?.toLocaleString?.() ?? String(value)} />} />
                                         <Pie data={CHANNEL_DATA} dataKey="value" nameKey="name" startAngle={180} endAngle={0} innerRadius={72} outerRadius={96} cx="50%" cy="100%" stroke="transparent" paddingAngle={2}>

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -1,12 +1,17 @@
 import { Link, router } from '@inertiajs/react';
 
+import { MigrationBanner } from '@/components/auth/MigrationBanner';
+
 export default function Dashboard() {
     return (
-        <div className="flex min-h-screen items-center justify-center bg-gray-50">
-            <div className="text-center">
-                <h1 className="text-3xl font-bold text-gray-900">osTicket Staff Control Panel</h1>
-                <p className="mt-2 text-gray-500">Welcome back.</p>
-                <div className="mt-6 flex items-center justify-center gap-3">
+        <div className="min-h-screen bg-gray-50 px-4 py-10">
+            <div className="mx-auto max-w-4xl space-y-6">
+                <MigrationBanner />
+
+                <div className="rounded-2xl bg-white p-10 text-center shadow-sm">
+                    <h1 className="text-3xl font-bold text-gray-900">osTicket Staff Control Panel</h1>
+                    <p className="mt-2 text-gray-500">Welcome back.</p>
+                    <div className="mt-6 flex items-center justify-center gap-3">
                     <Link
                         href="/scp/account/security"
                         className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-white"
@@ -20,6 +25,7 @@ export default function Dashboard() {
                     >
                         Sign out
                     </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\Account\SecurityController;
+use App\Http\Controllers\Account\MigrationBannerController;
+use App\Http\Controllers\Account\TwoFactorWizardController;
 use App\Http\Controllers\Account\TwoFactorSecurityController;
 use App\Http\Controllers\Auth\ConfirmPasswordController;
 use App\Http\Controllers\Auth\LoginController;
@@ -44,8 +46,10 @@ Route::prefix('scp')->name('scp.')->group(function () {
         Route::get('/account/security', [SecurityController::class, 'show'])->name('account.security');
         Route::get('/account/security/confirm-password', [ConfirmPasswordController::class, 'show'])->name('password.confirm');
         Route::post('/account/security/confirm-password', [ConfirmPasswordController::class, 'store'])->name('password.confirm.store');
+        Route::post('/account/migration-banner/dismiss', [MigrationBannerController::class, 'dismiss'])->name('account.migration-banner.dismiss');
 
         Route::middleware(RequirePassword::using('scp.password.confirm'))->group(function () {
+            Route::get('/account/security/two-factor', [TwoFactorWizardController::class, 'show'])->name('account.security.two-factor.show');
             Route::post('/account/security/two-factor/enable', [TwoFactorSecurityController::class, 'enable'])->name('account.security.two-factor.enable');
             Route::post('/account/security/two-factor/confirm', [TwoFactorSecurityController::class, 'confirm'])->name('account.security.two-factor.confirm');
             Route::get('/account/security/two-factor/recovery-codes', [TwoFactorSecurityController::class, 'recoveryCodes'])->name('account.security.two-factor.recovery-codes');

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,7 +53,6 @@ Route::prefix('scp')->name('scp.')->group(function () {
             Route::post('/account/security/two-factor/enable', [TwoFactorSecurityController::class, 'enable'])->name('account.security.two-factor.enable');
             Route::post('/account/security/two-factor/confirm', [TwoFactorSecurityController::class, 'confirm'])->name('account.security.two-factor.confirm');
             Route::get('/account/security/two-factor/recovery-codes', [TwoFactorSecurityController::class, 'recoveryCodes'])->name('account.security.two-factor.recovery-codes');
-            Route::get('/account/security/two-factor/qr-code', [TwoFactorSecurityController::class, 'qrCode'])->name('account.security.two-factor.qr-code');
             Route::post('/account/security/two-factor/regenerate-codes', [TwoFactorSecurityController::class, 'regenerateRecoveryCodes'])->name('account.security.two-factor.regenerate-codes');
             Route::delete('/account/security/two-factor', [TwoFactorSecurityController::class, 'disable'])->name('account.security.two-factor.disable');
         });

--- a/tests/Feature/Auth/FortifyMigrationTest.php
+++ b/tests/Feature/Auth/FortifyMigrationTest.php
@@ -264,33 +264,6 @@ test('recovery code is not consumed when challenge expires during verification',
     expect($staff->fresh()->recoveryCodes())->toContain($recoveryCode);
 });
 
-test('qr code endpoint requires a confirmed password and hides confirmed setup material', function () {
-    $staff = createLegacyStaff();
-    $service = app(StaffTwoFactorService::class);
-    $service->enable($staff);
-
-    $redirectResponse = $this->actingAs($staff->fresh(), 'staff')
-        ->get('/scp/account/security/two-factor/qr-code');
-
-    $redirectResponse->assertRedirect('/scp/account/security/confirm-password');
-
-    $pendingResponse = $this->actingAs($staff->fresh(), 'staff')
-        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
-        ->get('/scp/account/security/two-factor/qr-code');
-
-    $pendingResponse->assertOk();
-    $pendingResponse->assertJsonStructure(['svg', 'url']);
-
-    $service->confirm($staff->fresh(), app(Google2FA::class)->getCurrentOtp((string) $staff->fresh()->two_factor_secret));
-
-    $confirmedResponse = $this->actingAs($staff->fresh(), 'staff')
-        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
-        ->get('/scp/account/security/two-factor/qr-code');
-
-    $confirmedResponse->assertOk();
-    expect($confirmedResponse->json())->toBe([]);
-});
-
 test('non-enrolled staff continue to the email otp flow', function () {
     Mail::fake();
 

--- a/tests/Feature/Auth/FortifyMigrationTest.php
+++ b/tests/Feature/Auth/FortifyMigrationTest.php
@@ -108,7 +108,7 @@ test('security page only exposes setup secret while two-factor confirmation is p
         ->and($pendingTwoFactor['pending'])->toBeTrue()
         ->and($pendingTwoFactor['setupKey'])->toBeString()->not->toBe('')
         ->and($pendingTwoFactor['qrCodeSvg'])->toBeString()->not->toBe('')
-        ->and($pendingTwoFactor['qrCodeUrl'])->toBeString()->not->toBe('');
+        ->and($pendingTwoFactor)->not->toHaveKey('qrCodeUrl');
 
     $service->confirm($staff->fresh(), app(Google2FA::class)->getCurrentOtp((string) $staff->fresh()->two_factor_secret));
 
@@ -121,7 +121,7 @@ test('security page only exposes setup secret while two-factor confirmation is p
     $confirmedResponse->assertJsonPath('props.twoFactor.enabled', true);
     $confirmedResponse->assertJsonPath('props.twoFactor.setupKey', null);
     $confirmedResponse->assertJsonPath('props.twoFactor.qrCodeSvg', null);
-    $confirmedResponse->assertJsonPath('props.twoFactor.qrCodeUrl', null);
+    expect(Arr::get($confirmedResponse->json(), 'props.twoFactor'))->not->toHaveKey('qrCodeUrl');
 });
 
 test('login routes totp-enrolled staff to the app challenge', function () {

--- a/tests/Feature/Auth/FortifyMigrationTest.php
+++ b/tests/Feature/Auth/FortifyMigrationTest.php
@@ -90,6 +90,38 @@ test('confirming two-factor marks the staff member as migrated', function () {
     $this->travelBack();
 });
 
+test('confirming two-factor clears the cached migration banner result', function () {
+    $this->travelTo(now());
+
+    $staff = createLegacyStaff();
+    $cacheKey = "auth.migration_banner.{$staff->staff_id}";
+
+    $this->actingAs($staff, 'staff')
+        ->get('/scp')
+        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', false))
+        ->assertSessionHas($cacheKey, fn (array $cache): bool => $cache['visible'] === false && is_int($cache['cached_at']));
+
+    $service = app(StaffTwoFactorService::class);
+    $service->enable($staff);
+
+    $otp = app(Google2FA::class)->getCurrentOtp((string) $staff->fresh()->two_factor_secret);
+
+    $this->actingAs($staff->fresh(), 'staff')
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->post('/scp/account/security/two-factor/confirm', [
+            'code' => $otp,
+        ])
+        ->assertRedirect('/scp/account/security')
+        ->assertSessionMissing($cacheKey);
+
+    $this->actingAs($staff->fresh(), 'staff')
+        ->get('/scp')
+        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', false))
+        ->assertSessionHas($cacheKey, fn (array $cache): bool => $cache['visible'] === false && is_int($cache['cached_at']));
+
+    $this->travelBack();
+});
+
 test('security page only exposes setup secret while two-factor confirmation is pending', function () {
     $staff = createLegacyStaff();
     $service = app(StaffTwoFactorService::class);

--- a/tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php
+++ b/tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php
@@ -45,6 +45,7 @@ test('staff auth migrations migration backfills missing optional columns on an e
     });
 
     loadMigration('2026_04_19_000200_create_staff_auth_migrations_table.php')->up();
+    loadMigration('2026_04_22_140000_add_dismissed_migration_banner_at_to_staff_auth_migrations.php')->up();
 
     $schema = Schema::connection('osticket2');
 
@@ -54,6 +55,7 @@ test('staff auth migrations migration backfills missing optional columns on an e
         'migrated_at',
         'must_upgrade_after',
         'upgrade_method',
+        'dismissed_migration_banner_at',
         'created_at',
         'updated_at',
     ]))->toBeTrue()

--- a/tests/Feature/Auth/LegacyTwoFactorMigrationServiceTest.php
+++ b/tests/Feature/Auth/LegacyTwoFactorMigrationServiceTest.php
@@ -1,0 +1,231 @@
+<?php
+
+use App\Models\Staff;
+use App\Models\StaffAuthMigration;
+use App\Models\StaffTwoFactorCredential;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    $schema = Schema::connection('legacy');
+
+    if (! $schema->hasTable('config')) {
+        $schema->create('config', function (Blueprint $table): void {
+            $table->id();
+            $table->string('namespace');
+            $table->string('key');
+            $table->text('value');
+            $table->timestamp('updated')->nullable();
+        });
+    }
+
+    DB::connection('legacy')->table('config')->delete();
+});
+
+function createLegacyMigrationStaff(array $attributes = []): Staff
+{
+    $staffId = $attributes['staff_id'] ?? random_int(1000, 9999);
+
+    DB::connection('legacy')->table('staff')->insert(array_merge([
+        'staff_id' => $staffId,
+        'dept_id' => 1,
+        'username' => "migration{$staffId}",
+        'firstname' => 'Migration',
+        'lastname' => 'Tester',
+        'email' => "migration{$staffId}@example.com",
+        'passwd' => bcrypt('password'),
+        'isactive' => 1,
+        'isadmin' => 0,
+        'created' => now(),
+    ], $attributes));
+
+    return Staff::on('legacy')->findOrFail($staffId);
+}
+
+function insertLegacyTwoFactorConfig(Staff $staff, string $backend, array $config, int $verified): void
+{
+    DB::connection('legacy')->table('config')->insert([
+        'namespace' => "staff.{$staff->staff_id}",
+        'key' => $backend,
+        'value' => json_encode([
+            'config' => $config,
+            'verified' => $verified,
+        ]),
+        'updated' => now(),
+    ]);
+}
+
+function loginLegacyMigrationStaff(Staff $staff, string $redirect = '/scp/2fa'): void
+{
+    Mail::fake();
+
+    test()->post('/scp/login', [
+        'username' => $staff->username,
+        'password' => 'password',
+    ])->assertRedirect($redirect);
+}
+
+test('verified legacy totp plugin imports app credentials and marks totp migration', function () {
+    $staff = createLegacyMigrationStaff();
+
+    insertLegacyTwoFactorConfig($staff, 'auth.agent', [
+        'key' => 'JBSWY3DPEHPK3PXP',
+        'external2fa' => true,
+    ], 1700000000);
+
+    loginLegacyMigrationStaff($staff, '/scp/2fa-app');
+
+    $credential = StaffTwoFactorCredential::query()->where('staff_id', $staff->staff_id)->first();
+    $migration = StaffAuthMigration::query()->where('staff_id', $staff->staff_id)->first();
+
+    expect($credential)->not->toBeNull()
+        ->and($credential?->two_factor_secret)->toBe('JBSWY3DPEHPK3PXP')
+        ->and($credential?->two_factor_recovery_codes)->toHaveCount(8)
+        ->and($credential?->two_factor_confirmed_at)->not->toBeNull()
+        ->and($migration)->not->toBeNull()
+        ->and($migration?->migrated_at)->not->toBeNull()
+        ->and($migration?->upgrade_method)->toBe('totp');
+});
+
+test('unverified legacy totp plugin does not migrate anything', function () {
+    $staff = createLegacyMigrationStaff();
+
+    insertLegacyTwoFactorConfig($staff, 'auth.agent', [
+        'key' => 'JBSWY3DPEHPK3PXP',
+        'external2fa' => true,
+    ], 0);
+
+    loginLegacyMigrationStaff($staff);
+
+    expect(StaffTwoFactorCredential::query()->where('staff_id', $staff->staff_id)->exists())->toBeFalse()
+        ->and(StaffAuthMigration::query()->where('staff_id', $staff->staff_id)->exists())->toBeFalse();
+});
+
+test('verified legacy email otp dismisses the migration banner without creating app credentials', function () {
+    $staff = createLegacyMigrationStaff();
+
+    insertLegacyTwoFactorConfig($staff, 'email', [
+        'email' => 'a@b.com',
+    ], 1700000000);
+
+    loginLegacyMigrationStaff($staff);
+
+    $migration = StaffAuthMigration::query()->where('staff_id', $staff->staff_id)->first();
+
+    expect(StaffTwoFactorCredential::query()->where('staff_id', $staff->staff_id)->exists())->toBeFalse()
+        ->and($migration)->not->toBeNull()
+        ->and($migration?->migrated_at)->not->toBeNull()
+        ->and($migration?->dismissed_migration_banner_at)->not->toBeNull()
+        ->and($migration?->upgrade_method)->toBeNull();
+});
+
+test('missing legacy two-factor config does not migrate anything', function () {
+    $staff = createLegacyMigrationStaff();
+
+    loginLegacyMigrationStaff($staff);
+
+    expect(StaffTwoFactorCredential::query()->where('staff_id', $staff->staff_id)->exists())->toBeFalse()
+        ->and(StaffAuthMigration::query()->where('staff_id', $staff->staff_id)->exists())->toBeFalse();
+});
+
+test('already migrated totp credentials are not overwritten', function () {
+    $this->travelTo(now());
+
+    $staff = createLegacyMigrationStaff();
+    $staff->upsertTwoFactorCredential([
+        'two_factor_secret' => 'EXISTINGSECRET',
+        'two_factor_recovery_codes' => ['existing-code'],
+        'two_factor_confirmed_at' => now(),
+    ]);
+    $originalConfirmedAt = StaffTwoFactorCredential::query()
+        ->where('staff_id', $staff->staff_id)
+        ->firstOrFail()
+        ->two_factor_confirmed_at;
+
+    insertLegacyTwoFactorConfig($staff, 'auth.agent', [
+        'key' => 'JBSWY3DPEHPK3PXP',
+        'external2fa' => true,
+    ], 1700000000);
+
+    $this->travel(1)->day();
+
+    loginLegacyMigrationStaff($staff, '/scp/2fa-app');
+
+    $credential = StaffTwoFactorCredential::query()->where('staff_id', $staff->staff_id)->first();
+
+    expect($credential?->two_factor_secret)->toBe('EXISTINGSECRET')
+        ->and($credential?->two_factor_confirmed_at?->equalTo($originalConfirmedAt))->toBeTrue();
+
+    $this->travelBack();
+});
+
+test('disabled dual legacy totp and email migration is not reimported or shown as a banner', function () {
+    $staff = createLegacyMigrationStaff();
+
+    $staff->upsertTwoFactorCredential([
+        'two_factor_secret' => null,
+        'two_factor_recovery_codes' => null,
+        'two_factor_confirmed_at' => null,
+    ]);
+    StaffAuthMigration::query()->create([
+        'staff_id' => $staff->staff_id,
+        'migrated_at' => null,
+        'upgrade_method' => null,
+        'dismissed_migration_banner_at' => null,
+    ]);
+    insertLegacyTwoFactorConfig($staff, 'auth.agent', [
+        'key' => 'JBSWY3DPEHPK3PXP',
+        'external2fa' => true,
+    ], 1700000000);
+    insertLegacyTwoFactorConfig($staff, 'email', [
+        'email' => 'a@b.com',
+    ], 1700000000);
+
+    loginLegacyMigrationStaff($staff);
+
+    $migration = StaffAuthMigration::query()->where('staff_id', $staff->staff_id)->first();
+    $credential = StaffTwoFactorCredential::query()->where('staff_id', $staff->staff_id)->first();
+
+    expect($credential)->not->toBeNull()
+        ->and($credential?->two_factor_secret)->toBeNull()
+        ->and($credential?->two_factor_confirmed_at)->toBeNull()
+        ->and($migration?->migrated_at)->toBeNull()
+        ->and($migration?->upgrade_method)->toBeNull()
+        ->and($migration?->dismissed_migration_banner_at)->toBeNull();
+
+    $this->actingAs($staff->fresh(), 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp')
+        ->assertOk()
+        ->assertJsonPath('props.auth.staff.migrationBanner', false);
+});
+
+test('already dismissed email migration is not overwritten', function () {
+    $this->travelTo(now()->setDate(2024, 1, 1)->setTime(0, 0));
+
+    $staff = createLegacyMigrationStaff();
+    $originalTimestamp = now();
+
+    StaffAuthMigration::query()->create([
+        'staff_id' => $staff->staff_id,
+        'migrated_at' => $originalTimestamp,
+        'dismissed_migration_banner_at' => $originalTimestamp,
+    ]);
+    insertLegacyTwoFactorConfig($staff, 'email', [
+        'email' => 'a@b.com',
+    ], 1700000000);
+
+    $this->travel(1)->day();
+
+    loginLegacyMigrationStaff($staff);
+
+    $migration = StaffAuthMigration::query()->where('staff_id', $staff->staff_id)->first();
+
+    expect($migration?->migrated_at?->equalTo($originalTimestamp))->toBeTrue()
+        ->and($migration?->dismissed_migration_banner_at?->equalTo($originalTimestamp))->toBeTrue()
+        ->and($migration?->upgrade_method)->toBeNull();
+
+    $this->travelBack();
+});

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -280,7 +280,7 @@ test('password reset form rejects malformed tokens', function () {
     $response = $this->get('/scp/password/reset/not-a-valid-token');
 
     $response->assertRedirect('/scp/password/forgot');
-    $response->assertSessionHasErrors(['email']);
+    $response->assertSessionHasErrors(['general']);
 });
 
 test('inactive staff cannot reset their password with a valid token', function () {

--- a/tests/Feature/Auth/MigrationBannerTest.php
+++ b/tests/Feature/Auth/MigrationBannerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\Staff;
+use App\Models\StaffAuthMigration;
+
+it('shows the banner for migrated staff who have not dismissed it', function () {
+    $staff = Staff::factory()->create(['isactive' => 1]);
+
+    StaffAuthMigration::create([
+        'staff_id' => $staff->staff_id,
+        'migrated_at' => now()->subDay(),
+        'upgrade_method' => 'auto',
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')->get('/scp');
+
+    $response->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', true));
+});
+
+it('hides the banner once dismissed', function () {
+    $staff = Staff::factory()->create(['isactive' => 1]);
+
+    StaffAuthMigration::create([
+        'staff_id' => $staff->staff_id,
+        'migrated_at' => now()->subDay(),
+        'upgrade_method' => 'auto',
+        'dismissed_migration_banner_at' => now(),
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')->get('/scp');
+
+    $response->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', false));
+});
+
+it('persists dismissal via the controller', function () {
+    $staff = Staff::factory()->create(['isactive' => 1]);
+
+    StaffAuthMigration::create([
+        'staff_id' => $staff->staff_id,
+        'migrated_at' => now()->subDay(),
+        'upgrade_method' => 'auto',
+    ]);
+
+    $this->actingAs($staff, 'staff')
+        ->post('/scp/account/migration-banner/dismiss')
+        ->assertRedirect();
+
+    expect($staff->fresh()->authMigration?->dismissed_migration_banner_at)->not->toBeNull();
+});

--- a/tests/Feature/Auth/MigrationBannerTest.php
+++ b/tests/Feature/Auth/MigrationBannerTest.php
@@ -48,12 +48,32 @@ it('persists dismissal via the controller', function () {
     expect($staff->fresh()->authMigration?->dismissed_migration_banner_at)->not->toBeNull();
 });
 
-it('recomputes the banner after a false session result when migration state changes', function () {
+it('caches a false session result for staff who should not see the banner', function () {
+    $this->travelTo(now());
+
     $staff = Staff::factory()->create(['isactive' => 1]);
+    $cacheKey = "auth.migration_banner.{$staff->staff_id}";
+
+    $response = $this->actingAs($staff, 'staff')
+        ->get('/scp');
+
+    $response
+        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', false))
+        ->assertSessionHas($cacheKey, fn (array $cache): bool => $cache['visible'] === false && is_int($cache['cached_at']));
+
+    $this->travelBack();
+});
+
+it('recomputes a stale false session result when migration state changes', function () {
+    $this->travelTo(now());
+
+    $staff = Staff::factory()->create(['isactive' => 1]);
+    $cacheKey = "auth.migration_banner.{$staff->staff_id}";
 
     $this->actingAs($staff, 'staff')
         ->get('/scp')
-        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', false));
+        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', false))
+        ->assertSessionHas($cacheKey, fn (array $cache): bool => $cache['visible'] === false && is_int($cache['cached_at']));
 
     StaffAuthMigration::create([
         'staff_id' => $staff->staff_id,
@@ -61,7 +81,12 @@ it('recomputes the banner after a false session result when migration state chan
         'upgrade_method' => 'auto',
     ]);
 
+    $this->travel(6)->minutes();
+
     $this->actingAs($staff->fresh(), 'staff')
         ->get('/scp')
-        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', true));
+        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', true))
+        ->assertSessionHas($cacheKey, fn (array $cache): bool => $cache['visible'] === true && is_int($cache['cached_at']));
+
+    $this->travelBack();
 });

--- a/tests/Feature/Auth/MigrationBannerTest.php
+++ b/tests/Feature/Auth/MigrationBannerTest.php
@@ -47,3 +47,21 @@ it('persists dismissal via the controller', function () {
 
     expect($staff->fresh()->authMigration?->dismissed_migration_banner_at)->not->toBeNull();
 });
+
+it('recomputes the banner after a false session result when migration state changes', function () {
+    $staff = Staff::factory()->create(['isactive' => 1]);
+
+    $this->actingAs($staff, 'staff')
+        ->get('/scp')
+        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', false));
+
+    StaffAuthMigration::create([
+        'staff_id' => $staff->staff_id,
+        'migrated_at' => now()->subDay(),
+        'upgrade_method' => 'auto',
+    ]);
+
+    $this->actingAs($staff->fresh(), 'staff')
+        ->get('/scp')
+        ->assertInertia(fn ($page) => $page->where('auth.staff.migrationBanner', true));
+});

--- a/tests/Feature/Auth/TwoFactorWizardTest.php
+++ b/tests/Feature/Auth/TwoFactorWizardTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\Staff;
+use App\Services\StaffTwoFactorService;
+use Illuminate\Support\Facades\Hash;
+use PragmaRX\Google2FA\Google2FA;
+
+it('renders the wizard at step 1 by default', function () {
+    $staff = Staff::factory()->create(['passwd' => Hash::make('hello'), 'isactive' => 1]);
+
+    $this->actingAs($staff, 'staff');
+    $this->withSession(['auth.password_confirmed_at' => now()->timestamp]);
+
+    $response = $this->get('/scp/account/security/two-factor');
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('Account/Security/TwoFactorWizard')
+        ->where('step', 1)
+        ->where('twoFactor.enabled', false)
+        ->where('twoFactor.pending', false)
+    );
+});
+
+it('jumps to step 3 when a secret exists but setup is still pending', function () {
+    $staff = Staff::factory()->create(['passwd' => Hash::make('hello'), 'isactive' => 1]);
+    app(StaffTwoFactorService::class)->enable($staff, true);
+
+    $this->actingAs($staff, 'staff');
+    $this->withSession(['auth.password_confirmed_at' => now()->timestamp]);
+
+    $response = $this->get('/scp/account/security/two-factor?step=3');
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('Account/Security/TwoFactorWizard')
+        ->where('step', 3)
+        ->where('twoFactor.pending', true)
+        ->whereNotNull('twoFactor.qrCodeSvg')
+        ->whereNotNull('twoFactor.setupKey')
+    );
+});
+
+it('exposes flashed recovery codes on the wizard page', function () {
+    $staff = Staff::factory()->create(['passwd' => Hash::make('hello'), 'isactive' => 1]);
+
+    $this->actingAs($staff, 'staff');
+    $this->withSession([
+        'auth.password_confirmed_at' => now()->timestamp,
+        'two_factor_recovery_codes' => ['alpha', 'beta'],
+    ]);
+
+    $response = $this->get('/scp/account/security/two-factor?step=4');
+
+    $response->assertInertia(fn ($page) => $page
+        ->where('step', 4)
+        ->where('twoFactor.recoveryCodes', ['alpha', 'beta'])
+    );
+});
+
+it('returns to the wizard after password confirmation', function () {
+    $staff = Staff::factory()->create([
+        'passwd' => Hash::make('hello'),
+        'isactive' => 1,
+    ]);
+
+    $this->actingAs($staff, 'staff')
+        ->get('/scp/account/security/two-factor?step=1')
+        ->assertRedirect('/scp/account/security/confirm-password');
+
+    $this->actingAs($staff, 'staff')
+        ->post('/scp/account/security/confirm-password', [
+            'password' => 'hello',
+        ])
+        ->assertRedirect('/scp/account/security/two-factor?step=1');
+});
+
+it('redirects wizard enable and confirm actions back into the wizard flow', function () {
+    $this->travelTo(now());
+
+    $staff = Staff::factory()->create([
+        'passwd' => Hash::make('hello'),
+        'isactive' => 1,
+    ]);
+
+    $this->actingAs($staff, 'staff')
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->post('/scp/account/security/two-factor/enable', [
+            'force' => true,
+            'return_to_wizard' => true,
+        ])
+        ->assertRedirect('/scp/account/security/two-factor?step=2');
+
+    $otp = app(Google2FA::class)->getCurrentOtp((string) $staff->fresh()->two_factor_secret);
+
+    $this->actingAs($staff->fresh(), 'staff')
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->post('/scp/account/security/two-factor/confirm', [
+            'code' => $otp,
+            'return_to_wizard' => true,
+        ])
+        ->assertRedirect('/scp/account/security/two-factor?step=4');
+
+    $this->travelBack();
+});

--- a/tests/Feature/Auth/TwoFactorWizardTest.php
+++ b/tests/Feature/Auth/TwoFactorWizardTest.php
@@ -101,3 +101,29 @@ it('redirects wizard enable and confirm actions back into the wizard flow', func
 
     $this->travelBack();
 });
+
+it('clears a dismissed migration banner timestamp when two-factor is disabled', function () {
+    $staff = Staff::factory()->create([
+        'passwd' => Hash::make('hello'),
+        'isactive' => 1,
+    ]);
+
+    app(StaffTwoFactorService::class)->enable($staff, true);
+
+    $staff->authMigration()->create([
+        'migrated_at' => now()->subDay(),
+        'upgrade_method' => 'totp',
+        'dismissed_migration_banner_at' => now(),
+    ]);
+
+    $this->actingAs($staff->fresh(), 'staff')
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->delete('/scp/account/security/two-factor')
+        ->assertRedirect('/scp/account/security');
+
+    $migration = $staff->fresh()->authMigration;
+
+    expect($migration?->migrated_at)->toBeNull()
+        ->and($migration?->upgrade_method)->toBeNull()
+        ->and($migration?->dismissed_migration_banner_at)->toBeNull();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -116,8 +116,15 @@ abstract class TestCase extends BaseTestCase
                 $table->timestamp('migrated_at')->nullable();
                 $table->timestamp('must_upgrade_after')->nullable();
                 $table->string('upgrade_method', 32)->nullable();
+                $table->timestamp('dismissed_migration_banner_at')->nullable();
                 $table->timestamps();
             });
+
+            if (! $osticket2->hasColumn('staff_auth_migrations', 'dismissed_migration_banner_at')) {
+                $osticket2->table('staff_auth_migrations', function (Blueprint $table): void {
+                    $table->timestamp('dismissed_migration_banner_at')->nullable()->after('upgrade_method');
+                });
+            }
 
             foreach ([
                 'staff_auth_migrations',


### PR DESCRIPTION
## Overview
Ship the Phase 2 staff-authentication experience from the migration banner backend contract through the authenticated dashboard shell redesign. This branch adds the migration-banner persistence and wizard-aware backend flow, then layers on the shared dashboard component foundation, the authenticated shell, the security/settings shell, and the analytics-heavy staff landing page.

## Problem
Phase 1 left the staff authentication upgrade in an in-between state: the backend could support migration work, but the signed-in experience still lacked a cohesive authenticated shell, the security flow was visually detached from the dashboard, and the main control panel remained a placeholder instead of an operational staff surface. Without bringing those pieces together, migrated staff would have backend support for stronger auth without a polished path to discover, complete, and manage it.

## Fix
- added the backend support for the Phase 2 migration flow, including the dismissal timestamp schema update, shared Inertia banner state, banner dismissal handling, and wizard-aware two-factor controller behavior
- introduced the reusable UI foundation for the new signed-in shell with shared chart, card, select, input-group, keyboard hint, textarea, and tooltip primitives plus the new Recharts dependency stack
- added `DashboardLayout` and retuned the scoped auth/dashboard theme tokens so authenticated pages share one navigation rail, search surface, support panel, and shell header
- moved the account security index and two-factor wizard into the dashboard shell, expanded the sessions tab into a richer management surface, and preserved the migration banner entry point
- rebuilt the staff dashboard into an analytics-first landing page with metric cards, created-vs-solved ticket charts, reply-time breakdowns, channel distribution, and customer-satisfaction sections
- aligned the lingering malformed reset-token test expectation with the auth-shell error contract already used by the branch

## Commit Summary
- `a3edcc8` feat(auth): add migration banner dismissal schema support
- `f9d13a3` feat(auth): add migration banner and 2fa wizard backend flow
- `c762f70` feat(auth-ui): mount the migration banner on the dashboard shell
- `0a0f667` feat(auth-ui): add the account-security tab shell and 2fa wizard
- `59730b7` test(auth): align malformed reset-token assertion with auth shell errors
- `14416ce` feat(ui): add dashboard chart foundation
- `2e334b5` feat(ui): add dashboard shell control primitives
- `256de24` feat(ui): add dashboard surface primitives
- `5f08714` feat(auth-ui): add the authenticated dashboard shell
- `998f681` feat(auth-ui): move security settings into the dashboard shell
- `767c0d8` feat(auth-ui): redesign the staff dashboard analytics view

## Verification
Branch history includes verification with:
- `vendor/bin/pest tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php`
- `vendor/bin/pest tests/Feature/Auth/MigrationBannerTest.php tests/Feature/Auth/TwoFactorWizardTest.php tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php`
- `vendor/bin/pest tests/Feature/Auth/MigrationBannerTest.php`
- `vendor/bin/pest tests/Feature/Auth/TwoFactorWizardTest.php`
- `vendor/bin/pest tests/Feature/Auth`
- `vendor/bin/pest`
- `npx tsc --noEmit`
- `npm run build`

## Notes
- left `.claude/` and `docs/` files uncommitted because they are local/planning artifacts rather than branch code changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 5-step Two‑Factor setup wizard, dismissible account migration banner, new Dashboard with charts/KPIs, Sessions page, MigrationBanner component, DashboardLayout, and multiple reusable UI primitives (Card, Chart framework, InputGroup, Select, Textarea, Kbd, Tooltip).

* **Style**
  * Authentication theme palette updated to purple/emerald/lavender and scrollbar styling added.

* **Chores**
  * Added charting library and DB column to track dismissed migration banners.

* **Tests**
  * New/updated feature tests for migration banner and two‑factor wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->