### PR TITLE
fix(auth-ui): address staff auth review issues

### DIFF
--- a/app/Http/Controllers/Account/MigrationBannerController.php
+++ b/app/Http/Controllers/Account/MigrationBannerController.php
@@ -24,6 +24,8 @@ class MigrationBannerController extends Controller
             'dismissed_migration_banner_at' => now(),
         ])->save();
 
+        $request->session()->forget("auth.migration_banner.{$staff->staff_id}");
+
         return back();
     }
 }

--- a/app/Http/Controllers/Account/TwoFactorSecurityController.php
+++ b/app/Http/Controllers/Account/TwoFactorSecurityController.php
@@ -8,7 +8,6 @@ use App\Services\StaffTwoFactorService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Routing\Redirector;
 
 class TwoFactorSecurityController extends Controller
 {
@@ -61,6 +60,7 @@ class TwoFactorSecurityController extends Controller
                 'upgrade_method' => 'totp',
             ],
         );
+        $request->session()->forget("auth.migration_banner.{$staff->staff_id}");
 
         return $this->securityRedirect($request, 4)
             ->with('status', 'Two-factor authentication enabled.')
@@ -105,13 +105,14 @@ class TwoFactorSecurityController extends Controller
                 'upgrade_method' => null,
             ],
         );
+        $request->session()->forget("auth.migration_banner.{$staff->staff_id}");
 
         return redirect()
             ->route('scp.account.security')
             ->with('status', 'Two-factor authentication disabled.');
     }
 
