### PR TITLE
fix(auth-ui): resolve PR review follow-ups

### DIFF
--- a/app/Http/Controllers/Account/TwoFactorSecurityController.php
+++ b/app/Http/Controllers/Account/TwoFactorSecurityController.php
@@ -103,6 +103,7 @@ class TwoFactorSecurityController extends Controller
             [
                 'migrated_at' => null,
                 'upgrade_method' => null,
+                'dismissed_migration_banner_at' => null,
             ],
         );
         $request->session()->forget("auth.migration_banner.{$staff->staff_id}");

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -420,6 +420,11 @@
     box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.12);
 }
 
+.custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: #e2e8f0 transparent;
+}
+
 .custom-scrollbar::-webkit-scrollbar {
     width: 4px;
     height: 4px;

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -65,9 +65,9 @@ const CONVERSATION_ITEMS = [
 ] as const;
 
 const PINNED_TICKETS = [
-    { href: '#', label: '#TC-192 product inquiry...' },
-    { href: '#', label: '#TC-191 payment issue...' },
-    { href: '#', label: '+1 678-908-78...' },
+    { label: '#TC-192 product inquiry...' },
+    { label: '#TC-191 payment issue...' },
+    { label: '+1 678-908-78...' },
 ] as const;
 
 const navBaseClass = 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium font-body transition-colors duration-150';
@@ -270,8 +270,14 @@ export default function DashboardLayout({
                                     </Button>
                                 </div>
                                 <div className="space-y-3">
-                                    {PINNED_TICKETS.map(({ href, label }, index) => (
-                                        <a key={label} href={href} className="group flex items-center justify-between gap-3">
+                                    {PINNED_TICKETS.map(({ label }, index) => (
+                                        <button
+                                            key={label}
+                                            type="button"
+                                            disabled
+                                            aria-disabled="true"
+                                            className="group flex w-full cursor-not-allowed items-center justify-between gap-3 text-left opacity-70"
+                                        >
                                             <div className="flex min-w-0 items-center gap-2">
                                                 <div className={cn(
                                                     'flex h-4 w-4 items-center justify-center rounded-full',
@@ -284,7 +290,7 @@ export default function DashboardLayout({
                                                 </span>
                                             </div>
                                             <span className="text-xs text-[#CBD5E1] transition-colors group-hover:text-[#5B619D]">⌁</span>
-                                        </a>
+                                        </button>
                                     ))}
 
                                     <Button variant="ghost" className="mt-1 h-auto justify-start rounded-md px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#0F172A]">

--- a/resources/js/pages/Account/Security/TwoFactorWizard.tsx
+++ b/resources/js/pages/Account/Security/TwoFactorWizard.tsx
@@ -243,8 +243,11 @@ function Recovery({ codes }: { codes: string[] }) {
 
         anchor.href = url;
         anchor.download = "osticket-recovery-codes.txt";
+        anchor.rel = "noopener";
+        document.body.append(anchor);
         anchor.click();
-        URL.revokeObjectURL(url);
+        anchor.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 0);
     }
 
     if (codes.length === 0) {

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -128,6 +128,14 @@ const replyTimeInteractiveChartConfig = {
     ),
 } satisfies ChartConfig;
 
+function getStatCardBorderClass(index: number) {
+    return cn(
+        index > 0 && 'border-t border-[#E2E8F0] md:border-t-0',
+        index % 2 === 1 && 'md:border-l md:border-[#E2E8F0] xl:border-l',
+        index >= 2 && 'xl:border-l xl:border-t-0',
+    );
+}
+
 function StatCard({ label, value, suffix, trend, positive }: StatCardItem) {
     return (
         <Card className="rounded-none border-0 py-0 shadow-none ring-0">
@@ -213,12 +221,12 @@ function ReplyTimeInteractiveChart() {
                             <SelectValue placeholder="Select segment" />
                         </SelectTrigger>
                         <SelectContent align="end" className="rounded-xl">
-                            {REPLY_TIME_DATA.map(({ name }) => (
+                            {REPLY_TIME_DATA.map(({ fill, name }) => (
                                 <SelectItem key={name} value={name} className="rounded-lg [&_span]:flex">
                                     <div className="flex items-center gap-2 text-xs">
                                         <span
                                             className="flex h-3 w-3 shrink-0 rounded-[2px]"
-                                            style={{ backgroundColor: `var(--color-${name})` }}
+                                            style={{ backgroundColor: fill }}
                                         />
                                         {name}
                                     </div>
@@ -294,10 +302,20 @@ export default function Dashboard() {
             <MigrationBanner />
 
             <div className="space-y-6 xl:space-y-8">
+                <div className="flex flex-wrap items-center justify-between gap-3 rounded-[14px] border border-dashed border-[#C4A5F3]/50 bg-[#F8FAFC] px-4 py-3">
+                    <div>
+                        <p className="font-body text-sm font-medium text-[#0F172A]">Analytics preview</p>
+                        <p className="mt-0.5 text-xs text-[#64748B]">Dashboard metrics are sample values until live reporting endpoints are connected.</p>
+                    </div>
+                    <span className="rounded-full bg-[#F3ECFF] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#5B619D]">
+                        Sample data
+                    </span>
+                </div>
+
                 <SectionFrame>
                     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4">
                         {STAT_CARDS.map((card, index) => (
-                            <div key={card.label} className={cn(index > 0 && 'border-t border-[#E2E8F0] md:border-t-0', index % 2 === 1 && 'md:border-l md:border-[#E2E8F0] xl:border-l', index >= 2 && 'xl:border-l xl:border-t-0')}>
+                            <div key={card.label} className={getStatCardBorderClass(index)}>
                                 <StatCard {...card} />
                             </div>
                         ))}

--- a/tests/Feature/Auth/TwoFactorWizardTest.php
+++ b/tests/Feature/Auth/TwoFactorWizardTest.php
@@ -101,3 +101,29 @@ it('redirects wizard enable and confirm actions back into the wizard flow', func
 
     $this->travelBack();
 });
+
+it('clears a dismissed migration banner timestamp when two-factor is disabled', function () {
+    $staff = Staff::factory()->create([
+        'passwd' => Hash::make('hello'),
+        'isactive' => 1,
+    ]);
+
+    app(StaffTwoFactorService::class)->enable($staff, true);
+
+    $staff->authMigration()->create([
+        'migrated_at' => now()->subDay(),
+        'upgrade_method' => 'totp',
+        'dismissed_migration_banner_at' => now(),
+    ]);
+
+    $this->actingAs($staff->fresh(), 'staff')
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->delete('/scp/account/security/two-factor')
+        ->assertRedirect('/scp/account/security');
+
+    $migration = $staff->fresh()->authMigration;
+
+    expect($migration?->migrated_at)->toBeNull()
+        ->and($migration?->upgrade_method)->toBeNull()
+        ->and($migration?->dismissed_migration_banner_at)->toBeNull();
+});


### PR DESCRIPTION
## Summary
Resolve the remaining verified PR review follow-ups for the staff auth dashboard and two-factor flow. This clears stale migration-banner dismissal state when 2FA is disabled, fixes inert placeholder UI and recovery-code download behavior, corrects reply-time color dots, adds a sample-data notice, and improves Firefox scrollbar styling.

## Verification
Ran Pint on touched PHP files, targeted TwoFactorWizard and MigrationBanner feature tests, TypeScript checking, and the Vite production build.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
