### PR TITLE
[codex] Fix security footer active state

### DIFF
--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -74,6 +74,9 @@ const navBaseClass = 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm fon
 const navActiveClass = `${navBaseClass} bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
 const navInactiveClass = `${navBaseClass} text-[#64748B] hover:bg-white hover:text-[#0F172A]`;
 const navDisabledClass = `${navBaseClass} cursor-not-allowed text-[#94A3B8] opacity-50`;
+const footerActionBaseClass = 'inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-xs font-medium transition-colors';
+const footerActionActiveClass = `${footerActionBaseClass} border-[#CBD5E1] bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
+const footerActionInactiveClass = `${footerActionBaseClass} border-[#E2E8F0] bg-white text-[#64748B] hover:text-[#0F172A]`;
 
 function getNavClasses(activeNav: string | undefined, navItem: string, disabled = false): string {
     if (disabled) return navDisabledClass;
@@ -84,6 +87,14 @@ function getNavClasses(activeNav: string | undefined, navItem: string, disabled 
 function getNavIconColor(activeNav: string | undefined, navItem: string, disabled = false): string {
     if (disabled) return '#CBD5E1';
 
+    return activeNav === navItem ? '#5B619D' : '#94A3B8';
+}
+
+function getFooterActionClasses(activeNav: string | undefined, navItem: string): string {
+    return activeNav === navItem ? footerActionActiveClass : footerActionInactiveClass;
+}
+
+function getFooterActionIconColor(activeNav: string | undefined, navItem: string): string {
     return activeNav === navItem ? '#5B619D' : '#94A3B8';
 }
 
@@ -351,8 +362,12 @@ export default function DashboardLayout({
                             </Card>
 
                             <div className="grid grid-cols-2 gap-2">
-                                <Link href="/scp/account/security" className="inline-flex items-center justify-center gap-2 rounded-md border border-[#E2E8F0] bg-white px-3 py-2 text-xs font-medium text-[#64748B] transition-colors hover:text-[#0F172A]">
-                                    <HugeiconsIcon icon={ShieldCheck} size={14} color="#94A3B8" />
+                                <Link
+                                    href="/scp/account/security"
+                                    className={getFooterActionClasses(activeNav, 'security')}
+                                    aria-current={activeNav === 'security' ? 'page' : undefined}
+                                >
+                                    <HugeiconsIcon icon={ShieldCheck} size={14} color={getFooterActionIconColor(activeNav, 'security')} />
                                     Security
                                 </Link>
                                 <Button


### PR DESCRIPTION
## Overview
Restore active navigation feedback on the staff account security experience by making the dashboard footer's existing Security action reflect the current page state. This keeps the current layout structure intact while fixing the dead `activeNav="security"` state on both the security overview and two-factor setup flow.

## Problem
Both `resources/js/pages/Account/Security/Index.tsx` and `resources/js/pages/Account/Security/TwoFactorWizard.tsx` pass `activeNav="security"` into `DashboardLayout`, but `resources/js/layouts/DashboardLayout.tsx` only applied active styling against ids defined in the main `NAV_ITEMS` array. Because that array does not contain a `security` entry, the security pages rendered with no highlighted navigation state at all. The only real Security destination already lived in the footer action area, but that link had no active-state logic and no `aria-current` hint.

## Fix
- add footer action style variants so footer links can participate in active page-state styling independently of the main sidebar items
- add small footer helpers that resolve the Security link's classes and icon color from `activeNav`
- apply the active treatment and `aria-current="page"` to the footer Security link when `activeNav === "security"`
- leave the main sidebar item list unchanged so the layout continues to present Security as a footer destination instead of duplicating it in the primary navigation

## Impact
Security pages now show a clear active navigation affordance in the part of the layout that actually links to those pages. This aligns the UI with the existing page props, removes dead state, and improves orientation for staff moving between dashboard and account security flows.

## Verification
- `npm run build`
- `git diff --check`