-    private function securityRedirect(Request $request, int $wizardStep): Redirector|RedirectResponse
+    private function securityRedirect(Request $request, int $wizardStep): RedirectResponse
     {
         if ($request->boolean('return_to_wizard')) {
             return redirect()->route('scp.account.security.two-factor.show', ['step' => $wizardStep]);

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -48,7 +48,7 @@ class HandleInertiaRequests extends Middleware
                         'id' => $staff->staff_id,
                         'name' => trim(($staff->firstname ?? '').' '.($staff->lastname ?? '')) ?: $staff->username,
                         'username' => $staff->username,
-                        'migrationBanner' => $this->shouldShowMigrationBanner($staff),
+                        'migrationBanner' => $this->migrationBannerVisible($request, $staff),
                     ]
                     : null,
                 'throttle' => [
@@ -62,12 +62,31 @@ class HandleInertiaRequests extends Middleware
 
     private function shouldShowMigrationBanner(Staff $staff): bool
     {
-        $migration = $staff->loadMissing('authMigration')->authMigration;
+        $staff->loadMissing(['authMigration', 'twoFactorCredential']);
+        $migration = $staff->authMigration;
 
         if (! $migration || is_null($migration->migrated_at)) {
             return false;
         }
 
         return is_null($migration->dismissed_migration_banner_at) && ! $staff->hasTotpEnabled();
+    }
+
+    private function migrationBannerVisible(Request $request, Staff $staff): bool
+    {
+        if (! $request->routeIs('scp.dashboard')) {
+            return false;
+        }
+
+        $key = "auth.migration_banner.{$staff->staff_id}";
+
+        if ($request->session()->has($key)) {
+            return (bool) $request->session()->get($key);
+        }
+
+        $visible = $this->shouldShowMigrationBanner($staff);
+        $request->session()->put($key, $visible);
+
+        return $visible;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "osTicket2.0",
+    "name": "biarritz",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -173,6 +173,7 @@
     --input: #ffffff;
     --ring: #c4a5f3;
     --radius: 0.25rem;
+
     color-scheme: light;
     font-family: "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif;
     font-feature-settings: "ss01", "cv11";
@@ -392,7 +393,7 @@
     cursor: not-allowed;
 }
 
-/* Inputs inside auth-theme — clean cream-bordered with orange focus. */
+/* Inputs inside auth-theme — clean cream-bordered with lavender focus. */
 .auth-theme [data-slot="input"] {
     height: 44px;
     border-radius: 4px;

--- a/resources/js/components/ui/chart.tsx
+++ b/resources/js/components/ui/chart.tsx
@@ -8,6 +8,9 @@ import { cn } from "@/lib/utils";
 const THEMES = { light: "", dark: ".dark" } as const;
 
 const INITIAL_DIMENSION = { width: 320, height: 200 } as const;
+const SAFE_CSS_COLOR_VALUE =
+    /^(?:#[\da-fA-F]{3,8}|(?:rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|color-mix)\([a-zA-Z0-9\s.,%#+\-/*()]+\)|var\(--[a-zA-Z0-9_-]+\)|[a-zA-Z]+)$/;
+
 type TooltipNameType = number | string;
 
 export type ChartConfig = Record<
@@ -35,6 +38,21 @@ function useChart() {
     }
 
     return context;
+}
+
+function cssAttributeValue(value: string) {
+    return value
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/[\n\r\f]/g, "");
+}
+
+function cssVariableName(value: string) {
+    return value.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function safeCssColor(value: string | undefined) {
+    return value && SAFE_CSS_COLOR_VALUE.test(value) ? value : null;
 }
 
 function ChartContainer({
@@ -94,13 +112,17 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
                 __html: Object.entries(THEMES)
                     .map(
                         ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
+${prefix} [data-chart="${cssAttributeValue(id)}"] {
 ${colorConfig
     .map(([key, itemConfig]) => {
         const color =
             itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
             itemConfig.color;
-        return color ? `  --color-${key}: ${color};` : null;
+        const colorValue = safeCssColor(color);
+
+        return colorValue
+            ? `  --color-${cssVariableName(key)}: ${colorValue};`
+            : null;
     })
     .join("\n")}
 }
@@ -217,7 +239,7 @@ function ChartTooltipContent({
                             >
                                 {formatter &&
                                 item?.value !== undefined &&
-                                item.name ? (
+                                item.name != null ? (
                                     formatter(
                                         item.value,
                                         item.name,

--- a/resources/js/components/ui/input-group.tsx
+++ b/resources/js/components/ui/input-group.tsx
@@ -44,6 +44,7 @@ const inputGroupAddonVariants = cva(
 function InputGroupAddon({
   className,
   align = "inline-start",
+  onClick,
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
   return (
@@ -53,10 +54,19 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
+        onClick?.(e)
+
+        if (e.defaultPrevented) {
+          return
+        }
+
         if ((e.target as HTMLElement).closest("button")) {
           return
         }
-        e.currentTarget.parentElement?.querySelector("input")?.focus()
+
+        e.currentTarget.parentElement
+          ?.querySelector<HTMLInputElement | HTMLTextAreaElement>("input, textarea")
+          ?.focus()
       }}
       {...props}
     />

--- a/resources/js/components/ui/kbd.tsx
+++ b/resources/js/components/ui/kbd.tsx
@@ -13,7 +13,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       data-slot="kbd-group"

--- a/resources/js/layouts/AuthLayout.tsx
+++ b/resources/js/layouts/AuthLayout.tsx
@@ -4,7 +4,7 @@ import { usePage } from "@inertiajs/react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
 
-type EyebrowAccent = "orange" | "pink" | "indigo" | "gradient";
+type EyebrowAccent = "purple" | "indigo" | "emerald" | "gradient";
 
 interface AuthLayoutProps {
     title: string;
@@ -48,7 +48,7 @@ export function AuthLayout({
     title,
     subtitle,
     tag,
-    eyebrowAccent = "orange",
+    eyebrowAccent = "purple",
     sectionIndex = "01",
     children,
     footer,

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import { Children, type ReactNode } from 'react';
+import { Children, useRef, useState, type ReactNode } from 'react';
 import { Link, router } from '@inertiajs/react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
@@ -73,12 +73,17 @@ const PINNED_TICKETS = [
 const navBaseClass = 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium font-body transition-colors duration-150';
 const navActiveClass = `${navBaseClass} bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
 const navInactiveClass = `${navBaseClass} text-[#64748B] hover:bg-white hover:text-[#0F172A]`;
+const navDisabledClass = `${navBaseClass} cursor-not-allowed text-[#94A3B8] opacity-50`;
 
-function getNavClasses(activeNav: string | undefined, navItem: string): string {
+function getNavClasses(activeNav: string | undefined, navItem: string, disabled = false): string {
+    if (disabled) return navDisabledClass;
+
     return activeNav === navItem ? navActiveClass : navInactiveClass;
 }
 
-function getNavIconColor(activeNav: string | undefined, navItem: string): string {
+function getNavIconColor(activeNav: string | undefined, navItem: string, disabled = false): string {
+    if (disabled) return '#CBD5E1';
+
     return activeNav === navItem ? '#5B619D' : '#94A3B8';
 }
 
@@ -137,13 +142,31 @@ export default function DashboardLayout({
     const resolvedHeaderActions = headerActions === undefined
         ? <DefaultHeaderActions />
         : (Children.count(headerActions) > 0 ? headerActions : null);
+    const [isLoggingOut, setIsLoggingOut] = useState(false);
+    const isLoggingOutRef = useRef(false);
+
+    function logout() {
+        if (isLoggingOutRef.current) {
+            return;
+        }
+
+        isLoggingOutRef.current = true;
+        setIsLoggingOut(true);
+
+        router.post('/scp/logout', {}, {
+            onFinish: () => {
+                isLoggingOutRef.current = false;
+                setIsLoggingOut(false);
+            },
+        });
+    }
 
     return (
         <div className="auth-theme relative flex h-screen overflow-hidden bg-[#E9ECEF] text-[#0F172A]">
             <div className="auth-mesh pointer-events-none absolute inset-0"></div>
             <div className="auth-grain pointer-events-none absolute inset-0"></div>
 
-            <main className="relative z-10 flex h-full w-full">
+            <div className="relative z-10 flex h-full w-full">
                 <div className="flex h-full w-full overflow-hidden bg-white">
                     <aside className="flex w-72 shrink-0 flex-col border-r border-[#E2E8F0] bg-[#F8FAFC]/90">
                         <div className="px-5 py-5 transition-colors hover:bg-white/70">
@@ -172,7 +195,7 @@ export default function DashboardLayout({
                                 {NAV_ITEMS.map(({ id, label, icon, href }) => {
                                     const content = (
                                         <>
-                                            <HugeiconsIcon icon={icon} size={18} color={getNavIconColor(activeNav, id)} />
+                                            <HugeiconsIcon icon={icon} size={18} color={getNavIconColor(activeNav, id, !href)} />
                                             <span>{label}</span>
                                         </>
                                     );
@@ -182,7 +205,13 @@ export default function DashboardLayout({
                                             {content}
                                         </Link>
                                     ) : (
-                                        <button key={id} type="button" className={`${getNavClasses(activeNav, id)} w-full text-left`}>
+                                        <button
+                                            key={id}
+                                            type="button"
+                                            disabled
+                                            aria-disabled="true"
+                                            className={`${getNavClasses(activeNav, id, true)} w-full text-left`}
+                                        >
                                             {content}
                                         </button>
                                     );
@@ -294,8 +323,9 @@ export default function DashboardLayout({
                                 <Button
                                     variant="outline"
                                     size="sm"
-                                    onClick={() => router.post('/scp/logout')}
-                                    className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:text-red-600"
+                                    disabled={isLoggingOut}
+                                    onClick={logout}
+                                    className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:text-red-600 cursor-pointer"
                                 >
                                     <HugeiconsIcon icon={LogoutSquare01Icon} size={14} color="#94A3B8" />
                                     Sign out
@@ -319,7 +349,7 @@ export default function DashboardLayout({
                         </main>
                     </div>
                 </div>
-            </main>
+            </div>
         </div>
     );
 }

--- a/resources/js/pages/Account/Security/Index.tsx
+++ b/resources/js/pages/Account/Security/Index.tsx
@@ -208,7 +208,11 @@ export default function SecurityIndex({ twoFactor, migration, revealedRecoveryCo
     );
 }
 
-SecurityIndex.layout = (page: ReactElement) => (
+type SecurityPageComponent = typeof SecurityIndex & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(SecurityIndex as SecurityPageComponent).layout = (page: ReactElement) => (
     <DashboardLayout
         title="Account Security"
         subtitle="Manage two-factor authentication and active sessions."
@@ -219,9 +223,3 @@ SecurityIndex.layout = (page: ReactElement) => (
         {page}
     </DashboardLayout>
 );
-
-type SecurityPageComponent = typeof SecurityIndex & {
-    layout?: (page: ReactElement) => ReactNode;
-};
-
-(SecurityIndex as SecurityPageComponent).layout = SecurityIndex.layout;

--- a/resources/js/pages/Account/Security/Sessions.tsx
+++ b/resources/js/pages/Account/Security/Sessions.tsx
@@ -2,24 +2,8 @@ import { Button } from "@/components/ui/button";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
     ComputerIcon,
-    SmartPhone01Icon,
     MapPinIcon,
 } from "@hugeicons/core-free-icons";
-
-type DeviceIcon = typeof ComputerIcon | typeof SmartPhone01Icon;
-
-interface OtherSession {
-    icon: DeviceIcon;
-    device: string;
-    ip: string;
-    location: string;
-    lastSeen: string;
-}
-
-const OTHER_SESSIONS: OtherSession[] = [
-    { icon: SmartPhone01Icon, device: 'iOS • Chrome', ip: '10.0.0.25', location: 'Tokyo, JP', lastSeen: '3 days ago' },
-    { icon: ComputerIcon, device: 'Windows 11 • Edge', ip: '172.16.0.4', location: 'London, UK', lastSeen: '1 week ago' },
-];
 
 export default function Sessions() {
     return (
@@ -35,17 +19,17 @@ export default function Sessions() {
 
                     <div className="flex-1 space-y-1">
                         <div className="flex items-center gap-2">
-                            <span className="font-display font-medium text-foreground">Mac OS • Safari</span>
-                            <span className="inline-flex items-center rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
-                                Active now
+                            <span className="font-display font-medium text-foreground">Current browser session</span>
+                            <span className="inline-flex items-center rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20">
+                                Details unavailable
                             </span>
                         </div>
                         <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 font-mono text-xs text-muted-foreground">
-                            <span>192.168.1.1</span>
+                            <span>Session metadata is not connected yet.</span>
                             <span className="hidden sm:inline">•</span>
                             <span className="flex items-center gap-1 font-body">
                                 <HugeiconsIcon icon={MapPinIcon} className="size-3" />
-                                Ho Chi Minh City, VN
+                                Location unavailable
                             </span>
                         </div>
                     </div>
@@ -55,37 +39,13 @@ export default function Sessions() {
             <div className="space-y-4">
                 <h3 className="auth-eyebrow text-muted-foreground">Other Sessions</h3>
 
-                <div className="space-y-3">
-                    {OTHER_SESSIONS.map(({ icon, device, ip, location, lastSeen }) => (
-                        <div key={device} className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 rounded-md border border-[#E2E8F0] bg-white p-4">
-                            <div className="flex items-center gap-4">
-                                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted/50 border border-border text-muted-foreground">
-                                    <HugeiconsIcon icon={icon} className="size-5" />
-                                </div>
-                                <div className="space-y-1">
-                                    <div className="font-display font-medium text-foreground">{device}</div>
-                                    <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 font-mono text-xs text-muted-foreground">
-                                        <span>{ip}</span>
-                                        <span className="hidden sm:inline">•</span>
-                                        <span className="flex items-center gap-1 font-body">
-                                            <HugeiconsIcon icon={MapPinIcon} className="size-3" />
-                                            {location}
-                                        </span>
-                                        <span className="hidden sm:inline">•</span>
-                                        <span className="font-body text-muted-foreground/80">{lastSeen}</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <Button variant="outline" size="sm" onClick={() => console.log("revoke")} className="w-full sm:w-auto shrink-0 font-body">
-                                Revoke
-                            </Button>
-                        </div>
-                    ))}
+                <div className="rounded-md border border-dashed border-[#E2E8F0] bg-white p-5 text-sm text-muted-foreground">
+                    Session listing and revocation require backend session-management endpoints before they can be enabled.
                 </div>
             </div>
 
             <div className="pt-2 border-t border-[#E2E8F0]">
-                <Button variant="destructive" onClick={() => console.log("sign out all")} className="font-body w-full sm:w-auto">
+                <Button variant="destructive" disabled className="font-body w-full sm:w-auto">
                     Sign out of all other sessions
                 </Button>
             </div>

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -63,7 +63,11 @@ export default function TwoFactorWizard({ step, twoFactor }: PageProps) {
     );
 }
 
-TwoFactorWizard.layout = (page: ReactElement) => (
+type TwoFactorWizardPageComponent = typeof TwoFactorWizard & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(TwoFactorWizard as TwoFactorWizardPageComponent).layout = (page: ReactElement) => (
     <DashboardLayout
         title="Secure Your Account"
         subtitle="Add an authenticator app to complete your migration."
@@ -75,12 +79,6 @@ TwoFactorWizard.layout = (page: ReactElement) => (
         {page}
     </DashboardLayout>
 );
-
-type TwoFactorWizardPageComponent = typeof TwoFactorWizard & {
-    layout?: (page: ReactElement) => ReactNode;
-};
-
-(TwoFactorWizard as TwoFactorWizardPageComponent).layout = TwoFactorWizard.layout;
 
 function ChooseMethod() {
     const form = useForm({ force: true, return_to_wizard: true });
@@ -180,9 +178,7 @@ function Verify() {
         return_to_wizard: true,
     });
 
-    const submit = (code: string) => {
-        setData("code", code);
-        setData("return_to_wizard", true);
+    const submit = () => {
         post("/scp/account/security/two-factor/confirm", {
             preserveScroll: true,
         });
@@ -227,7 +223,7 @@ function Verify() {
                 <Button
                     type="button"
                     disabled={processing || data.code.length < 6}
-                    onClick={() => submit(data.code)}
+                    onClick={submit}
                 >
                     {processing ? "Verifying…" : "Verify"}
                 </Button>

--- a/resources/js/pages/Auth/ConfirmPassword.tsx
+++ b/resources/js/pages/Auth/ConfirmPassword.tsx
@@ -27,7 +27,7 @@ export default function ConfirmPassword() {
             title="Confirm your password."
             subtitle="Re-enter your password to continue to two-factor authentication settings."
             tag="Security · Re-auth"
-            eyebrowAccent="orange"
+            eyebrowAccent="purple"
             sectionIndex="04"
             footer={
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/resources/js/pages/Auth/ForgotPassword.tsx
+++ b/resources/js/pages/Auth/ForgotPassword.tsx
@@ -27,7 +27,7 @@ export default function ForgotPassword() {
             title="Recover your access."
             subtitle="Enter the email on file and we'll send a secure, single-use link to reset your password."
             tag="Recovery · Email"
-            eyebrowAccent="pink"
+            eyebrowAccent="emerald"
             sectionIndex="02"
             footer={
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/resources/js/pages/Auth/Login.tsx
+++ b/resources/js/pages/Auth/Login.tsx
@@ -56,7 +56,7 @@ export default function Login() {
             title="Sign in to the console."
             subtitle="Access the osTicket staff support panel with your credentials. Two-factor authentication may be required."
             tag="Login · Staff"
-            eyebrowAccent="orange"
+            eyebrowAccent="purple"
             sectionIndex="01"
             footer={
                 <div className="flex flex-wrap items-center justify-between gap-4">

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -439,14 +439,12 @@ export default function Dashboard() {
     );
 }
 
-Dashboard.layout = (page: ReactElement) => (
-    <DashboardLayout title="Dashboard" activeNav="dashboard" contentClassName="w-full">
-        {page}
-    </DashboardLayout>
-);
-
 type DashboardPageComponent = typeof Dashboard & {
     layout?: (page: ReactElement) => ReactNode;
 };
 
-(Dashboard as DashboardPageComponent).layout = Dashboard.layout;
+(Dashboard as DashboardPageComponent).layout = (page: ReactElement) => (
+    <DashboardLayout title="Dashboard" activeNav="dashboard" contentClassName="w-full">
+        {page}
+    </DashboardLayout>
+);


### PR DESCRIPTION
## Summary
Address the verified PR #48 staff-auth UI review findings by hardening chart styling, input-group focus behavior, dashboard shell navigation/logout behavior, Inertia layout assignments, and the security sessions tab.

## Details
This also narrows migration-banner relationship work to the dashboard route, invalidates cached banner visibility after banner or 2FA mutations, aligns auth eyebrow accents with the scoped CSS palette, and commits the workspace lockfile metadata change.

## Verification
- ./node_modules/.bin/tsc --noEmit
- php artisan test tests/Feature/Auth/MigrationBannerTest.php tests/Feature/Auth/TwoFactorWizardTest.php tests/Feature/Auth/FortifyMigrationTest.php
- npm run build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
