### PR TITLE
[codex] implement live SCP dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,8 @@ REDIS_PORT=6379
 
 OSTICKET_SECRET_SALT=
 OSTICKET_CONFIG_PATH=
+# Set to the osTicket filesystem storage plugin uploadpath, for example /opt/dataticket.
+OSTICKET_FILESYSTEM_ROOT=
 
 MAIL_MAILER=log
 MAIL_SCHEME=null

--- a/app/Console/Commands/CheckOverdueTicketsCommand.php
+++ b/app/Console/Commands/CheckOverdueTicketsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Eloquent\Scopes\TicketAccessibleScope;
 use App\Models\Ticket;
 use Illuminate\Console\Command;
 
@@ -24,6 +25,7 @@ final class CheckOverdueTicketsCommand extends Command
         $now = now();
 
         $query = Ticket::query()
+            ->withoutGlobalScope(TicketAccessibleScope::class)
             ->where('isoverdue', 0)
             ->whereNull('closed')
             ->whereNotNull('duedate')

--- a/app/Console/Commands/ScpParityCheck.php
+++ b/app/Console/Commands/ScpParityCheck.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Queue;
+use App\Models\Ticket;
+use App\Services\Scp\LegacyQueueCriteriaParser;
+use App\Services\Scp\TicketReadService;
+use Illuminate\Console\Command;
+
+class ScpParityCheck extends Command
+{
+    protected $signature = 'scp:parity-check {--queue=} {--sample=50}';
+
+    protected $description = 'Sample legacy tickets through the SCP read services and report projection errors.';
+
+    public function handle(LegacyQueueCriteriaParser $criteriaParser, TicketReadService $tickets): int
+    {
+        $sample = max(1, (int) $this->option('sample'));
+        $query = Ticket::query()->orderByDesc('ticket_id')->limit($sample);
+        $queueId = $this->option('queue');
+
+        if ($queueId) {
+            $queue = Queue::query()->find((int) $queueId);
+
+            if (! $queue) {
+                $this->error("Queue [{$queueId}] was not found.");
+
+                return self::FAILURE;
+            }
+
+            $unsupported = $criteriaParser->apply($query, $queue->config);
+
+            if ($unsupported !== []) {
+                $this->warn('Unsupported queue criteria: '.implode('; ', $unsupported));
+            }
+        }
+
+        $checked = 0;
+        $failures = 0;
+
+        foreach ($query->get() as $ticket) {
+            $checked++;
+
+            try {
+                $projection = $tickets->read($ticket);
+
+                if (($projection['ticket']['id'] ?? null) !== (int) $ticket->ticket_id) {
+                    $failures++;
+                    $this->line("Ticket {$ticket->ticket_id}: projection ID mismatch.");
+                }
+            } catch (\Throwable $exception) {
+                $failures++;
+                $this->line("Ticket {$ticket->ticket_id}: {$exception->getMessage()}");
+            }
+        }
+
+        $this->info("Checked {$checked} ticket(s); {$failures} failure(s).");
+
+        return $failures === 0 ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/app/Console/Commands/ScpParityCheck.php
+++ b/app/Console/Commands/ScpParityCheck.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Eloquent\Scopes\TicketAccessibleScope;
 use App\Models\Queue;
 use App\Models\Ticket;
 use App\Services\Scp\LegacyQueueCriteriaParser;
@@ -17,7 +18,10 @@ class ScpParityCheck extends Command
     public function handle(LegacyQueueCriteriaParser $criteriaParser, TicketReadService $tickets): int
     {
         $sample = max(1, (int) $this->option('sample'));
-        $query = Ticket::query()->orderByDesc('ticket_id')->limit($sample);
+        $query = Ticket::query()
+            ->withoutGlobalScope(TicketAccessibleScope::class)
+            ->orderByDesc('ticket_id')
+            ->limit($sample);
         $queueId = $this->option('queue');
 
         if ($queueId) {

--- a/app/Http/Controllers/Scp/AttachmentController.php
+++ b/app/Http/Controllers/Scp/AttachmentController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Scp;
+
+use App\Http\Controllers\Controller;
+use App\Models\File;
+use App\Services\FileStorage\FileStorageReaderResolver;
+use Symfony\Component\HttpFoundation\Response;
+
+class AttachmentController extends Controller
+{
+    public function __construct(private readonly FileStorageReaderResolver $readers) {}
+
+    public function download(File $file): Response
+    {
+        $reader = $this->readers->resolve($file);
+
+        abort_unless($reader->exists($file), 404);
+
+        return $reader->stream($file);
+    }
+}

--- a/app/Http/Controllers/Scp/AttachmentController.php
+++ b/app/Http/Controllers/Scp/AttachmentController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers\Scp;
 
 use App\Http\Controllers\Controller;
+use App\Models\Attachment;
 use App\Models\File;
+use App\Models\Ticket;
 use App\Services\FileStorage\FileStorageReaderResolver;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -13,10 +15,41 @@ class AttachmentController extends Controller
 
     public function download(File $file): Response
     {
+        abort_unless($this->canDownload($file), 404);
+
         $reader = $this->readers->resolve($file);
 
         abort_unless($reader->exists($file), 404);
 
         return $reader->stream($file);
+    }
+
+    private function canDownload(File $file): bool
+    {
+        $directTicketIds = Attachment::query()
+            ->where('file_id', $file->id)
+            ->where('object_type', 'T')
+            ->pluck('object_id')
+            ->map(fn ($id): int => (int) $id)
+            ->all();
+
+        if ($directTicketIds !== [] && Ticket::query()->whereIn('ticket_id', $directTicketIds)->exists()) {
+            return true;
+        }
+
+        $entryIds = Attachment::query()
+            ->where('file_id', $file->id)
+            ->whereIn('object_type', ['H', 'E', 'M', 'R', 'N'])
+            ->pluck('object_id')
+            ->map(fn ($id): int => (int) $id)
+            ->all();
+
+        if ($entryIds === []) {
+            return false;
+        }
+
+        return Ticket::query()
+            ->whereHas('thread.entries', fn ($query) => $query->whereIn('thread_entry.id', $entryIds))
+            ->exists();
     }
 }

--- a/app/Http/Controllers/Scp/DashboardController.php
+++ b/app/Http/Controllers/Scp/DashboardController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Scp;
+
+use App\Http\Controllers\Controller;
+use App\Services\Scp\DashboardService;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    public function __construct(private readonly DashboardService $dashboard) {}
+
+    public function index(Request $request): Response
+    {
+        $staff = $request->user('staff');
+        $range = $request->query('range', 'last_6_months');
+
+        if (! in_array($range, ['last_7_days', 'last_30_days', 'last_3_months', 'last_6_months'], true)) {
+            $range = 'last_6_months';
+        }
+
+        return Inertia::render('Dashboard', [
+            'metrics' => $this->dashboard->summary($staff, $range),
+            'range' => $range,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Scp/QueueController.php
+++ b/app/Http/Controllers/Scp/QueueController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Scp;
+
+use App\Http\Controllers\Controller;
+use App\Models\Queue;
+use App\Services\Scp\QueueExportService;
+use App\Services\Scp\QueueService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class QueueController extends Controller
+{
+    public function __construct(
+        private readonly QueueService $queues,
+        private readonly QueueExportService $exports,
+    ) {}
+
+    public function index(Request $request): Response|RedirectResponse
+    {
+        $staffId = $this->staffId($request);
+        $defaultId = $this->queues->defaultQueueId($staffId);
+
+        if ($defaultId !== null) {
+            return redirect()->route('scp.queues.show', ['queue' => $defaultId]);
+        }
+
+        return Inertia::render('Scp/Queues/Index', [
+            'navigation' => $this->queues->visibleQueues($staffId),
+        ]);
+    }
+
+    public function show(Request $request, Queue $queue): Response
+    {
+        $staff = $request->user('staff');
+
+        abort_unless($this->queues->canViewQueue($queue, (int) $staff->staff_id), 404);
+
+        $ticketRows = $this->queues->ticketRows(
+            queue: $queue,
+            staff: $staff,
+            page: max(1, (int) $request->query('page', 1)),
+        );
+
+        return Inertia::render('Scp/Queues/Show', [
+            'navigation' => $this->queues->visibleQueues((int) $staff->staff_id),
+            'queue' => [
+                'id' => (int) $queue->id,
+                'title' => (string) $queue->title,
+            ],
+            'tickets' => $ticketRows['tickets'],
+            'pagination' => $ticketRows['pagination'],
+            'unsupported' => $ticketRows['unsupported'],
+            'unsupportedReasons' => $ticketRows['unsupportedReasons'],
+        ]);
+    }
+
+    public function export(Request $request, Queue $queue): StreamedResponse
+    {
+        abort_unless($this->queues->canViewQueue($queue, $this->staffId($request)), 404);
+
+        return $this->exports->stream($queue, $request->user('staff'));
+    }
+
+    private function staffId(Request $request): int
+    {
+        return (int) $request->user('staff')->staff_id;
+    }
+}

--- a/app/Http/Controllers/Scp/QueueController.php
+++ b/app/Http/Controllers/Scp/QueueController.php
@@ -6,14 +6,18 @@ use App\Http\Controllers\Controller;
 use App\Models\Queue;
 use App\Services\Scp\QueueExportService;
 use App\Services\Scp\QueueService;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
 
 class QueueController extends Controller
 {
+    private const SORTABLE_COLUMNS = ['number', 'created', 'priority', 'from', 'assignee'];
+
     public function __construct(
         private readonly QueueService $queues,
         private readonly QueueExportService $exports,
@@ -39,10 +43,16 @@ class QueueController extends Controller
 
         abort_unless($this->queues->canViewQueue($queue, (int) $staff->staff_id), 404);
 
+        $filters = $this->parseFilters($request);
+        $sort = $this->parseSort($request);
+
         $ticketRows = $this->queues->ticketRows(
             queue: $queue,
             staff: $staff,
             page: max(1, (int) $request->query('page', 1)),
+            filters: $filters,
+            sort: $sort['by'],
+            direction: $sort['dir'],
         );
 
         return Inertia::render('Scp/Queues/Show', [
@@ -55,6 +65,9 @@ class QueueController extends Controller
             'pagination' => $ticketRows['pagination'],
             'unsupported' => $ticketRows['unsupported'],
             'unsupportedReasons' => $ticketRows['unsupportedReasons'],
+            'filters' => $filters,
+            'filterOptions' => $this->queues->filterOptions(),
+            'sort' => $sort,
         ]);
     }
 
@@ -68,5 +81,80 @@ class QueueController extends Controller
     private function staffId(Request $request): int
     {
         return (int) $request->user('staff')->staff_id;
+    }
+
+    /**
+     * @return array{
+     *   state: list<string>,
+     *   source: list<string>,
+     *   priority: list<int>,
+     *   created_from: ?string,
+     *   created_to: ?string
+     * }
+     */
+    private function parseFilters(Request $request): array
+    {
+        return [
+            'state' => $this->stringList($request->query('state')),
+            'source' => $this->stringList($request->query('source')),
+            'priority' => $this->intList($request->query('priority')),
+            'created_from' => $this->parseDate($request->query('created_from')),
+            'created_to' => $this->parseDate($request->query('created_to')),
+        ];
+    }
+
+    /**
+     * @return array{by:string, dir:string}
+     */
+    private function parseSort(Request $request): array
+    {
+        $by = (string) $request->query('sort', 'created');
+        $dir = strtolower((string) $request->query('dir', 'desc'));
+
+        return [
+            'by' => in_array($by, self::SORTABLE_COLUMNS, true) ? $by : 'created',
+            'dir' => $dir === 'asc' ? 'asc' : 'desc',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if ($value === null || $value === '') {
+            return [];
+        }
+
+        $items = is_array($value) ? $value : explode(',', (string) $value);
+
+        return array_values(array_filter(array_map(
+            fn (mixed $item): string => trim((string) $item),
+            $items,
+        ), fn (string $item): bool => $item !== ''));
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function intList(mixed $value): array
+    {
+        return array_values(array_filter(array_map(
+            fn (string $item): int => (int) $item,
+            $this->stringList($value),
+        ), fn (int $item): bool => $item > 0));
+    }
+
+    private function parseDate(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value)->toDateString();
+        } catch (Throwable) {
+            return null;
+        }
     }
 }

--- a/app/Http/Controllers/Scp/SearchController.php
+++ b/app/Http/Controllers/Scp/SearchController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Scp;
+
+use App\Http\Controllers\Controller;
+use App\Services\Scp\SearchService;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SearchController extends Controller
+{
+    public function __construct(private readonly SearchService $search) {}
+
+    public function index(Request $request): Response
+    {
+        $query = (string) $request->query('q', '');
+
+        return Inertia::render('Scp/Search/Index', [
+            'query' => $query,
+            'results' => $this->search->tickets($query),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Scp/StaffPreferencesController.php
+++ b/app/Http/Controllers/Scp/StaffPreferencesController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Scp;
+
+use App\Http\Controllers\Controller;
+use App\Models\Scp\StaffPreference;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class StaffPreferencesController extends Controller
+{
+    public function show(Request $request): Response
+    {
+        $staffId = (int) $request->user('staff')->staff_id;
+        $preferences = StaffPreference::firstOrCreate(
+            ['staff_id' => $staffId],
+            StaffPreference::defaults($staffId),
+        );
+
+        return Inertia::render('Scp/Preferences/Index', [
+            'preferences' => $preferences->only(['theme', 'language', 'timezone', 'notifications']),
+        ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $staffId = (int) $request->user('staff')->staff_id;
+        $validated = $request->validate([
+            'theme' => ['required', Rule::in(['light', 'dark', 'system'])],
+            'language' => ['nullable', 'string', 'max:16'],
+            'timezone' => ['nullable', 'timezone'],
+            'notifications' => ['array'],
+            'notifications.desktop' => ['boolean'],
+            'notifications.email' => ['boolean'],
+            'notifications.sound' => ['boolean'],
+        ]);
+
+        $defaults = StaffPreference::defaults($staffId);
+        $validated['notifications'] = array_merge(
+            $defaults['notifications'],
+            $validated['notifications'] ?? [],
+        );
+
+        StaffPreference::updateOrCreate(
+            ['staff_id' => $staffId],
+            $validated,
+        );
+
+        return back()->with('status', 'Preferences saved.');
+    }
+}

--- a/app/Http/Controllers/Scp/TicketController.php
+++ b/app/Http/Controllers/Scp/TicketController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Scp;
+
+use App\Http\Controllers\Controller;
+use App\Models\Ticket;
+use App\Services\Scp\TicketReadService;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TicketController extends Controller
+{
+    public function __construct(private readonly TicketReadService $tickets) {}
+
+    public function show(Ticket $ticket): Response
+    {
+        return Inertia::render('Scp/Tickets/Show', $this->tickets->read($ticket));
+    }
+}

--- a/app/Http/Middleware/EnsureScpStaff.php
+++ b/app/Http/Middleware/EnsureScpStaff.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureScpStaff
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $staff = Auth::guard('staff')->user();
+
+        if (! $staff) {
+            if ($request->expectsJson()) {
+                return response()->json(['message' => 'Unauthenticated.'], 401);
+            }
+
+            return redirect()->guest(route('scp.login'));
+        }
+
+        if (! (bool) $staff->isactive) {
+            Auth::guard('staff')->logout();
+
+            abort(403, 'Your staff account is inactive.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/LogScpAccess.php
+++ b/app/Http/Middleware/LogScpAccess.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Scp\ScpAccessLog;
+use Closure;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class LogScpAccess
+{
+    private const SUBJECT_KEYS = ['ticket', 'queue', 'file'];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $staff = Auth::guard('staff')->user();
+        $response = $next($request);
+
+        if ($staff) {
+            $this->writeLog($request, (int) $staff->staff_id, $response);
+        }
+
+        return $response;
+    }
+
+    private function writeLog(Request $request, int $staffId, Response $response): void
+    {
+        ['type' => $subjectType, 'id' => $subjectId] = $this->subject($request);
+
+        try {
+            ScpAccessLog::create([
+                'staff_id' => $staffId,
+                'action' => $request->route()?->getName() ?? $request->method().' '.$request->path(),
+                'subject_type' => $subjectType,
+                'subject_id' => $subjectId,
+                'metadata' => [
+                    'method' => $request->method(),
+                    'path' => '/'.$request->path(),
+                    'status' => $response->getStatusCode(),
+                    'query' => $request->query(),
+                ],
+                'ip_address' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ]);
+        } catch (QueryException) {
+            Log::warning('Unable to write SCP access log; is the osticket2 access_log table migrated?');
+        }
+    }
+
+    /**
+     * @return array{type: ?string, id: ?int}
+     */
+    private function subject(Request $request): array
+    {
+        foreach (self::SUBJECT_KEYS as $name) {
+            $value = $request->route($name);
+
+            if ($value === null) {
+                continue;
+            }
+
+            return ['type' => $name, 'id' => $this->resolveId($value)];
+        }
+
+        return ['type' => null, 'id' => null];
+    }
+
+    private function resolveId(mixed $value): ?int
+    {
+        if (is_object($value)) {
+            return match (true) {
+                isset($value->id) => (int) $value->id,
+                isset($value->ticket_id) => (int) $value->ticket_id,
+                default => null,
+            };
+        }
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+}

--- a/app/Mail/OutboundMailGuard.php
+++ b/app/Mail/OutboundMailGuard.php
@@ -27,7 +27,7 @@ class OutboundMailGuard
 
     private function isPasswordReset(MessageSending $event): bool
     {
-        return trim((string) $event->message->getSubject()) === 'Reset Your Password';
+        return ($event->data['__laravel_mailable'] ?? null) === PasswordResetLinkMail::class;
     }
 
     private function allRecipientsExplicitlyAllowed(MessageSending $event): bool

--- a/app/Mail/OutboundMailGuard.php
+++ b/app/Mail/OutboundMailGuard.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Mail\Events\MessageSending;
+use RuntimeException;
+use Symfony\Component\Mime\Address;
+
+class OutboundMailGuard
+{
+    public function handle(MessageSending $event): void
+    {
+        if (! app()->environment('production')) {
+            return;
+        }
+
+        if ($this->isPasswordReset($event)) {
+            return;
+        }
+
+        if ($this->allRecipientsExplicitlyAllowed($event)) {
+            return;
+        }
+
+        throw new RuntimeException('Outbound mail is disabled for this phase of the SCP migration.');
+    }
+
+    private function isPasswordReset(MessageSending $event): bool
+    {
+        return trim((string) $event->message->getSubject()) === 'Reset Your Password';
+    }
+
+    private function allRecipientsExplicitlyAllowed(MessageSending $event): bool
+    {
+        $allowed = collect(config('mail.outbound_guard.allowed_recipients', []))
+            ->map(fn (string $email): string => strtolower($email))
+            ->all();
+
+        if ($allowed === []) {
+            return false;
+        }
+
+        $recipients = array_merge(
+            $event->message->getTo(),
+            $event->message->getCc(),
+            $event->message->getBcc(),
+        );
+
+        if ($recipients === []) {
+            return false;
+        }
+
+        return collect($recipients)
+            ->map(fn (Address $address): string => strtolower($address->getAddress()))
+            ->every(fn (string $email): bool => in_array($email, $allowed, true));
+    }
+}

--- a/app/Models/Eloquent/Scopes/TicketAccessibleScope.php
+++ b/app/Models/Eloquent/Scopes/TicketAccessibleScope.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models\Eloquent\Scopes;
+
+use App\Models\Staff;
+use App\Services\DepartmentPermissionService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\Auth;
+
+class TicketAccessibleScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $staff = Auth::guard('staff')->user();
+
+        if (! $staff instanceof Staff) {
+            return;
+        }
+
+        $departmentPermissions = app(DepartmentPermissionService::class);
+
+        if ($departmentPermissions->canAccessAllDepartments($staff)) {
+            return;
+        }
+
+        $deptIds = $departmentPermissions->getAccessibleDepartmentIds($staff);
+
+        if ($deptIds === []) {
+            $builder->whereRaw('1 = 0');
+
+            return;
+        }
+
+        $builder->whereIn($model->qualifyColumn('dept_id'), $deptIds);
+    }
+}

--- a/app/Models/Eloquent/Scopes/TicketAccessibleScope.php
+++ b/app/Models/Eloquent/Scopes/TicketAccessibleScope.php
@@ -16,6 +16,8 @@ class TicketAccessibleScope implements Scope
         $staff = Auth::guard('staff')->user();
 
         if (! $staff instanceof Staff) {
+            $builder->whereRaw('1 = 0');
+
             return;
         }
 

--- a/app/Models/Scp/ScpAccessLog.php
+++ b/app/Models/Scp/ScpAccessLog.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\Scp;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ScpAccessLog extends Model
+{
+    protected $connection = 'osticket2';
+
+    protected $table = 'access_log';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'metadata' => 'array',
+        'created_at' => 'immutable_datetime',
+    ];
+}

--- a/app/Models/Scp/StaffPreference.php
+++ b/app/Models/Scp/StaffPreference.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models\Scp;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StaffPreference extends Model
+{
+    protected $connection = 'osticket2';
+
+    protected $table = 'staff_preferences';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'notifications' => 'array',
+    ];
+
+    public static function defaults(int $staffId): array
+    {
+        return [
+            'staff_id' => $staffId,
+            'theme' => 'system',
+            'language' => null,
+            'timezone' => null,
+            'notifications' => [
+                'desktop' => true,
+                'email' => false,
+                'sound' => false,
+            ],
+        ];
+    }
+}

--- a/app/Models/Staff.php
+++ b/app/Models/Staff.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Auth\StaffTwoFactorAuthenticatable;
+use App\Models\Eloquent\Scopes\TicketAccessibleScope;
 use Database\Factories\StaffFactory;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Collection;
@@ -85,7 +86,8 @@ class Staff extends LegacyModel implements Authenticatable
      */
     public function assignedTickets()
     {
-        return $this->hasMany(Ticket::class, 'staff_id', 'staff_id');
+        return $this->hasMany(Ticket::class, 'staff_id', 'staff_id')
+            ->withoutGlobalScope(TicketAccessibleScope::class);
     }
 
     /**

--- a/app/Models/Staff.php
+++ b/app/Models/Staff.php
@@ -38,6 +38,7 @@ class Staff extends LegacyModel implements Authenticatable
 {
     /** @use HasFactory<StaffFactory> */
     use HasFactory;
+
     use HasRoles;
     use StaffTwoFactorAuthenticatable;
 
@@ -163,6 +164,11 @@ class Staff extends LegacyModel implements Authenticatable
             $this->passwd = Hash::make($plainPassword);
             $this->save();
         }
+    }
+
+    public function displayName(): string
+    {
+        return trim($this->firstname.' '.$this->lastname) ?: $this->username;
     }
 
     public function hasTotpEnabled(): bool

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Eloquent\Scopes\TicketAccessibleScope;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
@@ -29,6 +30,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property string $updated
  * @property-read Staff|null      $staff
  * @property-read Department|null $department
+ * @property-read TicketStatus|null $status
  * @property-read Thread|null     $thread
  * @property-read LegacyUser|null $user
  * @property-read TicketCdata|null $cdata
@@ -48,6 +50,11 @@ class Ticket extends LegacyModel
      * @var string
      */
     protected $primaryKey = 'ticket_id';
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new TicketAccessibleScope);
+    }
 
     /**
      * Get the staff member assigned to the ticket.
@@ -75,6 +82,16 @@ class Ticket extends LegacyModel
             'dept_id',
             'id'
         );
+    }
+
+    /**
+     * Get the ticket status.
+     *
+     * @return BelongsTo<TicketStatus, $this>
+     */
+    public function status()
+    {
+        return $this->belongsTo(TicketStatus::class, 'status_id', 'id');
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,13 +3,16 @@
 namespace App\Providers;
 
 use App\Auth\StaffUserProvider;
+use App\Mail\OutboundMailGuard;
 use App\Models\Staff;
 use App\Models\Task;
 use App\Models\Ticket;
 use App\Services\LegacyHasher;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Hashing\HashManager;
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -44,5 +47,7 @@ class AppServiceProvider extends ServiceProvider
                 $app['cache']->store(),
             );
         });
+
+        Event::listen(MessageSending::class, OutboundMailGuard::class);
     }
 }

--- a/app/Services/FileStorage/FileMetadata.php
+++ b/app/Services/FileStorage/FileMetadata.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Services\FileStorage;
+
+class FileMetadata
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly ?string $mime,
+        public readonly int $size,
+    ) {}
+}

--- a/app/Services/FileStorage/FileStorageReader.php
+++ b/app/Services/FileStorage/FileStorageReader.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Services\FileStorage;
+
+use App\Models\File;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+interface FileStorageReader
+{
+    public function exists(File $file): bool;
+
+    public function metadata(File $file): FileMetadata;
+
+    public function stream(File $file): StreamedResponse;
+}

--- a/app/Services/FileStorage/FileStorageReaderResolver.php
+++ b/app/Services/FileStorage/FileStorageReaderResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services\FileStorage;
+
+use App\Models\File;
+use RuntimeException;
+
+class FileStorageReaderResolver
+{
+    public function __construct(
+        private readonly LegacyChunkReader $chunkReader,
+        private readonly LegacyFilesystemReader $filesystemReader,
+    ) {}
+
+    public function resolve(File $file): FileStorageReader
+    {
+        return match ((string) ($file->bk ?? 'D')) {
+            'D', '' => $this->chunkReader,
+            '6' => $this->filesystemReader,
+            default => throw new RuntimeException(sprintf('Unsupported legacy file backend [%s].', $file->bk)),
+        };
+    }
+}

--- a/app/Services/FileStorage/FileStorageReaderResolver.php
+++ b/app/Services/FileStorage/FileStorageReaderResolver.php
@@ -16,7 +16,7 @@ class FileStorageReaderResolver
     {
         return match ((string) ($file->bk ?? 'D')) {
             'D', '' => $this->chunkReader,
-            '6' => $this->filesystemReader,
+            '6', 'F' => $this->filesystemReader,
             default => throw new RuntimeException(sprintf('Unsupported legacy file backend [%s].', $file->bk)),
         };
     }

--- a/app/Services/FileStorage/LegacyChunkReader.php
+++ b/app/Services/FileStorage/LegacyChunkReader.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services\FileStorage;
+
+use App\Models\File;
+use App\Models\FileChunk;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class LegacyChunkReader implements FileStorageReader
+{
+    public function exists(File $file): bool
+    {
+        return FileChunk::query()->where('file_id', $file->id)->exists();
+    }
+
+    public function metadata(File $file): FileMetadata
+    {
+        return new FileMetadata(
+            name: $file->name ?: sprintf('file-%d', $file->id),
+            mime: $file->mime ?: 'application/octet-stream',
+            size: (int) $file->size,
+        );
+    }
+
+    public function stream(File $file): StreamedResponse
+    {
+        $metadata = $this->metadata($file);
+
+        return response()->streamDownload(function () use ($file): void {
+            FileChunk::query()
+                ->where('file_id', $file->id)
+                ->orderBy('chunk_id')
+                ->each(function (FileChunk $chunk): void {
+                    echo $chunk->filedata;
+                    flush();
+                });
+        }, $metadata->name, [
+            'Content-Type' => $metadata->mime ?? 'application/octet-stream',
+            'Content-Length' => (string) $metadata->size,
+        ]);
+    }
+}

--- a/app/Services/FileStorage/LegacyFilesystemReader.php
+++ b/app/Services/FileStorage/LegacyFilesystemReader.php
@@ -128,6 +128,10 @@ class LegacyFilesystemReader implements FileStorageReader
         }
 
         $normalizedRoot = rtrim(str_replace('\\', '/', $resolvedRoot), '/');
+        if ($normalizedRoot === '') {
+            return null;
+        }
+
         $normalizedPath = str_replace('\\', '/', $resolvedPath);
 
         if ($normalizedPath !== $normalizedRoot && ! str_starts_with($normalizedPath, $normalizedRoot.'/')) {

--- a/app/Services/FileStorage/LegacyFilesystemReader.php
+++ b/app/Services/FileStorage/LegacyFilesystemReader.php
@@ -43,12 +43,20 @@ class LegacyFilesystemReader implements FileStorageReader
                 throw new RuntimeException('Failed to open legacy filesystem file for reading.');
             }
 
-            while (! feof($handle)) {
-                echo fread($handle, 1024 * 512);
-                flush();
-            }
+            try {
+                while (! feof($handle)) {
+                    $chunk = fread($handle, 1024 * 512);
 
-            fclose($handle);
+                    if ($chunk === false) {
+                        throw new RuntimeException('Failed while reading legacy filesystem file stream.');
+                    }
+
+                    echo $chunk;
+                    flush();
+                }
+            } finally {
+                fclose($handle);
+            }
         }, $metadata->name, [
             'Content-Type' => $metadata->mime ?? 'application/octet-stream',
             'Content-Length' => (string) $metadata->size,
@@ -72,7 +80,11 @@ class LegacyFilesystemReader implements FileStorageReader
         if (is_array($decoded)) {
             foreach (['path', 'file', 'filename', 'key'] as $key) {
                 if (isset($decoded[$key]) && is_string($decoded[$key])) {
-                    return $this->sandboxedPath($decoded[$key]);
+                    $resolved = $this->sandboxedPath($decoded[$key]);
+
+                    if ($resolved !== null) {
+                        return $resolved;
+                    }
                 }
             }
         }

--- a/app/Services/FileStorage/LegacyFilesystemReader.php
+++ b/app/Services/FileStorage/LegacyFilesystemReader.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services\FileStorage;
+
+use App\Models\File;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class LegacyFilesystemReader implements FileStorageReader
+{
+    public function exists(File $file): bool
+    {
+        $path = $this->path($file);
+
+        return $path !== null && is_file($path);
+    }
+
+    public function metadata(File $file): FileMetadata
+    {
+        $path = $this->path($file);
+
+        return new FileMetadata(
+            name: $file->name ?: basename((string) $path),
+            mime: $file->mime ?: 'application/octet-stream',
+            size: $path && is_file($path) ? (int) filesize($path) : (int) $file->size,
+        );
+    }
+
+    public function stream(File $file): StreamedResponse
+    {
+        $path = $this->path($file);
+
+        if ($path === null || ! is_file($path)) {
+            throw new RuntimeException('Legacy filesystem file is missing.');
+        }
+
+        $metadata = $this->metadata($file);
+
+        return response()->streamDownload(function () use ($path): void {
+            $handle = fopen($path, 'rb');
+
+            if ($handle === false) {
+                return;
+            }
+
+            while (! feof($handle)) {
+                echo fread($handle, 1024 * 512);
+                flush();
+            }
+
+            fclose($handle);
+        }, $metadata->name, [
+            'Content-Type' => $metadata->mime ?? 'application/octet-stream',
+            'Content-Length' => (string) $metadata->size,
+        ]);
+    }
+
+    private function path(File $file): ?string
+    {
+        $attrs = $file->attrs ?? null;
+
+        if (! is_string($attrs) || trim($attrs) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($attrs, true);
+
+        if (is_array($decoded)) {
+            foreach (['path', 'file', 'filename', 'key'] as $key) {
+                if (isset($decoded[$key]) && is_string($decoded[$key])) {
+                    return $decoded[$key];
+                }
+            }
+        }
+
+        return $attrs;
+    }
+}

--- a/app/Services/FileStorage/LegacyFilesystemReader.php
+++ b/app/Services/FileStorage/LegacyFilesystemReader.php
@@ -40,7 +40,7 @@ class LegacyFilesystemReader implements FileStorageReader
             $handle = fopen($path, 'rb');
 
             if ($handle === false) {
-                return;
+                throw new RuntimeException('Failed to open legacy filesystem file for reading.');
             }
 
             while (! feof($handle)) {

--- a/app/Services/FileStorage/LegacyFilesystemReader.php
+++ b/app/Services/FileStorage/LegacyFilesystemReader.php
@@ -57,6 +57,10 @@ class LegacyFilesystemReader implements FileStorageReader
 
     private function path(File $file): ?string
     {
+        if ((string) $file->bk === 'F') {
+            return $this->pluginFilesystemPath($file);
+        }
+
         $attrs = $file->attrs ?? null;
 
         if (! is_string($attrs) || trim($attrs) === '') {
@@ -68,11 +72,56 @@ class LegacyFilesystemReader implements FileStorageReader
         if (is_array($decoded)) {
             foreach (['path', 'file', 'filename', 'key'] as $key) {
                 if (isset($decoded[$key]) && is_string($decoded[$key])) {
-                    return $decoded[$key];
+                    return $this->sandboxedPath($decoded[$key]);
                 }
             }
         }
 
-        return $attrs;
+        return $this->sandboxedPath($attrs);
+    }
+
+    private function pluginFilesystemPath(File $file): ?string
+    {
+        $key = $file->key ?? null;
+
+        if (! is_string($key) || $key === '') {
+            return null;
+        }
+
+        return $this->sandboxedPath($key[0].DIRECTORY_SEPARATOR.$key);
+    }
+
+    private function sandboxedPath(string $candidate): ?string
+    {
+        $root = config('services.osticket.filesystem_root');
+
+        if (! is_string($root) || trim($root) === '') {
+            return null;
+        }
+
+        $resolvedRoot = realpath($root);
+
+        if ($resolvedRoot === false) {
+            return null;
+        }
+
+        $candidate = trim($candidate);
+        $path = str_starts_with($candidate, DIRECTORY_SEPARATOR)
+            ? $candidate
+            : rtrim($resolvedRoot, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$candidate;
+        $resolvedPath = realpath($path);
+
+        if ($resolvedPath === false) {
+            return null;
+        }
+
+        $normalizedRoot = rtrim(str_replace('\\', '/', $resolvedRoot), '/');
+        $normalizedPath = str_replace('\\', '/', $resolvedPath);
+
+        if ($normalizedPath !== $normalizedRoot && ! str_starts_with($normalizedPath, $normalizedRoot.'/')) {
+            return null;
+        }
+
+        return $resolvedPath;
     }
 }

--- a/app/Services/Scp/DashboardService.php
+++ b/app/Services/Scp/DashboardService.php
@@ -2,8 +2,8 @@
 
 namespace App\Services\Scp;
 
-use App\Models\ThreadEvent;
 use App\Models\Staff;
+use App\Models\ThreadEvent;
 use App\Models\Ticket;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
@@ -79,8 +79,8 @@ class DashboardService
                 'unassigned' => 0,
                 'overdue' => 0,
                 'trend' => $this->emptyTrends(),
-                'statusComparison' => $this->emptyStatusComparison(),
-                'channelDistribution' => $this->emptyChannelDistribution(),
+                'statusComparison' => $this->emptyStatusComparison($range),
+                'channelDistribution' => $this->emptyChannelDistribution($range),
                 'recentActivity' => [],
                 'generatedAt' => now()->toIso8601String(),
             ];
@@ -115,8 +115,7 @@ class DashboardService
     }
 
     /**
-     * @param Builder<Ticket> $tickets
-     *
+     * @param  Builder<Ticket>  $tickets
      * @return array{open:int, assignedToMe:int, unassigned:int, overdue:int}
      */
     private function countsFor(Builder $tickets, int $staffId): array
@@ -137,9 +136,8 @@ class DashboardService
     }
 
     /**
-     * @param array{open:int, assignedToMe:int, unassigned:int, overdue:int} $current
-     * @param array{open:int, assignedToMe:int, unassigned:int, overdue:int} $previous
-     *
+     * @param  array{open:int, assignedToMe:int, unassigned:int, overdue:int}  $current
+     * @param  array{open:int, assignedToMe:int, unassigned:int, overdue:int}  $previous
      * @return array<string, array{previous:int, change:int, percent:float|null, direction:string}>
      */
     private function trends(array $current, array $previous): array
@@ -196,10 +194,10 @@ class DashboardService
         $today = now();
 
         return match ($range) {
-            'last_7_days'    => $today->copy()->subDays(6)->startOfDay(),
-            'last_30_days'   => $today->copy()->subDays(29)->startOfDay(),
-            'last_3_months'  => $today->copy()->startOfMonth()->subMonthsNoOverflow(2),
-            default          => $today->copy()->startOfMonth()->subMonthsNoOverflow(5),
+            'last_7_days' => $today->copy()->subDays(6)->startOfDay(),
+            'last_30_days' => $today->copy()->subDays(29)->startOfDay(),
+            'last_3_months' => $today->copy()->startOfMonth()->subMonthsNoOverflow(2),
+            default => $today->copy()->startOfMonth()->subMonthsNoOverflow(5),
         };
     }
 
@@ -257,7 +255,6 @@ class DashboardService
         $counts = [];
 
         Ticket::query()
-            ->whereHas('status', fn ($query) => $query->where('state', 'open'))
             ->whereNotNull('created')
             ->whereBetween('created', [$start->toDateTimeString(), $end->toDateTimeString()])
             ->pluck('created')
@@ -297,13 +294,13 @@ class DashboardService
      *     months:array<int, array{month:string, label:string, open:int, solved:int}>
      * }
      */
-    private function emptyStatusComparison(): array
+    private function emptyStatusComparison(string $range = 'last_6_months'): array
     {
         $today = now();
-        $rangeStart = $today->copy()->startOfMonth()->subMonthsNoOverflow(5);
+        $rangeStart = $this->rangeStart($range);
         $months = [];
 
-        for ($cursor = $rangeStart->copy(); $cursor <= $today; $cursor->addMonthNoOverflow()) {
+        for ($cursor = $rangeStart->copy()->startOfMonth(); $cursor <= $today; $cursor->addMonthNoOverflow()) {
             $month = $cursor->copy()->startOfMonth();
             $months[] = [
                 'month' => $month->toDateString(),
@@ -315,7 +312,7 @@ class DashboardService
 
         return [
             'rangeStart' => $rangeStart->toDateString(),
-            'rangeEnd' => $today->copy()->startOfMonth()->toDateString(),
+            'rangeEnd' => $today->toDateString(),
             'openTotal' => 0,
             'solvedTotal' => 0,
             'months' => $months,
@@ -412,13 +409,13 @@ class DashboardService
      *     channels:array<int, array{key:string, label:string, count:int, percent:float}>
      * }
      */
-    private function emptyChannelDistribution(): array
+    private function emptyChannelDistribution(string $range = 'last_6_months'): array
     {
         $today = now();
 
         return [
-            'rangeStart' => $today->copy()->startOfMonth()->subMonthsNoOverflow(5)->toDateString(),
-            'rangeEnd' => $today->copy()->startOfMonth()->toDateString(),
+            'rangeStart' => $this->rangeStart($range)->toDateString(),
+            'rangeEnd' => $today->toDateString(),
             'total' => 0,
             'channels' => [],
         ];

--- a/app/Services/Scp/DashboardService.php
+++ b/app/Services/Scp/DashboardService.php
@@ -252,18 +252,7 @@ class DashboardService
      */
     private function openCreatedCountsByMonth(CarbonInterface $start, CarbonInterface $end): array
     {
-        $counts = [];
-
-        Ticket::query()
-            ->whereNotNull('created')
-            ->whereBetween('created', [$start->toDateTimeString(), $end->toDateTimeString()])
-            ->pluck('created')
-            ->each(function (string $created) use (&$counts): void {
-                $month = Carbon::parse($created)->startOfMonth()->toDateString();
-                $counts[$month] = ($counts[$month] ?? 0) + 1;
-            });
-
-        return $counts;
+        return $this->countsByMonth('created', $start, $end);
     }
 
     /**
@@ -271,18 +260,33 @@ class DashboardService
      */
     private function solvedCountsByMonth(CarbonInterface $start, CarbonInterface $end): array
     {
-        $counts = [];
+        return $this->countsByMonth('closed', $start, $end);
+    }
 
-        Ticket::query()
-            ->whereNotNull('closed')
-            ->whereBetween('closed', [$start->toDateTimeString(), $end->toDateTimeString()])
-            ->pluck('closed')
-            ->each(function (string $closed) use (&$counts): void {
-                $month = Carbon::parse($closed)->startOfMonth()->toDateString();
-                $counts[$month] = ($counts[$month] ?? 0) + 1;
-            });
+    /**
+     * @return array<string, int>
+     */
+    private function countsByMonth(string $column, CarbonInterface $start, CarbonInterface $end): array
+    {
+        $monthExpression = $this->monthExpression($column);
 
-        return $counts;
+        return Ticket::query()
+            ->selectRaw("{$monthExpression} as month")
+            ->selectRaw('COUNT(*) as total')
+            ->whereNotNull($column)
+            ->whereBetween($column, [$start->toDateTimeString(), $end->toDateTimeString()])
+            ->groupByRaw($monthExpression)
+            ->pluck('total', 'month')
+            ->map(fn (int|string $total): int => (int) $total)
+            ->all();
+    }
+
+    private function monthExpression(string $column): string
+    {
+        return match (Ticket::query()->getConnection()->getDriverName()) {
+            'sqlite' => "strftime('%Y-%m-01', {$column})",
+            default => "DATE_FORMAT({$column}, '%Y-%m-01')",
+        };
     }
 
     /**
@@ -335,13 +339,16 @@ class DashboardService
         $labels = [];
 
         Ticket::query()
+            ->select('source')
+            ->selectRaw('COUNT(*) as total')
             ->whereNotNull('created')
             ->whereBetween('created', [$rangeStart->toDateTimeString(), $today->toDateTimeString()])
-            ->pluck('source')
-            ->each(function (?string $source) use (&$counts, &$labels): void {
-                $label = $this->channelLabel($source);
+            ->groupBy('source')
+            ->get()
+            ->each(function (Ticket $ticket) use (&$counts, &$labels): void {
+                $label = $this->channelLabel($ticket->source);
                 $key = $this->channelKey($label);
-                $counts[$key] = ($counts[$key] ?? 0) + 1;
+                $counts[$key] = ($counts[$key] ?? 0) + (int) $ticket->getAttribute('total');
                 $labels[$key] = $label;
             });
 

--- a/app/Services/Scp/DashboardService.php
+++ b/app/Services/Scp/DashboardService.php
@@ -1,0 +1,422 @@
+<?php
+
+namespace App\Services\Scp;
+
+use App\Models\ThreadEvent;
+use App\Models\Staff;
+use App\Models\Ticket;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\QueryException;
+
+class DashboardService
+{
+    /**
+     * @return array{
+     *     open:int,
+     *     assignedToMe:int,
+     *     unassigned:int,
+     *     overdue:int,
+     *     trend:array<string, array{previous:int, change:int, percent:float|null, direction:string}>,
+     *     statusComparison:array{
+     *         rangeStart:string,
+     *         rangeEnd:string,
+     *         openTotal:int,
+     *         solvedTotal:int,
+     *         months:array<int, array{month:string, label:string, open:int, solved:int}>
+     *     },
+     *     channelDistribution:array{
+     *         rangeStart:string,
+     *         rangeEnd:string,
+     *         total:int,
+     *         channels:array<int, array{key:string, label:string, count:int, percent:float}>
+     *     },
+     *     recentActivity:array<int, array<string, mixed>>,
+     *     generatedAt:string
+     * }
+     */
+    public function summary(Staff $staff, string $range = 'last_6_months'): array
+    {
+        try {
+            $staffId = (int) $staff->staff_id;
+            $currentCounts = $this->countsFor($this->currentOpenTickets(), $staffId);
+            $previousCounts = $this->countsFor(
+                $this->previousMonthOpenTickets(now()->subMonthNoOverflow()->endOfMonth()),
+                $staffId,
+            );
+
+            return [
+                ...$currentCounts,
+                'trend' => $this->trends($currentCounts, $previousCounts),
+                'statusComparison' => $this->statusComparison($range),
+                'channelDistribution' => $this->channelDistribution($range),
+                'recentActivity' => ThreadEvent::query()
+                    ->with(['event', 'thread.ticket.cdata'])
+                    ->whereHas('thread', fn ($query) => $query->where('object_type', 'T'))
+                    ->whereHas('thread.ticket')
+                    ->latest('timestamp')
+                    ->limit(10)
+                    ->get()
+                    ->map(fn (ThreadEvent $event): array => [
+                        'id' => $event->id,
+                        'thread_id' => $event->thread_id,
+                        'event_id' => $event->event_id,
+                        'event' => $event->event?->name,
+                        'ticket_id' => $event->thread?->ticket?->ticket_id,
+                        'ticket_number' => $event->thread?->ticket?->number,
+                        'ticket_subject' => $event->thread?->ticket?->cdata?->subject,
+                        'username' => $event->username,
+                        'timestamp' => $event->timestamp,
+                    ])
+                    ->all(),
+                'generatedAt' => now()->toIso8601String(),
+            ];
+        } catch (QueryException) {
+            return [
+                'open' => 0,
+                'assignedToMe' => 0,
+                'unassigned' => 0,
+                'overdue' => 0,
+                'trend' => $this->emptyTrends(),
+                'statusComparison' => $this->emptyStatusComparison(),
+                'channelDistribution' => $this->emptyChannelDistribution(),
+                'recentActivity' => [],
+                'generatedAt' => now()->toIso8601String(),
+            ];
+        }
+    }
+
+    /**
+     * @return Builder<Ticket>
+     */
+    private function currentOpenTickets(): Builder
+    {
+        return Ticket::query()
+            ->whereHas('status', fn ($query) => $query->where('state', 'open'));
+    }
+
+    /**
+     * Reconstructs the previous month backlog from legacy created/closed columns.
+     *
+     * @return Builder<Ticket>
+     */
+    private function previousMonthOpenTickets(CarbonInterface $asOf): Builder
+    {
+        $asOfDate = $asOf->toDateTimeString();
+
+        return Ticket::query()
+            ->whereNotNull('created')
+            ->where('created', '<=', $asOfDate)
+            ->where(function (Builder $query) use ($asOfDate): void {
+                $query->whereNull('closed')
+                    ->orWhere('closed', '>', $asOfDate);
+            });
+    }
+
+    /**
+     * @param Builder<Ticket> $tickets
+     *
+     * @return array{open:int, assignedToMe:int, unassigned:int, overdue:int}
+     */
+    private function countsFor(Builder $tickets, int $staffId): array
+    {
+        return [
+            'open' => (clone $tickets)->count(),
+            'assignedToMe' => (clone $tickets)
+                ->where('staff_id', $staffId)
+                ->count(),
+            'unassigned' => (clone $tickets)
+                ->where('staff_id', 0)
+                ->where('team_id', 0)
+                ->count(),
+            'overdue' => (clone $tickets)
+                ->where('isoverdue', 1)
+                ->count(),
+        ];
+    }
+
+    /**
+     * @param array{open:int, assignedToMe:int, unassigned:int, overdue:int} $current
+     * @param array{open:int, assignedToMe:int, unassigned:int, overdue:int} $previous
+     *
+     * @return array<string, array{previous:int, change:int, percent:float|null, direction:string}>
+     */
+    private function trends(array $current, array $previous): array
+    {
+        return [
+            'open' => $this->trend($current['open'], $previous['open']),
+            'assignedToMe' => $this->trend($current['assignedToMe'], $previous['assignedToMe']),
+            'unassigned' => $this->trend($current['unassigned'], $previous['unassigned']),
+            'overdue' => $this->trend($current['overdue'], $previous['overdue']),
+        ];
+    }
+
+    /**
+     * @return array{previous:int, change:int, percent:float|null, direction:string}
+     */
+    private function trend(int $current, int $previous): array
+    {
+        $change = $current - $previous;
+
+        if ($previous === 0) {
+            return [
+                'previous' => 0,
+                'change' => $change,
+                'percent' => $current === 0 ? 0.0 : null,
+                'direction' => $current === 0 ? 'flat' : 'new',
+            ];
+        }
+
+        return [
+            'previous' => $previous,
+            'change' => $change,
+            'percent' => round(($change / $previous) * 100, 1),
+            'direction' => $change > 0 ? 'up' : ($change < 0 ? 'down' : 'flat'),
+        ];
+    }
+
+    /**
+     * @return array<string, array{previous:int, change:int, percent:float|null, direction:string}>
+     */
+    private function emptyTrends(): array
+    {
+        return $this->trends(
+            ['open' => 0, 'assignedToMe' => 0, 'unassigned' => 0, 'overdue' => 0],
+            ['open' => 0, 'assignedToMe' => 0, 'unassigned' => 0, 'overdue' => 0],
+        );
+    }
+
+    private function rangeStart(string $range): Carbon
+    {
+        $today = now();
+
+        return match ($range) {
+            'last_7_days'    => $today->copy()->subDays(6)->startOfDay(),
+            'last_30_days'   => $today->copy()->subDays(29)->startOfDay(),
+            'last_3_months'  => $today->copy()->startOfMonth()->subMonthsNoOverflow(2),
+            default          => $today->copy()->startOfMonth()->subMonthsNoOverflow(5),
+        };
+    }
+
+    /**
+     * @return array{
+     *     rangeStart:string,
+     *     rangeEnd:string,
+     *     openTotal:int,
+     *     solvedTotal:int,
+     *     months:array<int, array{month:string, label:string, open:int, solved:int}>
+     * }
+     */
+    private function statusComparison(string $range = 'last_6_months'): array
+    {
+        $today = now();
+        $rangeStart = $this->rangeStart($range);
+        $months = [];
+
+        for ($cursor = $rangeStart->copy()->startOfMonth(); $cursor <= $today; $cursor->addMonthNoOverflow()) {
+            $month = $cursor->copy()->startOfMonth();
+            $months[$month->toDateString()] = [
+                'month' => $month->toDateString(),
+                'label' => $month->format('M'),
+                'open' => 0,
+                'solved' => 0,
+            ];
+        }
+
+        foreach ($this->openCreatedCountsByMonth($rangeStart, $today) as $month => $count) {
+            if (isset($months[$month])) {
+                $months[$month]['open'] = $count;
+            }
+        }
+
+        foreach ($this->solvedCountsByMonth($rangeStart, $today) as $month => $count) {
+            if (isset($months[$month])) {
+                $months[$month]['solved'] = $count;
+            }
+        }
+
+        return [
+            'rangeStart' => $rangeStart->toDateString(),
+            'rangeEnd' => $today->toDateString(),
+            'openTotal' => array_sum(array_column($months, 'open')),
+            'solvedTotal' => array_sum(array_column($months, 'solved')),
+            'months' => array_values($months),
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function openCreatedCountsByMonth(CarbonInterface $start, CarbonInterface $end): array
+    {
+        $counts = [];
+
+        Ticket::query()
+            ->whereHas('status', fn ($query) => $query->where('state', 'open'))
+            ->whereNotNull('created')
+            ->whereBetween('created', [$start->toDateTimeString(), $end->toDateTimeString()])
+            ->pluck('created')
+            ->each(function (string $created) use (&$counts): void {
+                $month = Carbon::parse($created)->startOfMonth()->toDateString();
+                $counts[$month] = ($counts[$month] ?? 0) + 1;
+            });
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function solvedCountsByMonth(CarbonInterface $start, CarbonInterface $end): array
+    {
+        $counts = [];
+
+        Ticket::query()
+            ->whereNotNull('closed')
+            ->whereBetween('closed', [$start->toDateTimeString(), $end->toDateTimeString()])
+            ->pluck('closed')
+            ->each(function (string $closed) use (&$counts): void {
+                $month = Carbon::parse($closed)->startOfMonth()->toDateString();
+                $counts[$month] = ($counts[$month] ?? 0) + 1;
+            });
+
+        return $counts;
+    }
+
+    /**
+     * @return array{
+     *     rangeStart:string,
+     *     rangeEnd:string,
+     *     openTotal:int,
+     *     solvedTotal:int,
+     *     months:array<int, array{month:string, label:string, open:int, solved:int}>
+     * }
+     */
+    private function emptyStatusComparison(): array
+    {
+        $today = now();
+        $rangeStart = $today->copy()->startOfMonth()->subMonthsNoOverflow(5);
+        $months = [];
+
+        for ($cursor = $rangeStart->copy(); $cursor <= $today; $cursor->addMonthNoOverflow()) {
+            $month = $cursor->copy()->startOfMonth();
+            $months[] = [
+                'month' => $month->toDateString(),
+                'label' => $month->format('M'),
+                'open' => 0,
+                'solved' => 0,
+            ];
+        }
+
+        return [
+            'rangeStart' => $rangeStart->toDateString(),
+            'rangeEnd' => $today->copy()->startOfMonth()->toDateString(),
+            'openTotal' => 0,
+            'solvedTotal' => 0,
+            'months' => $months,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     rangeStart:string,
+     *     rangeEnd:string,
+     *     total:int,
+     *     channels:array<int, array{key:string, label:string, count:int, percent:float}>
+     * }
+     */
+    private function channelDistribution(string $range = 'last_6_months'): array
+    {
+        $today = now();
+        $rangeStart = $this->rangeStart($range);
+        $counts = [];
+        $labels = [];
+
+        Ticket::query()
+            ->whereNotNull('created')
+            ->whereBetween('created', [$rangeStart->toDateTimeString(), $today->toDateTimeString()])
+            ->pluck('source')
+            ->each(function (?string $source) use (&$counts, &$labels): void {
+                $label = $this->channelLabel($source);
+                $key = $this->channelKey($label);
+                $counts[$key] = ($counts[$key] ?? 0) + 1;
+                $labels[$key] = $label;
+            });
+
+        arsort($counts);
+        $total = array_sum($counts);
+
+        return [
+            'rangeStart' => $rangeStart->toDateString(),
+            'rangeEnd' => $today->toDateString(),
+            'total' => $total,
+            'channels' => array_map(fn (string $key, int $count): array => [
+                'key' => $key,
+                'label' => $labels[$key],
+                'count' => $count,
+                'percent' => $total > 0 ? round(($count / $total) * 100, 1) : 0.0,
+            ], array_keys($counts), array_values($counts)),
+        ];
+    }
+
+    private function channelLabel(?string $source): string
+    {
+        $label = trim((string) $source);
+
+        if ($label === '') {
+            return 'Other';
+        }
+
+        $knownLabels = [
+            'api' => 'API',
+            'ccm' => 'CCM',
+            'email' => 'Email',
+            'mms' => 'MMS',
+            'phone' => 'Phone',
+            'sms' => 'SMS',
+            'web' => 'Web',
+        ];
+        $normalized = strtolower($label);
+
+        if (isset($knownLabels[$normalized])) {
+            return $knownLabels[$normalized];
+        }
+
+        if ($label === $normalized) {
+            return collect(explode(' ', $label))
+                ->map(fn (string $word): string => ucfirst($word))
+                ->implode(' ');
+        }
+
+        return $label;
+    }
+
+    private function channelKey(string $label): string
+    {
+        $key = strtolower(preg_replace('/[^a-zA-Z0-9]+/', '_', $label) ?? '');
+        $key = trim($key, '_');
+
+        return $key === '' ? 'other' : $key;
+    }
+
+    /**
+     * @return array{
+     *     rangeStart:string,
+     *     rangeEnd:string,
+     *     total:int,
+     *     channels:array<int, array{key:string, label:string, count:int, percent:float}>
+     * }
+     */
+    private function emptyChannelDistribution(): array
+    {
+        $today = now();
+
+        return [
+            'rangeStart' => $today->copy()->startOfMonth()->subMonthsNoOverflow(5)->toDateString(),
+            'rangeEnd' => $today->copy()->startOfMonth()->toDateString(),
+            'total' => 0,
+            'channels' => [],
+        ];
+    }
+}

--- a/app/Services/Scp/DashboardService.php
+++ b/app/Services/Scp/DashboardService.php
@@ -172,7 +172,11 @@ class DashboardService
             'previous' => $previous,
             'change' => $change,
             'percent' => round(($change / $previous) * 100, 1),
-            'direction' => $change > 0 ? 'up' : ($change < 0 ? 'down' : 'flat'),
+            'direction' => match (true) {
+                $change > 0 => 'up',
+                $change < 0 => 'down',
+                default => 'flat',
+            },
         ];
     }
 

--- a/app/Services/Scp/LegacyQueueCriteriaParser.php
+++ b/app/Services/Scp/LegacyQueueCriteriaParser.php
@@ -21,21 +21,21 @@ class LegacyQueueCriteriaParser
      * @var array<string, array{column:string, relation?:string}>
      */
     private const FIELD_MAP = [
-        'ticket_id' => ['column' => 'ticket_id'],
-        'number' => ['column' => 'number'],
-        'dept_id' => ['column' => 'dept_id'],
-        'staff_id' => ['column' => 'staff_id'],
-        'team_id' => ['column' => 'team_id'],
-        'topic_id' => ['column' => 'topic_id'],
-        'status_id' => ['column' => 'status_id'],
-        'source' => ['column' => 'source'],
-        'isoverdue' => ['column' => 'isoverdue'],
-        'isanswered' => ['column' => 'isanswered'],
-        'closed' => ['column' => 'closed'],
-        'created' => ['column' => 'created'],
-        'updated' => ['column' => 'updated'],
-        'lastupdate' => ['column' => 'lastupdate'],
-        'duedate' => ['column' => 'duedate'],
+        'ticket_id' => ['column' => 'ticket.ticket_id'],
+        'number' => ['column' => 'ticket.number'],
+        'dept_id' => ['column' => 'ticket.dept_id'],
+        'staff_id' => ['column' => 'ticket.staff_id'],
+        'team_id' => ['column' => 'ticket.team_id'],
+        'topic_id' => ['column' => 'ticket.topic_id'],
+        'status_id' => ['column' => 'ticket.status_id'],
+        'source' => ['column' => 'ticket.source'],
+        'isoverdue' => ['column' => 'ticket.isoverdue'],
+        'isanswered' => ['column' => 'ticket.isanswered'],
+        'closed' => ['column' => 'ticket.closed'],
+        'created' => ['column' => 'ticket.created'],
+        'updated' => ['column' => 'ticket.updated'],
+        'lastupdate' => ['column' => 'ticket.lastupdate'],
+        'duedate' => ['column' => 'ticket.duedate'],
         'status__state' => ['relation' => 'status', 'column' => 'state'],
         'status__name' => ['relation' => 'status', 'column' => 'name'],
         'cdata.subject' => ['relation' => 'cdata', 'column' => 'subject'],
@@ -268,13 +268,19 @@ class LegacyQueueCriteriaParser
         $teamIds = $includeTeams ? $this->teamIds((int) $staff->staff_id) : [];
 
         if ($operator === 'includes') {
+            if (! $includeMe && (! $includeTeams || $teamIds === [])) {
+                $query->whereRaw('1 = 0');
+
+                return;
+            }
+
             $query->where(function (Builder $query) use ($staff, $includeMe, $includeTeams, $teamIds): void {
                 if ($includeMe) {
-                    $query->orWhere('staff_id', (int) $staff->staff_id);
+                    $query->orWhere('ticket.staff_id', (int) $staff->staff_id);
                 }
 
                 if ($includeTeams && $teamIds !== []) {
-                    $query->orWhereIn('team_id', $teamIds);
+                    $query->orWhereIn('ticket.team_id', $teamIds);
                 }
             });
 
@@ -285,15 +291,15 @@ class LegacyQueueCriteriaParser
             $query->where(function (Builder $query) use ($staff, $includeMe, $includeTeams, $teamIds): void {
                 if ($includeMe) {
                     $query->where(function (Builder $query) use ($staff): void {
-                        $query->whereNull('staff_id')
-                            ->orWhere('staff_id', '!=', (int) $staff->staff_id);
+                        $query->whereNull('ticket.staff_id')
+                            ->orWhere('ticket.staff_id', '!=', (int) $staff->staff_id);
                     });
                 }
 
                 if ($includeTeams && $teamIds !== []) {
                     $query->where(function (Builder $query) use ($teamIds): void {
-                        $query->whereNull('team_id')
-                            ->orWhereNotIn('team_id', $teamIds);
+                        $query->whereNull('ticket.team_id')
+                            ->orWhereNotIn('ticket.team_id', $teamIds);
                     });
                 }
             });

--- a/app/Services/Scp/LegacyQueueCriteriaParser.php
+++ b/app/Services/Scp/LegacyQueueCriteriaParser.php
@@ -288,6 +288,11 @@ class LegacyQueueCriteriaParser
         }
 
         if ($operator === '!includes') {
+            if (! $includeMe && (! $includeTeams || $teamIds === [])) {
+                // Excluding no recognized assignee target intentionally leaves the queue unconstrained.
+                return;
+            }
+
             $query->where(function (Builder $query) use ($staff, $includeMe, $includeTeams, $teamIds): void {
                 if ($includeMe) {
                     $query->where(function (Builder $query) use ($staff): void {

--- a/app/Services/Scp/LegacyQueueCriteriaParser.php
+++ b/app/Services/Scp/LegacyQueueCriteriaParser.php
@@ -1,0 +1,357 @@
+<?php
+
+namespace App\Services\Scp;
+
+use App\Models\Staff;
+use App\Models\TeamMember;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
+
+class LegacyQueueCriteriaParser
+{
+    private const OPERATORS = [
+        'exact', 'gt', 'gte', 'lt', 'lte', 'contains', 'in', 'notin', 'isnull', 'notnull', 'between',
+        'includes', '!includes', 'greater', 'greater_equal', 'less', 'less_equal', 'period',
+    ];
+
+    /**
+     * @var array<string, array{column:string, relation?:string}>
+     */
+    private const FIELD_MAP = [
+        'ticket_id' => ['column' => 'ticket_id'],
+        'number' => ['column' => 'number'],
+        'dept_id' => ['column' => 'dept_id'],
+        'staff_id' => ['column' => 'staff_id'],
+        'team_id' => ['column' => 'team_id'],
+        'topic_id' => ['column' => 'topic_id'],
+        'status_id' => ['column' => 'status_id'],
+        'source' => ['column' => 'source'],
+        'isoverdue' => ['column' => 'isoverdue'],
+        'isanswered' => ['column' => 'isanswered'],
+        'closed' => ['column' => 'closed'],
+        'created' => ['column' => 'created'],
+        'updated' => ['column' => 'updated'],
+        'lastupdate' => ['column' => 'lastupdate'],
+        'duedate' => ['column' => 'duedate'],
+        'status__state' => ['relation' => 'status', 'column' => 'state'],
+        'status__name' => ['relation' => 'status', 'column' => 'name'],
+        'cdata.subject' => ['relation' => 'cdata', 'column' => 'subject'],
+        'cdata.priority' => ['relation' => 'cdata', 'column' => 'priority'],
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public function apply(Builder $query, ?string $config, ?Staff $staff = null): array
+    {
+        $criteria = $this->criteriaFromConfig($config);
+        $unsupported = [];
+
+        foreach ($criteria as $criterion) {
+            try {
+                $this->applyCriterion($query, $criterion, $staff);
+            } catch (InvalidArgumentException $exception) {
+                $unsupported[] = $exception->getMessage();
+            }
+        }
+
+        return $unsupported;
+    }
+
+    /**
+     * @return list<array{0:string,1:string,2:mixed}>
+     */
+    private function criteriaFromConfig(?string $config): array
+    {
+        if ($config === null || trim($config) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($config, true);
+
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        $rawCriteria = $this->looksLikeCriteriaList($decoded)
+            ? $decoded
+            : Arr::get($decoded, 'criteria', Arr::get($decoded, 'filter', []));
+
+        if (! is_array($rawCriteria)) {
+            return [];
+        }
+
+        $criteria = [];
+
+        foreach ($rawCriteria as $item) {
+            if (! is_array($item) || count($item) < 2) {
+                continue;
+            }
+
+            $field = (string) ($item[0] ?? '');
+            $operator = (string) ($item[1] ?? 'exact');
+            $value = $item[2] ?? null;
+
+            if ($field === '') {
+                continue;
+            }
+
+            $criteria[] = [$field, $operator, $value];
+        }
+
+        return $criteria;
+    }
+
+    /**
+     * @param  array<mixed>  $decoded
+     */
+    private function looksLikeCriteriaList(array $decoded): bool
+    {
+        $first = reset($decoded);
+
+        return is_array($first)
+            && isset($first[0], $first[1])
+            && is_string($first[0])
+            && is_string($first[1]);
+    }
+
+    /**
+     * @param  array{0:string,1:string,2:mixed}  $criterion
+     */
+    private function applyCriterion(Builder $query, array $criterion, ?Staff $staff): void
+    {
+        [$field, $operator, $value] = $criterion;
+        [$field, $operator] = $this->normalizeFieldAndOperator($field, $operator);
+
+        if ($field === 'assignee') {
+            $this->applyAssigneeCriterion($query, $operator, $value, $staff);
+
+            return;
+        }
+
+        if ($field === 'thread_count') {
+            $this->applyThreadCountCriterion($query, $operator, $value);
+
+            return;
+        }
+
+        $mapping = self::FIELD_MAP[$field] ?? null;
+
+        if ($mapping === null) {
+            throw new InvalidArgumentException("Unsupported queue field [{$field}].");
+        }
+
+        $callback = function (Builder $builder) use ($mapping, $operator, $value): void {
+            $this->applyOperator($builder, $mapping['column'], $operator, $value);
+        };
+
+        if (isset($mapping['relation'])) {
+            $query->whereHas($mapping['relation'], $callback);
+
+            return;
+        }
+
+        $callback($query);
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function normalizeFieldAndOperator(string $field, string $operator): array
+    {
+        $operator = strtolower($operator ?: 'exact');
+        $parts = explode('__', $field);
+        $lastPart = end($parts);
+
+        if (in_array($lastPart, self::OPERATORS, true)) {
+            array_pop($parts);
+
+            return [implode('__', $parts), $lastPart];
+        }
+
+        return [$field, $operator];
+    }
+
+    private function applyOperator(Builder $query, string $column, string $operator, mixed $value): void
+    {
+        $operator = $this->normalizeOperator($operator);
+
+        match ($operator) {
+            'exact' => $query->where($column, $value),
+            'gt' => $query->where($column, '>', $value),
+            'gte' => $query->where($column, '>=', $value),
+            'lt' => $query->where($column, '<', $value),
+            'lte' => $query->where($column, '<=', $value),
+            'contains' => $query->where($column, 'like', '%'.str_replace(['%', '_'], ['\%', '\_'], (string) $value).'%'),
+            'in' => $query->whereIn($column, $this->optionValues($value)),
+            'notin' => $query->whereNotIn($column, $this->optionValues($value)),
+            'isnull' => $query->whereNull($column),
+            'notnull' => $query->whereNotNull($column),
+            'between' => $query->whereBetween($column, $this->betweenValue($value)),
+            'period' => $this->applyPeriod($query, $column, (string) $value),
+            default => throw new InvalidArgumentException("Unsupported queue operator [{$operator}]."),
+        };
+    }
+
+    private function normalizeOperator(string $operator): string
+    {
+        return match (strtolower($operator)) {
+            'includes' => 'in',
+            '!includes' => 'notin',
+            'greater' => 'gt',
+            'greater_equal' => 'gte',
+            'less' => 'lt',
+            'less_equal' => 'lte',
+            default => strtolower($operator),
+        };
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function arrayValue(mixed $value): array
+    {
+        if (is_array($value)) {
+            return array_values($value);
+        }
+
+        if (is_string($value) && str_contains($value, ',')) {
+            return array_map('trim', explode(',', $value));
+        }
+
+        return [$value];
+    }
+
+    /**
+     * osTicket stores select options as JSON objects keyed by actual values:
+     * {"open":"Open"}, {"3":"Department"}. For those criteria, keys are the
+     * values the SQL layer should compare against.
+     *
+     * @return array<int, mixed>
+     */
+    private function optionValues(mixed $value): array
+    {
+        if (is_array($value) && ! array_is_list($value)) {
+            return array_keys($value);
+        }
+
+        return $this->arrayValue($value);
+    }
+
+    /**
+     * @return array{0:mixed,1:mixed}
+     */
+    private function betweenValue(mixed $value): array
+    {
+        $values = $this->arrayValue($value);
+
+        if (count($values) < 2) {
+            throw new InvalidArgumentException('Unsupported queue between value.');
+        }
+
+        return [$values[0], $values[1]];
+    }
+
+    private function applyAssigneeCriterion(Builder $query, string $operator, mixed $value, ?Staff $staff): void
+    {
+        if (! $staff) {
+            throw new InvalidArgumentException('Unsupported queue field [assignee] without staff context.');
+        }
+
+        $operator = strtolower($operator);
+        $values = $this->optionValues($value);
+        $includeMe = in_array('M', $values, true);
+        $includeTeams = in_array('T', $values, true);
+        $teamIds = $includeTeams ? $this->teamIds((int) $staff->staff_id) : [];
+
+        if ($operator === 'includes') {
+            $query->where(function (Builder $query) use ($staff, $includeMe, $includeTeams, $teamIds): void {
+                if ($includeMe) {
+                    $query->orWhere('staff_id', (int) $staff->staff_id);
+                }
+
+                if ($includeTeams && $teamIds !== []) {
+                    $query->orWhereIn('team_id', $teamIds);
+                }
+            });
+
+            return;
+        }
+
+        if ($operator === '!includes') {
+            $query->where(function (Builder $query) use ($staff, $includeMe, $includeTeams, $teamIds): void {
+                if ($includeMe) {
+                    $query->where(function (Builder $query) use ($staff): void {
+                        $query->whereNull('staff_id')
+                            ->orWhere('staff_id', '!=', (int) $staff->staff_id);
+                    });
+                }
+
+                if ($includeTeams && $teamIds !== []) {
+                    $query->where(function (Builder $query) use ($teamIds): void {
+                        $query->whereNull('team_id')
+                            ->orWhereNotIn('team_id', $teamIds);
+                    });
+                }
+            });
+
+            return;
+        }
+
+        throw new InvalidArgumentException("Unsupported queue operator [{$operator}] for assignee.");
+    }
+
+    private function applyThreadCountCriterion(Builder $query, string $operator, mixed $value): void
+    {
+        $operator = $this->normalizeOperator($operator);
+        $count = (int) $value;
+
+        match ($operator) {
+            'gt' => $query->has('thread.entries', '>', $count),
+            'gte' => $query->has('thread.entries', '>=', $count),
+            'lt' => $query->has('thread.entries', '<', $count),
+            'lte' => $query->has('thread.entries', '<=', $count),
+            'exact' => $query->has('thread.entries', '=', $count),
+            default => throw new InvalidArgumentException("Unsupported queue operator [{$operator}] for thread_count."),
+        };
+    }
+
+    private function applyPeriod(Builder $query, string $column, string $period): void
+    {
+        $now = CarbonImmutable::now();
+
+        [$start, $end] = match ($period) {
+            'td' => [$now->startOfDay(), $now->endOfDay()],
+            'yd' => [$now->subDay()->startOfDay(), $now->subDay()->endOfDay()],
+            'tw' => [$now->startOfWeek(), $now->endOfWeek()],
+            'tm' => [$now->startOfMonth(), $now->endOfMonth()],
+            'tq' => [$now->startOfQuarter(), $now->endOfQuarter()],
+            'ty' => [$now->startOfYear(), $now->endOfYear()],
+            default => throw new InvalidArgumentException("Unsupported queue period [{$period}]."),
+        };
+
+        $query->whereBetween($column, [
+            $start->toDateTimeString(),
+            $end->toDateTimeString(),
+        ]);
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function teamIds(int $staffId): array
+    {
+        try {
+            return TeamMember::query()
+                ->where('staff_id', $staffId)
+                ->pluck('team_id')
+                ->map(fn (mixed $teamId): int => (int) $teamId)
+                ->all();
+        } catch (QueryException) {
+            return [];
+        }
+    }
+}

--- a/app/Services/Scp/QueueExportService.php
+++ b/app/Services/Scp/QueueExportService.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Services\Scp;
+
+use App\Models\Queue;
+use App\Models\QueueExport;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\TicketPriority;
+use Illuminate\Database\QueryException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class QueueExportService
+{
+    private const DEFAULT_FIELDS = ['number', 'created', 'subject', 'from', 'priority', 'assignee'];
+
+    public function __construct(private readonly LegacyQueueCriteriaParser $criteriaParser) {}
+
+    public function stream(Queue $queue, Staff $staff): StreamedResponse
+    {
+        $fields = $this->fields($queue);
+
+        return response()->streamDownload(function () use ($queue, $staff, $fields): void {
+            $output = fopen('php://output', 'w');
+            fputcsv($output, array_map(fn (string $field): string => $this->heading($field), $fields));
+
+            $query = Ticket::query()
+                ->with(['cdata', 'staff', 'user.defaultEmail', 'status'])
+                ->orderBy('ticket_id');
+
+            $unsupported = $this->criteriaParser->apply($query, $queue->config, $staff);
+
+            if ($unsupported !== []) {
+                fputcsv($output, ['Unsupported queue criteria: '.implode('; ', $unsupported)]);
+                fclose($output);
+
+                return;
+            }
+
+            $query->chunkById(1000, function ($tickets) use ($output, $fields): void {
+                $priorityNames = $this->priorityNames($tickets->pluck('cdata.priority')->filter()->all());
+
+                foreach ($tickets as $ticket) {
+                    fputcsv($output, array_map(
+                        fn (string $field): mixed => $this->value($ticket, $field, $priorityNames),
+                        $fields,
+                    ));
+                }
+
+                flush();
+            }, 'ticket_id');
+
+            fclose($output);
+        }, sprintf('queue-%d.csv', $queue->id), [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fields(Queue $queue): array
+    {
+        try {
+            $export = QueueExport::query()
+                ->where('queue_id', $queue->id)
+                ->orderBy('id')
+                ->first();
+        } catch (QueryException) {
+            return self::DEFAULT_FIELDS;
+        }
+
+        if (! $export || ! is_string($export->config)) {
+            return self::DEFAULT_FIELDS;
+        }
+
+        $decoded = json_decode($export->config, true);
+        $fields = is_array($decoded)
+            ? ($decoded['fields'] ?? $decoded['columns'] ?? $decoded)
+            : [];
+
+        if (! is_array($fields)) {
+            return self::DEFAULT_FIELDS;
+        }
+
+        $fields = array_values(array_filter(array_map(
+            fn (mixed $field): ?string => is_string($field) ? $field : null,
+            $fields,
+        )));
+
+        return $fields !== [] ? $fields : self::DEFAULT_FIELDS;
+    }
+
+    private function heading(string $field): string
+    {
+        return str($field)->replace(['cdata.', '__'], ['', ' '])->replace('_', ' ')->title()->toString();
+    }
+
+    /**
+     * @param  array<string, string>  $priorityNames
+     */
+    private function value(Ticket $ticket, string $field, array $priorityNames): mixed
+    {
+        return match ($field) {
+            'ticket_id', 'id' => $ticket->ticket_id,
+            'number' => $ticket->number,
+            'created' => $ticket->created,
+            'updated' => $ticket->updated,
+            'closed' => $ticket->closed,
+            'status', 'status__name' => $ticket->status?->name,
+            'status__state' => $ticket->status?->state,
+            'dept_id' => $ticket->dept_id,
+            'staff_id' => $ticket->staff_id,
+            'assignee' => $ticket->staff?->displayName(),
+            'from', 'requester' => $ticket->user?->name ?: $ticket->user?->defaultEmail?->address,
+            'cdata.subject', 'subject' => $ticket->cdata?->subject,
+            'cdata.priority', 'priority' => $priorityNames[(string) $ticket->cdata?->priority] ?? $ticket->cdata?->priority,
+            default => data_get($ticket, $field),
+        };
+    }
+
+    /**
+     * @param  array<int, mixed>  $priorityIds
+     * @return array<string, string>
+     */
+    private function priorityNames(array $priorityIds): array
+    {
+        $priorityIds = array_values(array_unique(array_filter($priorityIds, is_numeric(...))));
+
+        if ($priorityIds === []) {
+            return [];
+        }
+
+        try {
+            return TicketPriority::query()
+                ->whereIn('priority_id', $priorityIds)
+                ->pluck('priority', 'priority_id')
+                ->mapWithKeys(fn (string $name, int|string $id): array => [(string) $id => $name])
+                ->all();
+        } catch (QueryException) {
+            return [];
+        }
+    }
+}

--- a/app/Services/Scp/QueueExportService.php
+++ b/app/Services/Scp/QueueExportService.php
@@ -14,6 +14,25 @@ class QueueExportService
 {
     private const DEFAULT_FIELDS = ['number', 'created', 'subject', 'from', 'priority', 'assignee'];
 
+    private const SAFE_DATA_FIELDS = [
+        'topic_id',
+        'team_id',
+        'sla_id',
+        'email_id',
+        'source',
+        'ip_address',
+        'duedate',
+        'lastupdate',
+        'lastmessage',
+        'lastresponse',
+        'isoverdue',
+        'isanswered',
+        'status.name',
+        'status.state',
+        'user.name',
+        'user.defaultEmail.address',
+    ];
+
     public function __construct(private readonly LegacyQueueCriteriaParser $criteriaParser) {}
 
     public function stream(Queue $queue, Staff $staff): StreamedResponse
@@ -115,7 +134,7 @@ class QueueExportService
             'from', 'requester' => $ticket->user?->name ?: $ticket->user?->defaultEmail?->address,
             'cdata.subject', 'subject' => $ticket->cdata?->subject,
             'cdata.priority', 'priority' => $priorityNames[(string) $ticket->cdata?->priority] ?? $ticket->cdata?->priority,
-            default => data_get($ticket, $field),
+            default => in_array($field, self::SAFE_DATA_FIELDS, true) ? data_get($ticket, $field) : null,
         };
     }
 

--- a/app/Services/Scp/QueueService.php
+++ b/app/Services/Scp/QueueService.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\QueryException;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 
 class QueueService
 {
@@ -128,7 +129,6 @@ class QueueService
      *   created_from?: ?string,
      *   created_to?: ?string
      * }  $filters
-     *
      * @return array{
      *   tickets: array<int, array{id:int,number:string,created:?string,subject:?string,from:?string,priority:?string,assignee:?string,status:?string,status_state:?string,source:?string}>,
      *   pagination: array{page:int,perPage:int,total:int},
@@ -149,17 +149,37 @@ class QueueService
             ->select('ticket.*')
             ->with(['cdata', 'staff', 'status', 'user.defaultEmail']);
 
-        $unsupportedReasons = $this->criteriaParser->apply($query, $queue->config, $staff);
+        $unsupportedReasons = [];
 
-        $this->applyFilters($query, $filters);
-        $this->applySort($query, $sort, $direction);
+        try {
+            $unsupportedReasons = $this->criteriaParser->apply($query, $queue->config, $staff);
+            $this->applyFilters($query, $filters);
+            $this->applySort($query, $sort, $direction);
 
-        $paginator = $query->paginate(
-            perPage: $perPage,
-            columns: ['ticket.*'],
-            pageName: 'page',
-            page: $page,
-        );
+            $paginator = $query->paginate(
+                perPage: $perPage,
+                columns: ['ticket.*'],
+                pageName: 'page',
+                page: $page,
+            );
+        } catch (QueryException $exception) {
+            Log::warning('Unable to read SCP queue ticket rows from legacy database.', [
+                'queue_id' => (int) $queue->id,
+                'staff_id' => (int) $staff->staff_id,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return [
+                'tickets' => [],
+                'pagination' => [
+                    'page' => $page,
+                    'perPage' => $perPage,
+                    'total' => 0,
+                ],
+                'unsupported' => false,
+                'unsupportedReasons' => $unsupportedReasons,
+            ];
+        }
 
         return [
             'tickets' => $this->mapRows($paginator),
@@ -257,7 +277,7 @@ class QueueService
                 break;
             case 'priority':
                 $query->leftJoin('ticket__cdata as sort_cdata', 'sort_cdata.ticket_id', '=', 'ticket.ticket_id')
-                    ->orderBy('sort_cdata.priority', $direction);
+                    ->orderByRaw($this->numericPrioritySortExpression().' '.$direction);
                 break;
             case 'from':
                 $query->leftJoin('user as sort_user', 'sort_user.id', '=', 'ticket.user_id')
@@ -275,6 +295,16 @@ class QueueService
         }
 
         $query->orderBy('ticket.ticket_id', 'desc');
+    }
+
+    private function numericPrioritySortExpression(): string
+    {
+        $driver = Ticket::query()->getConnection()->getDriverName();
+        $alias = Ticket::query()->getConnection()->getTablePrefix().'sort_cdata';
+
+        return in_array($driver, ['mysql', 'mariadb'], true)
+            ? "CAST({$alias}.priority AS UNSIGNED)"
+            : "CAST({$alias}.priority AS INTEGER)";
     }
 
     /**

--- a/app/Services/Scp/QueueService.php
+++ b/app/Services/Scp/QueueService.php
@@ -6,6 +6,7 @@ use App\Models\Queue;
 use App\Models\Staff;
 use App\Models\Ticket;
 use App\Models\TicketPriority;
+use App\Models\TicketStatus;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\QueryException;
@@ -19,6 +20,8 @@ class QueueService
     private const FLAG_QUEUE = 0x0002;
 
     private const FLAG_DISABLED = 0x0004;
+
+    private const COMMON_SOURCES = ['Email', 'Web', 'Phone', 'API', 'SMS', 'MMS', 'CCM', 'Other'];
 
     public function __construct(private readonly LegacyQueueCriteriaParser $criteriaParser) {}
 
@@ -118,26 +121,42 @@ class QueueService
     }
 
     /**
+     * @param  array{
+     *   state?: list<string>,
+     *   source?: list<string>,
+     *   priority?: list<int>,
+     *   created_from?: ?string,
+     *   created_to?: ?string
+     * }  $filters
+     *
      * @return array{
-     *   tickets: array<int, array{id:int,number:string,created:?string,subject:?string,from:?string,priority:?string,assignee:?string}>,
+     *   tickets: array<int, array{id:int,number:string,created:?string,subject:?string,from:?string,priority:?string,assignee:?string,status:?string,status_state:?string,source:?string}>,
      *   pagination: array{page:int,perPage:int,total:int},
      *   unsupported: bool,
      *   unsupportedReasons: list<string>
      * }
      */
-    public function ticketRows(Queue $queue, Staff $staff, int $page): array
-    {
+    public function ticketRows(
+        Queue $queue,
+        Staff $staff,
+        int $page,
+        array $filters = [],
+        string $sort = 'created',
+        string $direction = 'desc',
+    ): array {
         $perPage = $this->perPage($staff);
         $query = Ticket::query()
-            ->with(['cdata', 'staff', 'user.defaultEmail'])
-            ->orderByDesc('created')
-            ->orderByDesc('ticket_id');
+            ->select('ticket.*')
+            ->with(['cdata', 'staff', 'status', 'user.defaultEmail']);
 
         $unsupportedReasons = $this->criteriaParser->apply($query, $queue->config, $staff);
 
+        $this->applyFilters($query, $filters);
+        $this->applySort($query, $sort, $direction);
+
         $paginator = $query->paginate(
             perPage: $perPage,
-            columns: ['*'],
+            columns: ['ticket.*'],
             pageName: 'page',
             page: $page,
         );
@@ -152,6 +171,110 @@ class QueueService
             'unsupported' => $unsupportedReasons !== [],
             'unsupportedReasons' => $unsupportedReasons,
         ];
+    }
+
+    /**
+     * @return array{
+     *   states: list<string>,
+     *   sources: list<string>,
+     *   priorities: list<array{id:int,name:string}>
+     * }
+     */
+    public function filterOptions(): array
+    {
+        try {
+            $states = TicketStatus::query()
+                ->select('state')
+                ->distinct()
+                ->orderBy('state')
+                ->pluck('state')
+                ->filter()
+                ->values()
+                ->all();
+
+            $priorities = TicketPriority::query()
+                ->orderBy('priority_urgency')
+                ->orderBy('priority')
+                ->get(['priority_id', 'priority'])
+                ->map(fn (TicketPriority $row): array => [
+                    'id' => (int) $row->priority_id,
+                    'name' => (string) $row->priority,
+                ])
+                ->all();
+
+            return [
+                'states' => $states,
+                'sources' => self::COMMON_SOURCES,
+                'priorities' => $priorities,
+            ];
+        } catch (QueryException) {
+            return [
+                'states' => [],
+                'sources' => self::COMMON_SOURCES,
+                'priorities' => [],
+            ];
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    private function applyFilters(Builder $query, array $filters): void
+    {
+        $states = $filters['state'] ?? [];
+        if (is_array($states) && $states !== []) {
+            $query->whereHas('status', fn (Builder $sub) => $sub->whereIn('state', $states));
+        }
+
+        $sources = $filters['source'] ?? [];
+        if (is_array($sources) && $sources !== []) {
+            $query->whereIn('ticket.source', $sources);
+        }
+
+        $priorities = $filters['priority'] ?? [];
+        if (is_array($priorities) && $priorities !== []) {
+            $query->whereHas('cdata', fn (Builder $sub) => $sub->whereIn('priority', $priorities));
+        }
+
+        $createdFrom = $filters['created_from'] ?? null;
+        if (is_string($createdFrom) && $createdFrom !== '') {
+            $query->where('ticket.created', '>=', $createdFrom.' 00:00:00');
+        }
+
+        $createdTo = $filters['created_to'] ?? null;
+        if (is_string($createdTo) && $createdTo !== '') {
+            $query->where('ticket.created', '<=', $createdTo.' 23:59:59');
+        }
+    }
+
+    private function applySort(Builder $query, string $sort, string $direction): void
+    {
+        $direction = strtolower($direction) === 'asc' ? 'asc' : 'desc';
+
+        switch ($sort) {
+            case 'number':
+                $query->orderBy('ticket.number', $direction);
+                break;
+            case 'priority':
+                $query->leftJoin('ticket__cdata as sort_cdata', 'sort_cdata.ticket_id', '=', 'ticket.ticket_id')
+                    ->orderBy('sort_cdata.priority', $direction);
+                break;
+            case 'from':
+                $query->leftJoin('user as sort_user', 'sort_user.id', '=', 'ticket.user_id')
+                    ->orderBy('sort_user.name', $direction);
+                break;
+            case 'assignee':
+                $query->leftJoin('staff as sort_staff', 'sort_staff.staff_id', '=', 'ticket.staff_id')
+                    ->orderBy('sort_staff.firstname', $direction)
+                    ->orderBy('sort_staff.lastname', $direction);
+                break;
+            case 'created':
+            default:
+                $query->orderBy('ticket.created', $direction);
+                break;
+        }
+
+        $query->orderBy('ticket.ticket_id', 'desc');
     }
 
     /**
@@ -183,7 +306,7 @@ class QueueService
     }
 
     /**
-     * @return array<int, array{id:int,number:string,created:?string,subject:?string,from:?string,priority:?string,assignee:?string}>
+     * @return array<int, array{id:int,number:string,created:?string,subject:?string,from:?string,priority:?string,assignee:?string,status:?string,status_state:?string,source:?string}>
      */
     private function mapRows(LengthAwarePaginator $paginator): array
     {
@@ -200,6 +323,9 @@ class QueueService
                 'from' => $ticket->user?->name ?: $ticket->user?->defaultEmail?->address,
                 'priority' => $priorityNames[(string) $ticket->cdata?->priority] ?? $ticket->cdata?->priority,
                 'assignee' => $ticket->staff?->displayName(),
+                'status' => $ticket->status?->name,
+                'status_state' => $ticket->status?->state,
+                'source' => $ticket->source ?: null,
             ])
             ->values()
             ->all();

--- a/app/Services/Scp/QueueService.php
+++ b/app/Services/Scp/QueueService.php
@@ -176,7 +176,7 @@ class QueueService
                     'perPage' => $perPage,
                     'total' => 0,
                 ],
-                'unsupported' => false,
+                'unsupported' => $unsupportedReasons !== [],
                 'unsupportedReasons' => $unsupportedReasons,
             ];
         }

--- a/app/Services/Scp/QueueService.php
+++ b/app/Services/Scp/QueueService.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace App\Services\Scp;
+
+use App\Models\Queue;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\TicketPriority;
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\QueryException;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+class QueueService
+{
+    private const FLAG_PUBLIC = 0x0001;
+
+    private const FLAG_QUEUE = 0x0002;
+
+    private const FLAG_DISABLED = 0x0004;
+
+    public function __construct(private readonly LegacyQueueCriteriaParser $criteriaParser) {}
+
+    /**
+     * @return array{
+     *   queues: array<int, array<string, mixed>>,
+     *   personal: array<int, array<string, mixed>>,
+     *   savedSearches: array<int, array{id:int,title:string}>
+     * }
+     */
+    public function visibleQueues(int $staffId): array
+    {
+        try {
+            return [
+                'queues' => $this->fetchTree(fn (Builder $query) => $query
+                    ->where('staff_id', 0)
+                    ->whereRaw('(flags & ?) = ?', [self::FLAG_QUEUE, self::FLAG_QUEUE])
+                    ->whereRaw('(flags & ?) = ?', [self::FLAG_PUBLIC, self::FLAG_PUBLIC])
+                    ->whereRaw('(flags & ?) = 0', [self::FLAG_DISABLED])),
+                'personal' => $this->fetchTree(fn (Builder $query) => $query
+                    ->where('staff_id', $staffId)
+                    ->whereRaw('(flags & ?) = ?', [self::FLAG_QUEUE, self::FLAG_QUEUE])
+                    ->whereRaw('(flags & ?) = 0', [self::FLAG_DISABLED])),
+                'savedSearches' => Queue::query()
+                    ->where('staff_id', $staffId)
+                    ->whereRaw('(flags & ?) = 0', [self::FLAG_QUEUE])
+                    ->whereRaw('(flags & ?) = 0', [self::FLAG_DISABLED])
+                    ->orderBy('title')
+                    ->get(['id', 'title'])
+                    ->map(fn (Queue $queue): array => [
+                        'id' => (int) $queue->id,
+                        'title' => (string) $queue->title,
+                    ])
+                    ->all(),
+            ];
+        } catch (QueryException) {
+            return ['queues' => [], 'personal' => [], 'savedSearches' => []];
+        }
+    }
+
+    public function defaultQueueId(int $staffId): ?int
+    {
+        try {
+            $firstPublic = Queue::query()
+                ->where('staff_id', 0)
+                ->whereRaw('(flags & ?) = ?', [self::FLAG_QUEUE, self::FLAG_QUEUE])
+                ->whereRaw('(flags & ?) = ?', [self::FLAG_PUBLIC, self::FLAG_PUBLIC])
+                ->whereRaw('(flags & ?) = 0', [self::FLAG_DISABLED])
+                ->orderByRaw('COALESCE(parent_id, 0)')
+                ->orderBy('sort')
+                ->orderBy('title')
+                ->value('id');
+
+            if ($firstPublic !== null) {
+                return (int) $firstPublic;
+            }
+
+            $firstPersonal = Queue::query()
+                ->where('staff_id', $staffId)
+                ->whereRaw('(flags & ?) = ?', [self::FLAG_QUEUE, self::FLAG_QUEUE])
+                ->whereRaw('(flags & ?) = 0', [self::FLAG_DISABLED])
+                ->orderBy('sort')
+                ->orderBy('title')
+                ->value('id');
+
+            if ($firstPersonal !== null) {
+                return (int) $firstPersonal;
+            }
+
+            $firstSavedSearch = Queue::query()
+                ->where('staff_id', $staffId)
+                ->whereRaw('(flags & ?) = 0', [self::FLAG_QUEUE])
+                ->whereRaw('(flags & ?) = 0', [self::FLAG_DISABLED])
+                ->orderBy('title')
+                ->value('id');
+
+            return $firstSavedSearch !== null ? (int) $firstSavedSearch : null;
+        } catch (QueryException) {
+            return null;
+        }
+    }
+
+    public function canViewQueue(Queue $queue, int $staffId): bool
+    {
+        $flags = (int) $queue->flags;
+
+        if (($flags & self::FLAG_DISABLED) === self::FLAG_DISABLED) {
+            return false;
+        }
+
+        if ((int) $queue->staff_id === $staffId) {
+            return true;
+        }
+
+        return (int) $queue->staff_id === 0
+            && ($flags & self::FLAG_PUBLIC) === self::FLAG_PUBLIC;
+    }
+
+    /**
+     * @return array{
+     *   tickets: array<int, array{id:int,number:string,created:?string,subject:?string,from:?string,priority:?string,assignee:?string}>,
+     *   pagination: array{page:int,perPage:int,total:int},
+     *   unsupported: bool,
+     *   unsupportedReasons: list<string>
+     * }
+     */
+    public function ticketRows(Queue $queue, Staff $staff, int $page): array
+    {
+        $perPage = $this->perPage($staff);
+        $query = Ticket::query()
+            ->with(['cdata', 'staff', 'user.defaultEmail'])
+            ->orderByDesc('created')
+            ->orderByDesc('ticket_id');
+
+        $unsupportedReasons = $this->criteriaParser->apply($query, $queue->config, $staff);
+
+        $paginator = $query->paginate(
+            perPage: $perPage,
+            columns: ['*'],
+            pageName: 'page',
+            page: $page,
+        );
+
+        return [
+            'tickets' => $this->mapRows($paginator),
+            'pagination' => [
+                'page' => $paginator->currentPage(),
+                'perPage' => $paginator->perPage(),
+                'total' => $paginator->total(),
+            ],
+            'unsupported' => $unsupportedReasons !== [],
+            'unsupportedReasons' => $unsupportedReasons,
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchTree(Closure $constraint): array
+    {
+        $items = Queue::query()
+            ->tap($constraint)
+            ->orderByRaw('COALESCE(parent_id, 0)')
+            ->orderBy('sort')
+            ->orderBy('title')
+            ->get(['id', 'parent_id', 'title']);
+
+        $byParent = $items->groupBy(fn (Queue $queue): int => (int) ($queue->parent_id ?? 0));
+
+        return $this->buildTree($byParent, 0);
+    }
+
+    private function perPage(Staff $staff): int
+    {
+        $pageLimit = (int) ($staff->pagelimit ?? 25);
+
+        if ($pageLimit <= 0) {
+            return 25;
+        }
+
+        return max(10, min($pageLimit, 100));
+    }
+
+    /**
+     * @return array<int, array{id:int,number:string,created:?string,subject:?string,from:?string,priority:?string,assignee:?string}>
+     */
+    private function mapRows(LengthAwarePaginator $paginator): array
+    {
+        /** @var Collection<int, Ticket> $tickets */
+        $tickets = $paginator->getCollection();
+        $priorityNames = $this->priorityNames($tickets);
+
+        return $tickets
+            ->map(fn (Ticket $ticket): array => [
+                'id' => (int) $ticket->ticket_id,
+                'number' => (string) $ticket->number,
+                'created' => $ticket->created,
+                'subject' => $ticket->cdata?->subject,
+                'from' => $ticket->user?->name ?: $ticket->user?->defaultEmail?->address,
+                'priority' => $priorityNames[(string) $ticket->cdata?->priority] ?? $ticket->cdata?->priority,
+                'assignee' => $ticket->staff?->displayName(),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int, Ticket>  $tickets
+     * @return array<string, string>
+     */
+    private function priorityNames(Collection $tickets): array
+    {
+        $priorityIds = $tickets
+            ->map(fn (Ticket $ticket): mixed => $ticket->cdata?->priority)
+            ->filter(fn (mixed $priority): bool => is_numeric($priority))
+            ->map(fn (mixed $priority): int => (int) $priority)
+            ->unique()
+            ->values();
+
+        if ($priorityIds->isEmpty()) {
+            return [];
+        }
+
+        try {
+            return TicketPriority::query()
+                ->whereIn('priority_id', $priorityIds->all())
+                ->pluck('priority', 'priority_id')
+                ->mapWithKeys(fn (string $name, int|string $id): array => [(string) $id => $name])
+                ->all();
+        } catch (QueryException) {
+            return [];
+        }
+    }
+
+    /**
+     * @param  Collection<int, Collection<int, Queue>>  $byParent
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildTree(Collection $byParent, int $parentId): array
+    {
+        return ($byParent->get($parentId) ?? collect())
+            ->map(fn (Queue $queue): array => [
+                'id' => (int) $queue->id,
+                'title' => (string) $queue->title,
+                'children' => $this->buildTree($byParent, (int) $queue->id),
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/app/Services/Scp/SearchService.php
+++ b/app/Services/Scp/SearchService.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Services\Scp;
+
+use App\Models\Search;
+use App\Models\Ticket;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class SearchService
+{
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function tickets(string $query, int $limit = 25): array
+    {
+        $query = trim($query);
+
+        if ($query === '') {
+            return [];
+        }
+
+        try {
+            $searchRows = $this->searchRows($query, $limit * 3);
+            $ids = collect($searchRows)->pluck('object_id')->map(fn ($id): int => (int) $id)->unique()->values();
+
+            if ($ids->isEmpty()) {
+                return [];
+            }
+
+            $tickets = Ticket::query()
+                ->with(['cdata', 'user.defaultEmail'])
+                ->whereIn('ticket_id', $ids->all())
+                ->limit($limit)
+                ->get()
+                ->keyBy('ticket_id');
+
+            return collect($searchRows)
+                ->filter(fn ($row): bool => $tickets->has((int) $row->object_id))
+                ->take($limit)
+                ->map(function ($row) use ($tickets): array {
+                    /** @var Ticket $ticket */
+                    $ticket = $tickets->get((int) $row->object_id);
+
+                    return [
+                        'id' => (int) $ticket->ticket_id,
+                        'number' => (string) $ticket->number,
+                        'title' => $row->title ?: $ticket->cdata?->subject,
+                        'subject' => $ticket->cdata?->subject,
+                        'requester' => $ticket->user?->name ?: $ticket->user?->defaultEmail?->address,
+                        'score' => (float) ($row->score ?? 0),
+                        'created' => $ticket->created,
+                    ];
+                })
+                ->values()
+                ->all();
+        } catch (QueryException) {
+            return [];
+        }
+    }
+
+    /**
+     * @return Collection<int, object>
+     */
+    private function searchRows(string $query, int $limit)
+    {
+        if (DB::connection('legacy')->getDriverName() === 'mysql') {
+            return DB::connection('legacy')
+                ->table('_search')
+                ->selectRaw('object_type, object_id, title, MATCH(title, content) AGAINST(? IN BOOLEAN MODE) AS score', [$query])
+                ->where('object_type', 'T')
+                ->whereRaw('MATCH(title, content) AGAINST(? IN BOOLEAN MODE)', [$query])
+                ->orderByDesc('score')
+                ->orderByDesc('object_id')
+                ->limit($limit)
+                ->get();
+        }
+
+        return Search::query()
+            ->where('object_type', 'T')
+            ->where(function ($builder) use ($query): void {
+                $builder->where('title', 'like', "%{$query}%")
+                    ->orWhere('content', 'like', "%{$query}%");
+            })
+            ->orderByDesc('object_id')
+            ->limit($limit)
+            ->get()
+            ->map(function (Search $search): object {
+                return (object) [
+                    'object_type' => $search->object_type,
+                    'object_id' => $search->object_id,
+                    'title' => $search->title,
+                    'score' => 1,
+                ];
+            });
+    }
+}

--- a/app/Services/Scp/SearchService.php
+++ b/app/Services/Scp/SearchService.php
@@ -32,7 +32,6 @@ class SearchService
             $tickets = Ticket::query()
                 ->with(['cdata', 'user.defaultEmail'])
                 ->whereIn('ticket_id', $ids->all())
-                ->limit($limit)
                 ->get()
                 ->keyBy('ticket_id');
 

--- a/app/Services/Scp/SearchService.php
+++ b/app/Services/Scp/SearchService.php
@@ -66,22 +66,37 @@ class SearchService
     private function searchRows(string $query, int $limit)
     {
         if (DB::connection('legacy')->getDriverName() === 'mysql') {
-            return DB::connection('legacy')
-                ->table('_search')
-                ->selectRaw('object_type, object_id, title, MATCH(title, content) AGAINST(? IN BOOLEAN MODE) AS score', [$query])
-                ->where('object_type', 'T')
-                ->whereRaw('MATCH(title, content) AGAINST(? IN BOOLEAN MODE)', [$query])
-                ->orderByDesc('score')
-                ->orderByDesc('object_id')
-                ->limit($limit)
-                ->get();
+            try {
+                return DB::connection('legacy')
+                    ->table('_search')
+                    ->selectRaw('object_type, object_id, title, MATCH(title, content) AGAINST(? IN BOOLEAN MODE) AS score', [$query])
+                    ->where('object_type', 'T')
+                    ->whereRaw('MATCH(title, content) AGAINST(? IN BOOLEAN MODE)', [$query])
+                    ->orderByDesc('score')
+                    ->orderByDesc('object_id')
+                    ->limit($limit)
+                    ->get();
+            } catch (QueryException) {
+                return $this->fallbackSearchRows($query, $limit);
+            }
         }
 
+        return $this->fallbackSearchRows($query, $limit);
+    }
+
+    /**
+     * @return Collection<int, object>
+     */
+    private function fallbackSearchRows(string $query, int $limit)
+    {
         return Search::query()
             ->where('object_type', 'T')
             ->where(function ($builder) use ($query): void {
-                $builder->where('title', 'like', "%{$query}%")
-                    ->orWhere('content', 'like', "%{$query}%");
+                $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $query);
+                $pattern = "%{$escaped}%";
+
+                $builder->whereRaw('title like ? escape ?', [$pattern, '\\'])
+                    ->orWhereRaw('content like ? escape ?', [$pattern, '\\']);
             })
             ->orderByDesc('object_id')
             ->limit($limit)

--- a/app/Services/Scp/TicketCustomFields.php
+++ b/app/Services/Scp/TicketCustomFields.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Scp;
+
+use App\Models\Ticket;
+use App\Prototype\DynamicForms\JsonAccessorApproach;
+use Illuminate\Database\QueryException;
+
+class TicketCustomFields
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function forTicket(Ticket $ticket): array
+    {
+        try {
+            return JsonAccessorApproach::getFromTicket($ticket) ?? [];
+        } catch (QueryException) {
+            return [];
+        }
+    }
+}

--- a/app/Services/Scp/TicketReadService.php
+++ b/app/Services/Scp/TicketReadService.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Services\Scp;
+
+use App\Models\Attachment;
+use App\Models\ThreadCollaborator;
+use App\Models\ThreadEvent;
+use App\Models\ThreadReferral;
+use App\Models\Ticket;
+use Illuminate\Database\QueryException;
+
+class TicketReadService
+{
+    public function __construct(private readonly TicketCustomFields $customFields) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function read(Ticket $ticket): array
+    {
+        $ticket->loadMissing([
+            'department',
+            'staff',
+            'status',
+            'user.defaultEmail',
+            'cdata',
+            'thread.entries.staff',
+        ]);
+
+        $thread = $ticket->thread;
+        $entries = $thread?->entries ?? collect();
+        $threadId = $thread !== null ? (int) $thread->id : null;
+
+        return [
+            'ticket' => [
+                'id' => (int) $ticket->ticket_id,
+                'number' => (string) $ticket->number,
+                'status' => $ticket->status?->name ?? (string) $ticket->status_id,
+                'status_state' => $ticket->status?->state,
+                'priority' => $ticket->cdata?->priority,
+                'department' => $ticket->department?->name ?? (string) $ticket->dept_id,
+                'assignee' => $ticket->staff?->displayName(),
+                'sla_id' => (int) $ticket->sla_id,
+                'duedate' => $ticket->duedate,
+                'created' => $ticket->created,
+                'updated' => $ticket->updated,
+                'closed' => $ticket->closed,
+                'subject' => $ticket->cdata?->subject,
+                'requester' => $ticket->user?->name,
+                'requester_email' => $ticket->user?->defaultEmail?->address,
+            ],
+            'customFields' => $this->customFields->forTicket($ticket),
+            'timeline' => $this->timeline($ticket),
+            'attachments' => $this->attachments((int) $ticket->ticket_id, $entries->pluck('id')->map(fn ($id): int => (int) $id)->all()),
+            'collaborators' => $this->collaborators($threadId),
+            'referrals' => $this->referrals($threadId),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function timeline(Ticket $ticket): array
+    {
+        $thread = $ticket->thread;
+
+        if (! $thread) {
+            return [];
+        }
+
+        $entries = $thread->entries
+            ->map(fn ($entry): array => [
+                'kind' => 'entry',
+                'id' => (int) $entry->id,
+                'type' => $entry->type,
+                'author' => $entry->staff?->displayName(),
+                'body' => $entry->body,
+                'format' => $entry->format,
+                'created' => $entry->created,
+            ]);
+
+        try {
+            $events = ThreadEvent::query()
+                ->with(['event', 'staff'])
+                ->where('thread_id', $thread->id)
+                ->orderBy('timestamp')
+                ->get()
+                ->map(fn (ThreadEvent $event): array => [
+                    'kind' => 'event',
+                    'id' => (int) $event->id,
+                    'event_id' => (int) $event->event_id,
+                    'label' => $event->event?->name ?? $event->username,
+                    'data' => $event->data,
+                    'created' => $event->timestamp,
+                ]);
+        } catch (QueryException) {
+            $events = collect();
+        }
+
+        return $entries
+            ->concat($events)
+            ->sortBy('created')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int>  $entryIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function attachments(int $ticketId, array $entryIds): array
+    {
+        try {
+            return Attachment::query()
+                ->with('file')
+                ->where(function ($query) use ($ticketId, $entryIds): void {
+                    $query->where(function ($query) use ($ticketId): void {
+                        $query->where('object_type', 'T')->where('object_id', $ticketId);
+                    });
+
+                    if ($entryIds !== []) {
+                        $query->orWhere(function ($query) use ($entryIds): void {
+                            $query->whereIn('object_id', $entryIds)
+                                ->whereIn('object_type', ['H', 'E', 'M', 'R', 'N']);
+                        });
+                    }
+                })
+                ->orderBy('id')
+                ->get()
+                ->map(fn (Attachment $attachment): array => [
+                    'id' => (int) $attachment->id,
+                    'file_id' => (int) $attachment->file_id,
+                    'name' => $attachment->name ?: $attachment->file?->name,
+                    'mime' => $attachment->file?->mime,
+                    'size' => $attachment->file?->size,
+                    'inline' => (bool) $attachment->inline,
+                    'download_url' => route('scp.attachments.download', ['file' => $attachment->file_id]),
+                ])
+                ->all();
+        } catch (QueryException) {
+            return [];
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function collaborators(?int $threadId): array
+    {
+        if ($threadId === null) {
+            return [];
+        }
+
+        try {
+            return ThreadCollaborator::query()
+                ->with('user.defaultEmail')
+                ->where('thread_id', $threadId)
+                ->orderBy('id')
+                ->get()
+                ->map(fn (ThreadCollaborator $collaborator): array => [
+                    'id' => (int) $collaborator->id,
+                    'name' => $collaborator->user?->name,
+                    'email' => $collaborator->user?->defaultEmail?->address,
+                    'role' => $collaborator->role,
+                ])
+                ->all();
+        } catch (QueryException) {
+            return [];
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function referrals(?int $threadId): array
+    {
+        if ($threadId === null) {
+            return [];
+        }
+
+        try {
+            return ThreadReferral::query()
+                ->where('thread_id', $threadId)
+                ->orderBy('id')
+                ->get()
+                ->map(fn (ThreadReferral $referral): array => [
+                    'id' => (int) $referral->id,
+                    'object_type' => $referral->object_type,
+                    'object_id' => (int) $referral->object_id,
+                    'created' => $referral->created,
+                ])
+                ->all();
+        } catch (QueryException) {
+            return [];
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,13 +1,15 @@
 <?php
 
 use App\Http\Middleware\AuthenticateStaff;
+use App\Http\Middleware\EnsureScpStaff;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\LegacyAuthBridge;
+use App\Http\Middleware\LogScpAccess;
 use App\Http\Middleware\RequireDepartmentAccess;
-use Illuminate\Http\Request;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -33,6 +35,8 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'auth.staff' => AuthenticateStaff::class,
             'dept.access' => RequireDepartmentAccess::class,
+            'scp.access' => EnsureScpStaff::class,
+            'scp.log' => LogScpAccess::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/config/mail.php
+++ b/config/mail.php
@@ -115,4 +115,11 @@ return [
         'name' => env('MAIL_FROM_NAME', env('APP_NAME', 'Laravel')),
     ],
 
+    'outbound_guard' => [
+        'allowed_recipients' => array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) env('OUTBOUND_MAIL_ALLOWED_RECIPIENTS', '')),
+        ))),
+    ],
+
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -42,6 +42,7 @@ return [
     'osticket' => [
         'secret_salt' => env('OSTICKET_SECRET_SALT'),
         'config_path' => env('OSTICKET_CONFIG_PATH'),
+        'filesystem_root' => env('OSTICKET_FILESYSTEM_ROOT'),
     ],
 
 ];

--- a/database/migrations/2026_04_26_000100_create_staff_preferences_table.php
+++ b/database/migrations/2026_04_26_000100_create_staff_preferences_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $schema = Schema::connection('osticket2');
+
+        if (! $schema->hasTable('staff_preferences')) {
+            $this->createTable($schema);
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema);
+    }
+
+    public function down(): void
+    {
+        Schema::connection('osticket2')->dropIfExists('staff_preferences');
+    }
+
+    private function createTable(Builder $schema): void
+    {
+        $schema->create('staff_preferences', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('staff_id')->unique();
+            $table->string('theme', 16)->default('system');
+            $table->string('language', 16)->nullable();
+            $table->string('timezone', 64)->nullable();
+            $table->json('notifications')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function guardRequiredColumns(Builder $schema): void
+    {
+        $existingColumns = $schema->getColumnListing('staff_preferences');
+        $missingColumns = array_values(array_diff(['id', 'staff_id'], $existingColumns));
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Existing %s table is missing required column(s): %s.',
+            $schema->getConnection()->getTablePrefix().'staff_preferences',
+            implode(', ', $missingColumns),
+        ));
+    }
+};

--- a/database/migrations/2026_04_26_000100_create_staff_preferences_table.php
+++ b/database/migrations/2026_04_26_000100_create_staff_preferences_table.php
@@ -7,11 +7,15 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    private const TABLE = 'staff_preferences';
+
+    private const CREATED_MARKER = 'created_by_migration_2026_04_26_000100';
+
     public function up(): void
     {
         $schema = Schema::connection('osticket2');
 
-        if (! $schema->hasTable('staff_preferences')) {
+        if (! $schema->hasTable(self::TABLE)) {
             $this->createTable($schema);
 
             return;
@@ -22,25 +26,30 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::connection('osticket2')->dropIfExists('staff_preferences');
+        $schema = Schema::connection('osticket2');
+
+        if ($schema->hasColumn(self::TABLE, self::CREATED_MARKER)) {
+            $schema->dropIfExists(self::TABLE);
+        }
     }
 
     private function createTable(Builder $schema): void
     {
-        $schema->create('staff_preferences', function (Blueprint $table): void {
+        $schema->create(self::TABLE, function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('staff_id')->unique();
             $table->string('theme', 16)->default('system');
             $table->string('language', 16)->nullable();
             $table->string('timezone', 64)->nullable();
             $table->json('notifications')->nullable();
+            $table->boolean(self::CREATED_MARKER)->default(true);
             $table->timestamps();
         });
     }
 
     private function guardRequiredColumns(Builder $schema): void
     {
-        $existingColumns = $schema->getColumnListing('staff_preferences');
+        $existingColumns = $schema->getColumnListing(self::TABLE);
         $missingColumns = array_values(array_diff(['id', 'staff_id'], $existingColumns));
 
         if ($missingColumns === []) {
@@ -49,7 +58,7 @@ return new class extends Migration
 
         throw new RuntimeException(sprintf(
             'Existing %s table is missing required column(s): %s.',
-            $schema->getConnection()->getTablePrefix().'staff_preferences',
+            $schema->getConnection()->getTablePrefix().self::TABLE,
             implode(', ', $missingColumns),
         ));
     }

--- a/database/migrations/2026_04_26_000200_create_scp_access_log_table.php
+++ b/database/migrations/2026_04_26_000200_create_scp_access_log_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $schema = Schema::connection('osticket2');
+
+        if (! $schema->hasTable('access_log')) {
+            $this->createTable($schema);
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema);
+    }
+
+    public function down(): void
+    {
+        Schema::connection('osticket2')->dropIfExists('access_log');
+    }
+
+    private function createTable(Builder $schema): void
+    {
+        $schema->create('access_log', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('staff_id')->index();
+            $table->string('action', 128);
+            $table->string('subject_type', 64)->nullable();
+            $table->unsignedBigInteger('subject_id')->nullable();
+            $table->json('metadata')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['subject_type', 'subject_id']);
+            $table->index('created_at');
+        });
+    }
+
+    private function guardRequiredColumns(Builder $schema): void
+    {
+        $existingColumns = $schema->getColumnListing('access_log');
+        $missingColumns = array_values(array_diff(['id', 'staff_id', 'action', 'created_at'], $existingColumns));
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Existing %s table is missing required column(s): %s.',
+            $schema->getConnection()->getTablePrefix().'access_log',
+            implode(', ', $missingColumns),
+        ));
+    }
+};

--- a/database/migrations/2026_04_26_000200_create_scp_access_log_table.php
+++ b/database/migrations/2026_04_26_000200_create_scp_access_log_table.php
@@ -7,11 +7,15 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
+    private const TABLE = 'access_log';
+
+    private const CREATED_MARKER = 'created_by_migration_2026_04_26_000200';
+
     public function up(): void
     {
         $schema = Schema::connection('osticket2');
 
-        if (! $schema->hasTable('access_log')) {
+        if (! $schema->hasTable(self::TABLE)) {
             $this->createTable($schema);
 
             return;
@@ -22,12 +26,16 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::connection('osticket2')->dropIfExists('access_log');
+        $schema = Schema::connection('osticket2');
+
+        if ($schema->hasColumn(self::TABLE, self::CREATED_MARKER)) {
+            $schema->dropIfExists(self::TABLE);
+        }
     }
 
     private function createTable(Builder $schema): void
     {
-        $schema->create('access_log', function (Blueprint $table): void {
+        $schema->create(self::TABLE, function (Blueprint $table): void {
             $table->id();
             $table->unsignedBigInteger('staff_id')->index();
             $table->string('action', 128);
@@ -36,6 +44,7 @@ return new class extends Migration
             $table->json('metadata')->nullable();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
+            $table->boolean(self::CREATED_MARKER)->default(true);
             $table->timestamp('created_at')->useCurrent();
 
             $table->index(['subject_type', 'subject_id']);
@@ -45,7 +54,7 @@ return new class extends Migration
 
     private function guardRequiredColumns(Builder $schema): void
     {
-        $existingColumns = $schema->getColumnListing('access_log');
+        $existingColumns = $schema->getColumnListing(self::TABLE);
         $missingColumns = array_values(array_diff(['id', 'staff_id', 'action', 'created_at'], $existingColumns));
 
         if ($missingColumns === []) {
@@ -54,7 +63,7 @@ return new class extends Migration
 
         throw new RuntimeException(sprintf(
             'Existing %s table is missing required column(s): %s.',
-            $schema->getConnection()->getTablePrefix().'access_log',
+            $schema->getConnection()->getTablePrefix().self::TABLE,
             implode(', ', $missingColumns),
         ));
     }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,7 +2,12 @@
     "nav": {
         "dashboard": "Dashboard",
         "tickets": "Tickets",
+        "inbox": "Inbox",
+        "notifications": "Notifications",
         "knowledgebase": "Knowledgebase",
+        "customers": "Customers",
+        "forum": "Forum",
+        "reports": "Reports",
         "my_tickets": "My Tickets",
         "open_tickets": "Open Tickets",
         "new_ticket": "New Ticket",
@@ -101,6 +106,119 @@
             "resending": "Resending...",
             "back_to_login": "Back to login"
         }
+    },
+    "dashboard": {
+        "banner": {
+            "title": "Live dashboard",
+            "description": "Counts are queried from the legacy database on each page load{{refreshedAt}}."
+        },
+        "metrics": {
+            "open_tickets": {
+                "label": "Open Tickets",
+                "helper": "Visible tickets with status state open"
+            },
+            "assigned_to_me": {
+                "label": "Assigned to Me",
+                "helper": "{{percent}} of visible open tickets"
+            },
+            "unassigned": {
+                "label": "Unassigned",
+                "helper": "No staff or team owner"
+            },
+            "overdue": {
+                "label": "Overdue",
+                "helper": "{{percent}} of visible open tickets"
+            },
+            "trend": {
+                "up": "+{{percent}}",
+                "down": "-{{percent}}",
+                "flat": "0%",
+                "new": "New",
+                "compare_to_last_month": "Compare to last month"
+            }
+        },
+        "chart": {
+            "tickets": "Tickets",
+            "open": "Open",
+            "assigned": "Assigned",
+            "unassigned": "Unassigned",
+            "overdue": "Overdue"
+        },
+        "live_counts": {
+            "title": "Live Ticket Counts",
+            "description": "Queried from the legacy ticket tables for your visible departments."
+        },
+        "ticket_status_chart": {
+            "title": "Open vs Solved Tickets",
+            "description": "{{rangeStart}} - {{rangeEnd}}.",
+            "open": "Open",
+            "solved": "Solved",
+            "open_total": "Open: {{count}}",
+            "solved_total": "Solved: {{count}}"
+        },
+        "ownership": {
+            "title": "Open Ticket Ownership",
+            "description": "Staff assignment split for visible open tickets.",
+            "assigned": "Assigned",
+            "assigned_to_me": "Assigned to me",
+            "assigned_elsewhere": "Assigned elsewhere",
+            "unassigned": "Unassigned",
+            "select_segment": "Select segment",
+            "empty": "No open tickets are visible right now."
+        },
+        "quick_actions": {
+            "title": "Command Center",
+            "description": "Fast paths for the ticket work agents repeat most.",
+            "open_queues": "Open ticket queues",
+            "open_queues_hint": "Review assigned, unassigned, and overdue queues.",
+            "search_tickets": "Search tickets",
+            "search_tickets_hint": "Jump directly to a ticket, requester, or phrase.",
+            "staff_preferences": "Staff preferences",
+            "staff_preferences_hint": "Adjust your SCP language and display settings.",
+            "live_hint": "Actions use live staff access and current ticket visibility."
+        },
+        "channels": {
+            "title": "Tickets by Channel",
+            "description": "{{rangeStart}} - {{rangeEnd}}.",
+            "total": "Tickets",
+            "empty": "No visible ticket channels in this range."
+        },
+        "recent_activity": {
+            "title": "Live Ticket Stream",
+            "description": "Latest visible ticket events from legacy thread history.",
+            "empty": "No visible ticket activity yet.",
+            "thread": "Thread {{id}}",
+            "unknown_time": "Unknown time",
+            "ticket_activity": "ticket activity",
+            "untitled_ticket": "Untitled ticket",
+            "actor": "Updated by {{username}}",
+            "by_user": " by {{username}}"
+        },
+        "layout": {
+            "open_dashboard_actions": "Open dashboard actions",
+            "open_export_options": "Open export options",
+            "search_tickets": "Search tickets",
+            "search_placeholder": "Search...",
+            "conversation": "Conversation",
+            "favorites": "Favorites",
+            "favorites_hint": "Hover over any table and click the star to add it here.",
+            "pinned_tickets": "Pinned Tickets",
+            "unpin_all": "Unpin all",
+            "add_new": "Add new",
+            "preferences": "Preferences",
+            "powered_by": "Powered by",
+            "security": "Security",
+            "my_queue": "My Queue",
+            "new_ticket": "New Ticket"
+        },
+        "date_range": {
+            "label": "Date range",
+            "last_7_days": "Last 7 days",
+            "last_30_days": "Last 30 days",
+            "last_3_months": "Last 3 months",
+            "last_6_months": "Last 6 months"
+        },
+        "overview": "Overview"
     },
     "actions": {
         "submit": "Submit",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -2,7 +2,12 @@
     "nav": {
         "dashboard": "Bảng điều khiển",
         "tickets": "Yêu cầu",
+        "inbox": "Hộp thư",
+        "notifications": "Thông báo",
         "knowledgebase": "Kiến thức chung",
+        "customers": "Khách hàng",
+        "forum": "Diễn đàn",
+        "reports": "Báo cáo",
         "my_tickets": "Yêu cầu của tôi",
         "open_tickets": "Mở Tickets",
         "new_ticket": "Lệnh mới",
@@ -101,6 +106,119 @@
             "resending": "Đang gửi lại...",
             "back_to_login": "Quay lại đăng nhập"
         }
+    },
+    "dashboard": {
+        "banner": {
+            "title": "Bảng điều khiển trực tiếp",
+            "description": "Số liệu được truy vấn từ cơ sở dữ liệu legacy mỗi lần tải trang{{refreshedAt}}."
+        },
+        "metrics": {
+            "open_tickets": {
+                "label": "Yêu cầu đang mở",
+                "helper": "Yêu cầu hiển thị có trạng thái đang mở"
+            },
+            "assigned_to_me": {
+                "label": "Được giao cho tôi",
+                "helper": "{{percent}} yêu cầu đang mở có thể xem"
+            },
+            "unassigned": {
+                "label": "Chưa phân công",
+                "helper": "Chưa có nhân viên hoặc nhóm phụ trách"
+            },
+            "overdue": {
+                "label": "Quá hạn",
+                "helper": "{{percent}} yêu cầu đang mở có thể xem"
+            },
+            "trend": {
+                "up": "+{{percent}}",
+                "down": "-{{percent}}",
+                "flat": "0%",
+                "new": "Mới",
+                "compare_to_last_month": "So với tháng trước"
+            }
+        },
+        "chart": {
+            "tickets": "Yêu cầu",
+            "open": "Đang mở",
+            "assigned": "Đã phân công",
+            "unassigned": "Chưa phân công",
+            "overdue": "Quá hạn"
+        },
+        "live_counts": {
+            "title": "Số lượng yêu cầu trực tiếp",
+            "description": "Truy vấn từ các bảng yêu cầu legacy theo phòng ban bạn có quyền xem."
+        },
+        "ticket_status_chart": {
+            "title": "Yêu cầu mở và đã xử lý",
+            "description": "{{rangeStart}} - {{rangeEnd}}.",
+            "open": "Đang mở",
+            "solved": "Đã xử lý",
+            "open_total": "Đang mở: {{count}}",
+            "solved_total": "Đã xử lý: {{count}}"
+        },
+        "ownership": {
+            "title": "Phân công yêu cầu đang mở",
+            "description": "Tỷ lệ phân công nhân viên cho các yêu cầu đang mở có thể xem.",
+            "assigned": "Đã phân công",
+            "assigned_to_me": "Được giao cho tôi",
+            "assigned_elsewhere": "Được giao cho người khác",
+            "unassigned": "Chưa phân công",
+            "select_segment": "Chọn phân đoạn",
+            "empty": "Hiện không có yêu cầu đang mở nào có thể xem."
+        },
+        "quick_actions": {
+            "title": "Trung tâm thao tác",
+            "description": "Lối tắt cho các công việc yêu cầu nhân viên thường dùng.",
+            "open_queues": "Mở hàng đợi yêu cầu",
+            "open_queues_hint": "Xem hàng đợi được giao, chưa giao và quá hạn.",
+            "search_tickets": "Tìm kiếm yêu cầu",
+            "search_tickets_hint": "Mở nhanh yêu cầu, người gửi hoặc cụm từ.",
+            "staff_preferences": "Tùy chọn nhân viên",
+            "staff_preferences_hint": "Điều chỉnh ngôn ngữ và hiển thị SCP.",
+            "live_hint": "Thao tác dùng quyền nhân viên và khả năng xem yêu cầu hiện tại."
+        },
+        "channels": {
+            "title": "Yêu cầu theo kênh",
+            "description": "{{rangeStart}} - {{rangeEnd}}.",
+            "total": "Yêu cầu",
+            "empty": "Không có kênh yêu cầu nào có thể xem trong khoảng này."
+        },
+        "recent_activity": {
+            "title": "Luồng yêu cầu trực tiếp",
+            "description": "Các sự kiện yêu cầu mới nhất có thể xem từ lịch sử thread legacy.",
+            "empty": "Chưa có hoạt động yêu cầu nào có thể xem.",
+            "thread": "Thread {{id}}",
+            "unknown_time": "Không rõ thời gian",
+            "ticket_activity": "hoạt động yêu cầu",
+            "untitled_ticket": "Yêu cầu chưa có tiêu đề",
+            "actor": "Cập nhật bởi {{username}}",
+            "by_user": " bởi {{username}}"
+        },
+        "layout": {
+            "open_dashboard_actions": "Mở thao tác bảng điều khiển",
+            "open_export_options": "Mở tùy chọn xuất",
+            "search_tickets": "Tìm kiếm yêu cầu",
+            "search_placeholder": "Tìm kiếm...",
+            "conversation": "Hội thoại",
+            "favorites": "Yêu thích",
+            "favorites_hint": "Di chuột qua bảng bất kỳ và bấm biểu tượng sao để thêm vào đây.",
+            "pinned_tickets": "Yêu cầu đã ghim",
+            "unpin_all": "Bỏ ghim tất cả",
+            "add_new": "Thêm mới",
+            "preferences": "Tùy chọn",
+            "powered_by": "Cung cấp bởi",
+            "security": "Bảo mật",
+            "my_queue": "Hàng chờ của tôi",
+            "new_ticket": "Ticket mới"
+        },
+        "date_range": {
+            "label": "Khoảng thời gian",
+            "last_7_days": "7 ngày qua",
+            "last_30_days": "30 ngày qua",
+            "last_3_months": "3 tháng qua",
+            "last_6_months": "6 tháng qua"
+        },
+        "overview": "Tổng quan"
     },
     "actions": {
         "submit": "Đệ trình",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "tyler",
+    "name": "rio-de-janeiro",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "rio-de-janeiro",
             "dependencies": {
                 "@base-ui/react": "^1.4.0",
                 "@fontsource-variable/geist-mono": "^5.2.7",
@@ -17,6 +18,7 @@
                 "@inertiajs/react": "^3.0.1",
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
+                "dompurify": "^3.4.1",
                 "i18next": "^26.0.3",
                 "i18next-browser-languagedetector": "^8.2.1",
                 "input-otp": "^1.4.2",
@@ -1915,6 +1917,13 @@
             "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
             "license": "MIT"
         },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@types/use-sync-external-store": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -2863,6 +2872,15 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+            "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/dotenv": {
@@ -5090,9 +5108,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@inertiajs/react": "^3.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dompurify": "^3.4.1",
         "i18next": "^26.0.3",
         "i18next-browser-languagedetector": "^8.2.1",
         "input-otp": "^1.4.2",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -441,7 +441,7 @@
 
 .prose-ticket p { margin: 0 0 0.75rem 0; }
 .prose-ticket p:last-child { margin-bottom: 0; }
-.prose-ticket a { color: #5B619D; text-decoration: underline; word-break: break-word; }
+.prose-ticket a { color: #5B619D; text-decoration: underline; overflow-wrap: anywhere; }
 .prose-ticket a:hover { color: #4F548C; }
 .prose-ticket ul, .prose-ticket ol { padding-left: 1.25rem; margin: 0 0 0.75rem 0; }
 .prose-ticket ul { list-style: disc; }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -438,3 +438,55 @@
     background: #e2e8f0;
     border-radius: 9999px;
 }
+
+.prose-ticket p { margin: 0 0 0.75rem 0; }
+.prose-ticket p:last-child { margin-bottom: 0; }
+.prose-ticket a { color: #5B619D; text-decoration: underline; word-break: break-word; }
+.prose-ticket a:hover { color: #4F548C; }
+.prose-ticket ul, .prose-ticket ol { padding-left: 1.25rem; margin: 0 0 0.75rem 0; }
+.prose-ticket ul { list-style: disc; }
+.prose-ticket ol { list-style: decimal; }
+.prose-ticket li { margin: 0.125rem 0; }
+.prose-ticket blockquote {
+    margin: 0 0 0.75rem 0;
+    padding: 0.5rem 0.875rem;
+    border-left: 3px solid #E2E8F0;
+    background: #F8FAFC;
+    color: #475569;
+    border-radius: 0 6px 6px 0;
+}
+.prose-ticket pre {
+    margin: 0 0 0.75rem 0;
+    padding: 0.625rem 0.75rem;
+    background: #0F172A;
+    color: #E2E8F0;
+    border-radius: 8px;
+    font-size: 0.8125rem;
+    overflow-x: auto;
+}
+.prose-ticket code {
+    background: #F1F5F9;
+    border-radius: 4px;
+    padding: 0 0.25rem;
+    font-size: 0.875em;
+}
+.prose-ticket pre code { background: transparent; padding: 0; }
+.prose-ticket img { max-width: 100%; height: auto; border-radius: 6px; }
+.prose-ticket h1, .prose-ticket h2, .prose-ticket h3, .prose-ticket h4 {
+    font-weight: 600; color: #0F172A; margin: 1rem 0 0.5rem 0;
+}
+.prose-ticket h1 { font-size: 1.125rem; }
+.prose-ticket h2 { font-size: 1.0625rem; }
+.prose-ticket h3, .prose-ticket h4 { font-size: 1rem; }
+.prose-ticket table {
+    border-collapse: collapse;
+    margin: 0 0 0.75rem 0;
+    font-size: 0.8125rem;
+}
+.prose-ticket th, .prose-ticket td {
+    border: 1px solid #E2E8F0;
+    padding: 0.375rem 0.625rem;
+    text-align: left;
+}
+.prose-ticket th { background: #F8FAFC; font-weight: 600; }
+.prose-ticket hr { border: 0; border-top: 1px solid #E2E8F0; margin: 1rem 0; }

--- a/resources/js/components/LanguageSwitcher.tsx
+++ b/resources/js/components/LanguageSwitcher.tsx
@@ -15,20 +15,20 @@ export default function LanguageSwitcher({ className = '' }: LanguageSwitcherPro
     return (
         <div className={`relative inline-flex items-center gap-1 ${className}`}>
             <span className="sr-only">{t('language_switcher.select_language')}</span>
-            <div className="flex items-center rounded-md border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex items-center rounded-[4px] border border-[#E2E8F0] bg-white shadow-sm shadow-[#0F172A]/[0.03]">
                 {SUPPORTED_LANGUAGES.map((lang, index) => (
                     <button
                         key={lang.code}
                         onClick={() => changeLanguage(lang.code)}
                         aria-pressed={i18n.language === lang.code || i18n.language.startsWith(lang.code)}
                         className={[
-                            'px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1',
-                            index === 0 ? 'rounded-l-md' : '',
-                            index === SUPPORTED_LANGUAGES.length - 1 ? 'rounded-r-md' : '',
-                            index > 0 ? 'border-l border-gray-200 dark:border-gray-700' : '',
+                            'px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-[#C4A5F3]/40 focus:ring-offset-1',
+                            index === 0 ? 'rounded-l-[4px]' : '',
+                            index === SUPPORTED_LANGUAGES.length - 1 ? 'rounded-r-[4px]' : '',
+                            index > 0 ? 'border-l border-[#E2E8F0]' : '',
                             (i18n.language === lang.code || i18n.language.startsWith(lang.code))
-                                ? 'bg-blue-600 text-white'
-                                : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700',
+                                ? 'bg-[#5B619D] text-white'
+                                : 'text-[#64748B] hover:bg-[#F8FAFC] hover:text-[#0F172A]',
                         ]
                             .filter(Boolean)
                             .join(' ')}

--- a/resources/js/components/scp/Avatar.tsx
+++ b/resources/js/components/scp/Avatar.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface AvatarProps {
+    name: string | null | undefined;
+    size?: number;
+    className?: string;
+}
+
+const PALETTE = [
+    'bg-rose-100 text-rose-700',
+    'bg-amber-100 text-amber-800',
+    'bg-emerald-100 text-emerald-700',
+    'bg-sky-100 text-sky-700',
+    'bg-violet-100 text-violet-700',
+    'bg-pink-100 text-pink-700',
+    'bg-teal-100 text-teal-700',
+    'bg-indigo-100 text-indigo-700',
+];
+
+function initials(name: string): string {
+    return name
+        .trim()
+        .split(/\s+/)
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase() ?? '')
+        .join('') || '?';
+}
+
+function paletteFor(name: string): string {
+    let hash = 0;
+    for (let index = 0; index < name.length; index += 1) {
+        hash = (hash * 31 + name.charCodeAt(index)) >>> 0;
+    }
+    return PALETTE[hash % PALETTE.length];
+}
+
+export function Avatar({ name, size = 24, className }: AvatarProps) {
+    const label = name?.trim() ?? '';
+    const tone = useMemo(() => (label === '' ? 'bg-zinc-200 text-zinc-500' : paletteFor(label)), [label]);
+    const text = label === '' ? '?' : initials(label);
+
+    return (
+        <span
+            aria-hidden
+            style={{ width: size, height: size, fontSize: size * 0.42 }}
+            className={cn(
+                'inline-flex shrink-0 items-center justify-center rounded-full font-semibold leading-none',
+                tone,
+                className,
+            )}
+        >
+            {text}
+        </span>
+    );
+}

--- a/resources/js/components/scp/PriorityBadge.tsx
+++ b/resources/js/components/scp/PriorityBadge.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/lib/utils';
+
+interface PriorityBadgeProps {
+    priority?: string | null;
+    className?: string;
+}
+
+const PRIORITY_TONES: Record<string, string> = {
+    emergency: 'border-rose-300 bg-rose-50 text-rose-700',
+    critical: 'border-rose-300 bg-rose-50 text-rose-700',
+    urgent: 'border-rose-300 bg-rose-50 text-rose-700',
+    high: 'border-amber-300 bg-amber-50 text-amber-800',
+    normal: 'border-[#E2E8F0] bg-[#F8FAFC] text-[#475569]',
+    medium: 'border-[#E2E8F0] bg-[#F8FAFC] text-[#475569]',
+    low: 'border-[#E2E8F0] bg-[#F8FAFC] text-[#94A3B8]',
+};
+
+const NEUTRAL = 'border-[#E2E8F0] bg-[#F8FAFC] text-[#64748B]';
+
+export function PriorityBadge({ priority, className }: PriorityBadgeProps) {
+    if (!priority) {
+        return <span className="text-[#94A3B8]">—</span>;
+    }
+
+    const tone = PRIORITY_TONES[priority.toLowerCase()] ?? NEUTRAL;
+
+    return (
+        <span
+            className={cn(
+                'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium',
+                tone,
+                className,
+            )}
+        >
+            {priority}
+        </span>
+    );
+}

--- a/resources/js/components/scp/QueueSelector.tsx
+++ b/resources/js/components/scp/QueueSelector.tsx
@@ -1,0 +1,150 @@
+import { router } from '@inertiajs/react';
+import { useMemo } from 'react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Folder01Icon, Search01Icon, UserStar01Icon } from '@hugeicons/core-free-icons';
+
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectLabel,
+    SelectSeparator,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+
+import type { QueueNavigation, QueueNode, SavedSearch } from './queue-types';
+
+interface QueueSelectorProps {
+    navigation: QueueNavigation;
+    activeQueueId?: number;
+    placeholder?: string;
+    variant?: 'default' | 'heading';
+    label?: string;
+}
+
+interface FlatItem {
+    id: number;
+    title: string;
+    depth: number;
+    section: 'queues' | 'personal' | 'savedSearches';
+}
+
+function flattenTree(nodes: QueueNode[], section: FlatItem['section'], depth = 0, acc: FlatItem[] = []): FlatItem[] {
+    for (const node of nodes) {
+        acc.push({ id: node.id, title: node.title, depth, section });
+        if (node.children?.length) {
+            flattenTree(node.children, section, depth + 1, acc);
+        }
+    }
+    return acc;
+}
+
+function flattenSavedSearches(items: SavedSearch[]): FlatItem[] {
+    return items.map((item) => ({ id: item.id, title: item.title, depth: 0, section: 'savedSearches' as const }));
+}
+
+function indentPad(depth: number): string {
+    return '  '.repeat(depth);
+}
+
+export function QueueSelector({ navigation, activeQueueId, placeholder = 'Select a queue', variant = 'default', label }: QueueSelectorProps) {
+    const groups = useMemo(
+        () => ({
+            queues: flattenTree(navigation.queues, 'queues'),
+            personal: flattenTree(navigation.personal, 'personal'),
+            savedSearches: flattenSavedSearches(navigation.savedSearches),
+        }),
+        [navigation],
+    );
+
+    const value = activeQueueId !== undefined ? String(activeQueueId) : undefined;
+
+    function handleChange(next: string | null) {
+        if (!next) return;
+        router.get(`/scp/queues/${next}`);
+    }
+
+    const totalCount =
+        groups.queues.length + groups.personal.length + groups.savedSearches.length;
+
+    return (
+        <Select value={value} onValueChange={handleChange}>
+            {variant === 'heading' ? (
+                <SelectTrigger className="!h-auto gap-2 rounded-none border-0 bg-transparent px-0 py-0 font-display text-[28px] font-medium tracking-tight text-[#0F172A] shadow-none focus-visible:border-0 focus-visible:ring-0">
+                    <span className="flex flex-1 text-left">{label ?? placeholder}</span>
+                </SelectTrigger>
+            ) : (
+                <SelectTrigger className="h-9 min-w-[260px] rounded-md border-zinc-200 bg-white px-3 text-sm">
+                    <HugeiconsIcon icon={Folder01Icon} size={14} className="text-zinc-400" />
+                    <SelectValue placeholder={placeholder} />
+                </SelectTrigger>
+            )}
+            <SelectContent align="start" className="min-w-[280px] rounded-xl">
+                {totalCount === 0 ? (
+                    <p className="px-3 py-3 text-xs text-[#94A3B8]">No queues are visible to you yet.</p>
+                ) : (
+                    <>
+                        {groups.queues.length > 0 && (
+                            <SelectGroup>
+                                <SelectLabel>
+                                    <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">
+                                        <HugeiconsIcon icon={Folder01Icon} size={11} /> Queues
+                                    </span>
+                                </SelectLabel>
+                                {groups.queues.map((item) => (
+                                    <SelectItem key={`q-${item.id}`} value={String(item.id)}>
+                                        <span>
+                                            {indentPad(item.depth)}
+                                            {item.title}
+                                        </span>
+                                    </SelectItem>
+                                ))}
+                            </SelectGroup>
+                        )}
+
+                        {groups.personal.length > 0 && (
+                            <>
+                                {groups.queues.length > 0 && <SelectSeparator />}
+                                <SelectGroup>
+                                    <SelectLabel>
+                                        <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">
+                                            <HugeiconsIcon icon={UserStar01Icon} size={11} /> Personal
+                                        </span>
+                                    </SelectLabel>
+                                    {groups.personal.map((item) => (
+                                        <SelectItem key={`p-${item.id}`} value={String(item.id)}>
+                                            <span>
+                                                {indentPad(item.depth)}
+                                                {item.title}
+                                            </span>
+                                        </SelectItem>
+                                    ))}
+                                </SelectGroup>
+                            </>
+                        )}
+
+                        {groups.savedSearches.length > 0 && (
+                            <>
+                                {(groups.queues.length > 0 || groups.personal.length > 0) && <SelectSeparator />}
+                                <SelectGroup>
+                                    <SelectLabel>
+                                        <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">
+                                            <HugeiconsIcon icon={Search01Icon} size={11} /> My Advanced Searches
+                                        </span>
+                                    </SelectLabel>
+                                    {groups.savedSearches.map((item) => (
+                                        <SelectItem key={`s-${item.id}`} value={String(item.id)}>
+                                            <span>{item.title}</span>
+                                        </SelectItem>
+                                    ))}
+                                </SelectGroup>
+                            </>
+                        )}
+                    </>
+                )}
+            </SelectContent>
+        </Select>
+    );
+}

--- a/resources/js/components/scp/QueueTicketTable.tsx
+++ b/resources/js/components/scp/QueueTicketTable.tsx
@@ -1,5 +1,5 @@
-import { Link, router, usePage } from '@inertiajs/react';
-import { useMemo, useState } from 'react';
+import { Link, router } from '@inertiajs/react';
+import { useState } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
     ArrowDown01Icon,
@@ -10,6 +10,7 @@ import {
 
 import { Avatar } from '@/components/scp/Avatar';
 import { PriorityBadge } from '@/components/scp/PriorityBadge';
+import type { QueueFilters, QueueSortState } from '@/components/scp/TicketFilterChips';
 import { Button } from '@/components/ui/button';
 import { formatTicketDate } from '@/lib/datetime';
 import { cn } from '@/lib/utils';
@@ -22,6 +23,9 @@ export interface TicketRow {
     from: string | null;
     priority: string | null;
     assignee: string | null;
+    status?: string | null;
+    status_state?: string | null;
+    source?: string | null;
 }
 
 export interface PaginationState {
@@ -34,12 +38,14 @@ interface QueueTicketTableProps {
     queueId: number;
     tickets: TicketRow[];
     pagination: PaginationState;
+    sort: QueueSortState;
+    filters: QueueFilters;
 }
 
 type SortDirection = 'asc' | 'desc';
 
 interface ColumnDef {
-    id: keyof TicketRow;
+    id: string;
     label: string;
     sortable: boolean;
     width?: string;
@@ -94,23 +100,22 @@ function CheckboxButton({
     );
 }
 
-export function QueueTicketTable({ queueId, tickets, pagination }: QueueTicketTableProps) {
-    const { url } = usePage();
+function buildFilterParams(filters: QueueFilters): Record<string, string | number | string[] | number[]> {
+    const params: Record<string, string | number | string[] | number[]> = {};
+    if (filters.state.length > 0) params.state = filters.state;
+    if (filters.source.length > 0) params.source = filters.source;
+    if (filters.priority.length > 0) params.priority = filters.priority;
+    if (filters.created_from) params.created_from = filters.created_from;
+    if (filters.created_to) params.created_to = filters.created_to;
+    return params;
+}
+
+export function QueueTicketTable({ queueId, tickets, pagination, sort, filters }: QueueTicketTableProps) {
     const [selected, setSelected] = useState<Set<number>>(new Set());
     const allSelected = tickets.length > 0 && selected.size === tickets.length;
 
-    const { sortBy, sortDir } = useMemo(() => {
-        const search = url.includes('?') ? url.slice(url.indexOf('?')) : '';
-        const params = new URLSearchParams(search);
-        const sort = params.get('sort') as keyof TicketRow | null;
-        const dir = params.get('dir') as SortDirection | null;
-        const validKey = COLUMNS.some((column) => column.id === sort);
-
-        return {
-            sortBy: validKey ? (sort as keyof TicketRow) : 'created',
-            sortDir: dir === 'asc' ? 'asc' : 'desc',
-        };
-    }, [url]);
+    const sortBy = sort.by;
+    const sortDir: SortDirection = sort.dir === 'asc' ? 'asc' : 'desc';
 
     function toggleAll() {
         setSelected(allSelected ? new Set() : new Set(tickets.map((ticket) => ticket.id)));
@@ -133,7 +138,7 @@ export function QueueTicketTable({ queueId, tickets, pagination }: QueueTicketTa
         const nextDir: SortDirection = column.id === sortBy && sortDir === 'asc' ? 'desc' : 'asc';
         router.get(
             `/scp/queues/${queueId}`,
-            { sort: column.id, dir: nextDir, page: 1 },
+            { ...buildFilterParams(filters), sort: column.id, dir: nextDir, page: 1 },
             { preserveScroll: true, preserveState: true, replace: true },
         );
     }
@@ -141,7 +146,7 @@ export function QueueTicketTable({ queueId, tickets, pagination }: QueueTicketTa
     function navigatePage(nextPage: number) {
         router.get(
             `/scp/queues/${queueId}`,
-            { page: nextPage, sort: sortBy, dir: sortDir },
+            { ...buildFilterParams(filters), page: nextPage, sort: sortBy, dir: sortDir },
             { preserveScroll: true, preserveState: true },
         );
     }
@@ -168,15 +173,24 @@ export function QueueTicketTable({ queueId, tickets, pagination }: QueueTicketTa
                                     scope="col"
                                     className={cn(
                                         'px-3 py-2 text-xs font-normal whitespace-nowrap',
-                                        column.sortable ? 'cursor-pointer text-zinc-500 hover:text-zinc-800' : 'text-zinc-500',
+                                        column.sortable ? 'text-zinc-500' : 'text-zinc-500',
                                         column.width,
                                     )}
+                                    aria-sort={
+                                        sortBy === column.id
+                                            ? sortDir === 'asc' ? 'ascending' : 'descending'
+                                            : 'none'
+                                    }
                                 >
                                     <button
                                         type="button"
                                         onClick={() => handleSort(column)}
                                         disabled={!column.sortable}
-                                        className="inline-flex items-center gap-1"
+                                        className={cn(
+                                            'inline-flex items-center gap-1 transition-colors',
+                                            column.sortable ? 'cursor-pointer hover:text-zinc-800' : 'cursor-default',
+                                            sortBy === column.id && 'text-zinc-900',
+                                        )}
                                     >
                                         {column.label}
                                         {column.sortable && (

--- a/resources/js/components/scp/QueueTicketTable.tsx
+++ b/resources/js/components/scp/QueueTicketTable.tsx
@@ -1,0 +1,309 @@
+import { Link, router, usePage } from '@inertiajs/react';
+import { useMemo, useState } from 'react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import {
+    ArrowDown01Icon,
+    ArrowUp01Icon,
+    MoreHorizontalIcon,
+    Tick02Icon,
+} from '@hugeicons/core-free-icons';
+
+import { Avatar } from '@/components/scp/Avatar';
+import { PriorityBadge } from '@/components/scp/PriorityBadge';
+import { Button } from '@/components/ui/button';
+import { formatTicketDate } from '@/lib/datetime';
+import { cn } from '@/lib/utils';
+
+export interface TicketRow {
+    id: number;
+    number: string;
+    created: string | null;
+    subject: string | null;
+    from: string | null;
+    priority: string | null;
+    assignee: string | null;
+}
+
+export interface PaginationState {
+    page: number;
+    perPage: number;
+    total: number;
+}
+
+interface QueueTicketTableProps {
+    queueId: number;
+    tickets: TicketRow[];
+    pagination: PaginationState;
+}
+
+type SortDirection = 'asc' | 'desc';
+
+interface ColumnDef {
+    id: keyof TicketRow;
+    label: string;
+    sortable: boolean;
+    width?: string;
+}
+
+const COLUMNS: ColumnDef[] = [
+    { id: 'number', label: 'Ticket ID', sortable: true, width: 'w-28' },
+    { id: 'subject', label: 'Subject', sortable: false },
+    { id: 'priority', label: 'Priority', sortable: true, width: 'w-32' },
+    { id: 'from', label: 'Client', sortable: true, width: 'w-56' },
+    { id: 'assignee', label: 'Assignee', sortable: true, width: 'w-44' },
+    { id: 'created', label: 'Request Date', sortable: true, width: 'w-48' },
+];
+
+const ROW_BORDER = 'border-y border-zinc-100';
+const ROW_BORDER_FIRST = 'border-l border-zinc-100';
+const ROW_BORDER_LAST = 'border-r border-zinc-100';
+const ACTIVE_BORDER = 'border-y border-[#5B619D]';
+const ACTIVE_BORDER_FIRST = 'border-l border-[#5B619D]';
+const ACTIVE_BORDER_LAST = 'border-r border-[#5B619D]';
+const ACTIVE_BG = 'bg-[#F3ECFF]';
+
+function CheckboxButton({
+    checked,
+    onChange,
+    label,
+    accent = false,
+}: {
+    checked: boolean;
+    onChange: () => void;
+    label: string;
+    accent?: boolean;
+}) {
+    return (
+        <button
+            type="button"
+            role="checkbox"
+            aria-checked={checked}
+            aria-label={label}
+            onClick={onChange}
+            className={cn(
+                'grid h-4 w-4 place-items-center rounded border transition-colors',
+                checked
+                    ? 'border-[#5B619D] bg-[#5B619D] text-white'
+                    : accent
+                      ? 'border-zinc-400 text-transparent hover:border-zinc-500'
+                      : 'border-zinc-300 text-transparent hover:border-zinc-400',
+            )}
+        >
+            <HugeiconsIcon icon={Tick02Icon} size={10} strokeWidth={3} />
+        </button>
+    );
+}
+
+export function QueueTicketTable({ queueId, tickets, pagination }: QueueTicketTableProps) {
+    const { url } = usePage();
+    const [selected, setSelected] = useState<Set<number>>(new Set());
+    const allSelected = tickets.length > 0 && selected.size === tickets.length;
+
+    const { sortBy, sortDir } = useMemo(() => {
+        const search = url.includes('?') ? url.slice(url.indexOf('?')) : '';
+        const params = new URLSearchParams(search);
+        const sort = params.get('sort') as keyof TicketRow | null;
+        const dir = params.get('dir') as SortDirection | null;
+        const validKey = COLUMNS.some((column) => column.id === sort);
+
+        return {
+            sortBy: validKey ? (sort as keyof TicketRow) : 'created',
+            sortDir: dir === 'asc' ? 'asc' : 'desc',
+        };
+    }, [url]);
+
+    function toggleAll() {
+        setSelected(allSelected ? new Set() : new Set(tickets.map((ticket) => ticket.id)));
+    }
+
+    function toggle(id: number) {
+        setSelected((current) => {
+            const next = new Set(current);
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+            return next;
+        });
+    }
+
+    function handleSort(column: ColumnDef) {
+        if (!column.sortable) return;
+        const nextDir: SortDirection = column.id === sortBy && sortDir === 'asc' ? 'desc' : 'asc';
+        router.get(
+            `/scp/queues/${queueId}`,
+            { sort: column.id, dir: nextDir, page: 1 },
+            { preserveScroll: true, preserveState: true, replace: true },
+        );
+    }
+
+    function navigatePage(nextPage: number) {
+        router.get(
+            `/scp/queues/${queueId}`,
+            { page: nextPage, sort: sortBy, dir: sortDir },
+            { preserveScroll: true, preserveState: true },
+        );
+    }
+
+    const showingFrom = pagination.total === 0 ? 0 : (pagination.page - 1) * pagination.perPage + 1;
+    const showingTo = Math.min(pagination.page * pagination.perPage, pagination.total);
+
+    return (
+        <div className="flex flex-col">
+            <div className="overflow-x-auto px-1">
+                <table className="w-full text-left" style={{ borderCollapse: 'separate', borderSpacing: '0 4px' }}>
+                    <thead>
+                        <tr>
+                            <th scope="col" className="w-12 px-3 py-2 font-normal">
+                                <CheckboxButton
+                                    checked={allSelected}
+                                    onChange={toggleAll}
+                                    label="Select all tickets"
+                                />
+                            </th>
+                            {COLUMNS.map((column) => (
+                                <th
+                                    key={column.id}
+                                    scope="col"
+                                    className={cn(
+                                        'px-3 py-2 text-xs font-normal whitespace-nowrap',
+                                        column.sortable ? 'cursor-pointer text-zinc-500 hover:text-zinc-800' : 'text-zinc-500',
+                                        column.width,
+                                    )}
+                                >
+                                    <button
+                                        type="button"
+                                        onClick={() => handleSort(column)}
+                                        disabled={!column.sortable}
+                                        className="inline-flex items-center gap-1"
+                                    >
+                                        {column.label}
+                                        {column.sortable && (
+                                            <HugeiconsIcon
+                                                icon={sortBy === column.id && sortDir === 'asc' ? ArrowUp01Icon : ArrowDown01Icon}
+                                                size={11}
+                                                className={sortBy === column.id ? 'opacity-100' : 'opacity-50'}
+                                            />
+                                        )}
+                                    </button>
+                                </th>
+                            ))}
+                            <th scope="col" className="w-12 px-3 py-2" aria-label="Actions" />
+                        </tr>
+                    </thead>
+                    <tbody className="text-sm">
+                        {tickets.length === 0 ? (
+                            <tr>
+                                <td
+                                    colSpan={COLUMNS.length + 2}
+                                    className="rounded-lg border border-dashed border-zinc-200 bg-white px-6 py-12 text-center text-sm text-zinc-500"
+                                >
+                                    <p className="font-medium text-zinc-700">No tickets match this queue.</p>
+                                    <p className="mt-1 text-xs">
+                                        The queue&apos;s criteria returned 0 results for tickets you have access to. Try a different queue from the dropdown above.
+                                    </p>
+                                </td>
+                            </tr>
+                        ) : (
+                            tickets.map((ticket) => {
+                                const isSelected = selected.has(ticket.id);
+                                const cellBase = 'px-3 py-3 whitespace-nowrap transition-colors';
+                                const borderClass = isSelected ? ACTIVE_BORDER : ROW_BORDER;
+                                const firstBorder = isSelected ? ACTIVE_BORDER_FIRST : ROW_BORDER_FIRST;
+                                const lastBorder = isSelected ? ACTIVE_BORDER_LAST : ROW_BORDER_LAST;
+                                const cellBg = isSelected
+                                    ? ACTIVE_BG
+                                    : 'bg-white group-hover:bg-zinc-50';
+
+                                return (
+                                    <tr key={ticket.id} className="group">
+                                        <td className={cn(cellBase, borderClass, firstBorder, cellBg, 'rounded-l-lg')}>
+                                            <CheckboxButton
+                                                checked={isSelected}
+                                                onChange={() => toggle(ticket.id)}
+                                                label={`Select ticket ${ticket.number}`}
+                                                accent={isSelected}
+                                            />
+                                        </td>
+                                        <td className={cn(cellBase, borderClass, cellBg, 'font-medium text-zinc-700')}>
+                                            <Link href={`/scp/tickets/${ticket.id}`} className="hover:underline">
+                                                #{ticket.number}
+                                            </Link>
+                                        </td>
+                                        <td className={cn(cellBase, borderClass, cellBg, 'whitespace-normal text-zinc-800')}>
+                                            <Link
+                                                href={`/scp/tickets/${ticket.id}`}
+                                                className="line-clamp-1 hover:underline"
+                                            >
+                                                {ticket.subject ?? '—'}
+                                            </Link>
+                                        </td>
+                                        <td className={cn(cellBase, borderClass, cellBg)}>
+                                            <PriorityBadge priority={ticket.priority} />
+                                        </td>
+                                        <td className={cn(cellBase, borderClass, cellBg, 'text-zinc-700')}>
+                                            {ticket.from ? (
+                                                <span className="flex items-center gap-2">
+                                                    <Avatar name={ticket.from} size={24} />
+                                                    <span className="truncate">{ticket.from}</span>
+                                                </span>
+                                            ) : (
+                                                <span className="text-zinc-400">—</span>
+                                            )}
+                                        </td>
+                                        <td className={cn(cellBase, borderClass, cellBg, 'text-zinc-600')}>
+                                            {ticket.assignee ?? <span className="text-zinc-400">Unassigned</span>}
+                                        </td>
+                                        <td className={cn(cellBase, borderClass, cellBg, 'text-zinc-500')}>
+                                            {formatTicketDate(ticket.created) ?? '—'}
+                                        </td>
+                                        <td className={cn(cellBase, borderClass, lastBorder, cellBg, 'rounded-r-lg text-right')}>
+                                            <button
+                                                type="button"
+                                                disabled
+                                                aria-disabled="true"
+                                                title="Row actions coming soon"
+                                                className="rounded p-1 text-zinc-400 transition-colors hover:text-zinc-600"
+                                            >
+                                                <HugeiconsIcon icon={MoreHorizontalIcon} size={16} />
+                                            </button>
+                                        </td>
+                                    </tr>
+                                );
+                            })
+                        )}
+                    </tbody>
+                </table>
+            </div>
+
+            <footer className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-zinc-100 px-3 pt-4 text-xs text-zinc-500">
+                <span>
+                    {pagination.total === 0
+                        ? 'No tickets'
+                        : `Showing ${showingFrom}–${showingTo} of ${pagination.total}`}
+                </span>
+                <div className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={pagination.page <= 1}
+                        aria-disabled={pagination.page <= 1}
+                        onClick={() => navigatePage(pagination.page - 1)}
+                    >
+                        Previous
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={showingTo >= pagination.total}
+                        aria-disabled={showingTo >= pagination.total}
+                        onClick={() => navigatePage(pagination.page + 1)}
+                    >
+                        Next
+                    </Button>
+                </div>
+            </footer>
+        </div>
+    );
+}

--- a/resources/js/components/scp/QueueTicketTable.tsx
+++ b/resources/js/components/scp/QueueTicketTable.tsx
@@ -1,5 +1,5 @@
 import { Link, router } from '@inertiajs/react';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
     ArrowDown01Icon,
@@ -112,13 +112,19 @@ function buildFilterParams(filters: QueueFilters): Record<string, string | numbe
 
 export function QueueTicketTable({ queueId, tickets, pagination, sort, filters }: QueueTicketTableProps) {
     const [selected, setSelected] = useState<Set<number>>(new Set());
-    const allSelected = tickets.length > 0 && selected.size === tickets.length;
+    const visibleIds = useMemo(() => tickets.map((ticket) => ticket.id), [tickets]);
+    const visibleIdSet = useMemo(() => new Set(visibleIds), [visibleIds]);
+    const allSelected = tickets.length > 0 && tickets.every((ticket) => selected.has(ticket.id));
 
     const sortBy = sort.by;
     const sortDir: SortDirection = sort.dir === 'asc' ? 'asc' : 'desc';
 
+    useEffect(() => {
+        setSelected((current) => new Set([...current].filter((id) => visibleIdSet.has(id))));
+    }, [visibleIdSet]);
+
     function toggleAll() {
-        setSelected(allSelected ? new Set() : new Set(tickets.map((ticket) => ticket.id)));
+        setSelected(allSelected ? new Set() : new Set(visibleIds));
     }
 
     function toggle(id: number) {

--- a/resources/js/components/scp/StatusBadge.tsx
+++ b/resources/js/components/scp/StatusBadge.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@/lib/utils';
+
+interface StatusBadgeProps {
+    status?: string | null;
+    state?: string | null;
+    className?: string;
+}
+
+const STATE_TONES: Record<string, string> = {
+    open: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    answered: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    pending: 'border-amber-200 bg-amber-50 text-amber-800',
+    overdue: 'border-rose-200 bg-rose-50 text-rose-700',
+    resolved: 'border-sky-200 bg-sky-50 text-sky-700',
+    closed: 'border-[#E2E8F0] bg-[#F1F5F9] text-[#475569]',
+    archived: 'border-[#E2E8F0] bg-[#F1F5F9] text-[#475569]',
+    deleted: 'border-rose-200 bg-rose-50 text-rose-700',
+};
+
+const NEUTRAL = 'border-[#E2E8F0] bg-[#F8FAFC] text-[#64748B]';
+
+export function StatusBadge({ status, state, className }: StatusBadgeProps) {
+    if (!status && !state) return null;
+
+    const tone = STATE_TONES[(state ?? '').toLowerCase()] ?? NEUTRAL;
+    const label = status ?? state ?? '';
+
+    return (
+        <span
+            className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]',
+                tone,
+                className,
+            )}
+        >
+            <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
+            {label}
+        </span>
+    );
+}

--- a/resources/js/components/scp/TicketFilterChips.tsx
+++ b/resources/js/components/scp/TicketFilterChips.tsx
@@ -1,64 +1,408 @@
+import { router } from '@inertiajs/react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
     AlertCircleIcon,
     ArrowDown01Icon,
     Calendar01Icon,
+    Cancel01Icon,
     FilterIcon,
     InboxIcon,
     Layers01Icon,
+    Tick02Icon,
 } from '@hugeicons/core-free-icons';
 
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 
-interface FilterChip {
-    id: string;
-    label: string;
-    icon: typeof FilterIcon;
+export interface QueueFilters {
+    state: string[];
+    source: string[];
+    priority: number[];
+    created_from: string | null;
+    created_to: string | null;
 }
 
-const CHIPS: FilterChip[] = [
-    { id: 'type', label: 'Type', icon: Layers01Icon },
-    { id: 'source', label: 'Source', icon: InboxIcon },
-    { id: 'priority', label: 'Priority', icon: AlertCircleIcon },
-    { id: 'date', label: 'Date Added', icon: Calendar01Icon },
+export interface QueueFilterOptions {
+    states: string[];
+    sources: string[];
+    priorities: { id: number; name: string }[];
+}
+
+export interface QueueSortState {
+    by: string;
+    dir: string;
+}
+
+interface TicketFilterChipsProps {
+    queueId: number;
+    filters: QueueFilters;
+    filterOptions: QueueFilterOptions;
+    sort: QueueSortState;
+}
+
+const DATE_PRESETS: { id: string; label: string; days: number | null }[] = [
+    { id: 'today', label: 'Today', days: 0 },
+    { id: 'last_7', label: 'Last 7 days', days: 6 },
+    { id: 'last_30', label: 'Last 30 days', days: 29 },
+    { id: 'last_90', label: 'Last 90 days', days: 89 },
+    { id: 'all', label: 'All time', days: null },
 ];
 
-export function TicketFilterChips({ disabled = true }: { disabled?: boolean }) {
+function isoDate(date: Date): string {
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+}
+
+function startOfRange(days: number): string {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    start.setDate(start.getDate() - days);
+    return isoDate(start);
+}
+
+function activeDatePreset(filters: QueueFilters): string | null {
+    if (!filters.created_from && !filters.created_to) return 'all';
+    const today = isoDate(new Date());
+    if (filters.created_to !== today && filters.created_to !== null) return null;
+
+    for (const preset of DATE_PRESETS) {
+        if (preset.days === null) continue;
+        if (filters.created_from === startOfRange(preset.days) && (filters.created_to === today || filters.created_to === null)) {
+            return preset.id;
+        }
+    }
+    return null;
+}
+
+function formatDateRange(filters: QueueFilters): string {
+    if (filters.created_from && filters.created_to) {
+        return `${filters.created_from} → ${filters.created_to}`;
+    }
+    if (filters.created_from) return `From ${filters.created_from}`;
+    if (filters.created_to) return `Until ${filters.created_to}`;
+    return 'Any';
+}
+
+function titleCase(value: string): string {
+    return value.replace(/(^|[\s_-])([a-z])/g, (_, prefix, letter) => prefix + letter.toUpperCase());
+}
+
+export function TicketFilterChips({ queueId, filters, filterOptions, sort }: TicketFilterChipsProps) {
+    const [openId, setOpenId] = useState<string | null>(null);
+
+    const totalActive = useMemo(() => {
+        return (
+            filters.state.length +
+            filters.source.length +
+            filters.priority.length +
+            (filters.created_from || filters.created_to ? 1 : 0)
+        );
+    }, [filters]);
+
+    function applyFilters(next: QueueFilters) {
+        const params: Record<string, string | number | string[] | number[]> = {
+            page: 1,
+            sort: sort.by,
+            dir: sort.dir,
+        };
+        if (next.state.length > 0) params.state = next.state;
+        if (next.source.length > 0) params.source = next.source;
+        if (next.priority.length > 0) params.priority = next.priority;
+        if (next.created_from) params.created_from = next.created_from;
+        if (next.created_to) params.created_to = next.created_to;
+
+        router.get(`/scp/queues/${queueId}`, params, {
+            preserveScroll: true,
+            preserveState: true,
+            replace: true,
+        });
+    }
+
+    function toggleString(key: 'state' | 'source', value: string) {
+        const set = new Set(filters[key]);
+        if (set.has(value)) set.delete(value); else set.add(value);
+        applyFilters({ ...filters, [key]: Array.from(set) });
+    }
+
+    function togglePriority(id: number) {
+        const set = new Set(filters.priority);
+        if (set.has(id)) set.delete(id); else set.add(id);
+        applyFilters({ ...filters, priority: Array.from(set) });
+    }
+
+    function setDatePreset(preset: { days: number | null }) {
+        if (preset.days === null) {
+            applyFilters({ ...filters, created_from: null, created_to: null });
+            return;
+        }
+        applyFilters({
+            ...filters,
+            created_from: startOfRange(preset.days),
+            created_to: isoDate(new Date()),
+        });
+    }
+
+    function setCustomDate(field: 'created_from' | 'created_to', value: string) {
+        applyFilters({ ...filters, [field]: value === '' ? null : value });
+    }
+
+    function clearAll() {
+        applyFilters({ state: [], source: [], priority: [], created_from: null, created_to: null });
+    }
+
     return (
-        <div className="flex items-center gap-5">
-            {CHIPS.map(({ id, label, icon }) => (
-                <button
-                    key={id}
-                    type="button"
-                    disabled={disabled}
-                    aria-disabled={disabled}
-                    title={disabled ? 'Coming soon' : undefined}
-                    className={cn(
-                        'inline-flex items-center gap-1.5 text-sm transition-colors',
-                        disabled
-                            ? 'cursor-not-allowed text-zinc-400'
-                            : 'text-zinc-600 hover:text-zinc-900',
+        <div className="flex flex-wrap items-center gap-2.5">
+            <Chip
+                id="state"
+                openId={openId}
+                onOpenChange={setOpenId}
+                icon={Layers01Icon}
+                label="Status"
+                count={filters.state.length}
+            >
+                <PopoverList>
+                    {filterOptions.states.length === 0 ? (
+                        <PopoverEmpty text="No statuses available." />
+                    ) : (
+                        filterOptions.states.map((state) => (
+                            <CheckRow
+                                key={state}
+                                checked={filters.state.includes(state)}
+                                onSelect={() => toggleString('state', state)}
+                                label={titleCase(state)}
+                            />
+                        ))
                     )}
-                >
-                    <HugeiconsIcon icon={icon} size={16} />
-                    {label}
-                    <HugeiconsIcon icon={ArrowDown01Icon} size={12} className="opacity-60" />
-                </button>
-            ))}
-            <span className="h-4 w-px bg-zinc-200" aria-hidden />
+                </PopoverList>
+                {filters.state.length > 0 && (
+                    <PopoverFooter onClear={() => applyFilters({ ...filters, state: [] })} />
+                )}
+            </Chip>
+
+            <Chip
+                id="source"
+                openId={openId}
+                onOpenChange={setOpenId}
+                icon={InboxIcon}
+                label="Source"
+                count={filters.source.length}
+            >
+                <PopoverList>
+                    {filterOptions.sources.map((source) => (
+                        <CheckRow
+                            key={source}
+                            checked={filters.source.includes(source)}
+                            onSelect={() => toggleString('source', source)}
+                            label={source}
+                        />
+                    ))}
+                </PopoverList>
+                {filters.source.length > 0 && (
+                    <PopoverFooter onClear={() => applyFilters({ ...filters, source: [] })} />
+                )}
+            </Chip>
+
+            <Chip
+                id="priority"
+                openId={openId}
+                onOpenChange={setOpenId}
+                icon={AlertCircleIcon}
+                label="Priority"
+                count={filters.priority.length}
+            >
+                <PopoverList>
+                    {filterOptions.priorities.length === 0 ? (
+                        <PopoverEmpty text="No priorities available." />
+                    ) : (
+                        filterOptions.priorities.map((priority) => (
+                            <CheckRow
+                                key={priority.id}
+                                checked={filters.priority.includes(priority.id)}
+                                onSelect={() => togglePriority(priority.id)}
+                                label={priority.name}
+                            />
+                        ))
+                    )}
+                </PopoverList>
+                {filters.priority.length > 0 && (
+                    <PopoverFooter onClear={() => applyFilters({ ...filters, priority: [] })} />
+                )}
+            </Chip>
+
+            <Chip
+                id="date"
+                openId={openId}
+                onOpenChange={setOpenId}
+                icon={Calendar01Icon}
+                label="Date Added"
+                count={filters.created_from || filters.created_to ? 1 : 0}
+                value={filters.created_from || filters.created_to ? formatDateRange(filters) : undefined}
+            >
+                <PopoverList>
+                    {DATE_PRESETS.map((preset) => {
+                        const isActive = activeDatePreset(filters) === preset.id;
+                        return (
+                            <CheckRow
+                                key={preset.id}
+                                checked={isActive}
+                                onSelect={() => setDatePreset(preset)}
+                                label={preset.label}
+                                rounded
+                            />
+                        );
+                    })}
+                </PopoverList>
+                <div className="mt-2 border-t border-[#E2E8F0] px-2 py-3">
+                    <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[#94A3B8]">Custom range</p>
+                    <div className="space-y-2">
+                        <DateInput
+                            label="From"
+                            value={filters.created_from ?? ''}
+                            onChange={(value) => setCustomDate('created_from', value)}
+                        />
+                        <DateInput
+                            label="To"
+                            value={filters.created_to ?? ''}
+                            onChange={(value) => setCustomDate('created_to', value)}
+                        />
+                    </div>
+                </div>
+            </Chip>
+
+            <span className="hidden h-4 w-px bg-zinc-200 sm:inline-block" aria-hidden />
+
             <button
                 type="button"
-                disabled={disabled}
-                aria-disabled={disabled}
-                title={disabled ? 'Coming soon' : undefined}
+                onClick={clearAll}
+                disabled={totalActive === 0}
                 className={cn(
-                    'inline-flex items-center gap-1.5 text-sm transition-colors',
-                    disabled ? 'cursor-not-allowed text-zinc-400' : 'text-zinc-600 hover:text-zinc-900',
+                    'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-colors',
+                    totalActive === 0
+                        ? 'cursor-not-allowed text-zinc-400'
+                        : 'text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900',
                 )}
             >
-                <HugeiconsIcon icon={FilterIcon} size={16} />
-                Ticket Filters
+                <HugeiconsIcon icon={Cancel01Icon} size={12} />
+                Clear filters{totalActive > 0 ? ` (${totalActive})` : ''}
             </button>
         </div>
+    );
+}
+
+interface ChipProps {
+    id: string;
+    openId: string | null;
+    onOpenChange: (id: string | null) => void;
+    icon: typeof FilterIcon;
+    label: string;
+    count: number;
+    value?: string;
+    children: ReactNode;
+}
+
+function Chip({ id, openId, onOpenChange, icon, label, count, value, children }: ChipProps) {
+    const open = openId === id;
+    const active = count > 0;
+    return (
+        <Popover open={open} onOpenChange={(next) => onOpenChange(next ? id : null)}>
+            <PopoverTrigger
+                render={
+                    <button
+                        type="button"
+                        className={cn(
+                            'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
+                            active
+                                ? 'border-[#5B619D] bg-[#F3ECFF] text-[#3F4577]'
+                                : 'border-[#E2E8F0] bg-white text-zinc-600 hover:border-[#CBD5E1] hover:text-zinc-900',
+                        )}
+                    >
+                        <HugeiconsIcon icon={icon} size={13} />
+                        <span>{label}</span>
+                        {value && <span className="text-[#94A3B8]">·</span>}
+                        {value && <span className="max-w-[12rem] truncate text-zinc-700">{value}</span>}
+                        {count > 0 && (
+                            <span className="ml-0.5 inline-flex items-center justify-center rounded-full bg-[#5B619D] px-1.5 text-[10px] font-semibold leading-4 text-white">
+                                {count}
+                            </span>
+                        )}
+                        <HugeiconsIcon icon={ArrowDown01Icon} size={11} className="opacity-60" />
+                    </button>
+                }
+            />
+            <PopoverContent className="w-60">
+                {children}
+            </PopoverContent>
+        </Popover>
+    );
+}
+
+function PopoverList({ children }: { children: ReactNode }) {
+    return <div className="max-h-72 space-y-0.5 overflow-y-auto">{children}</div>;
+}
+
+function PopoverEmpty({ text }: { text: string }) {
+    return <p className="px-2 py-3 text-xs text-zinc-500">{text}</p>;
+}
+
+function PopoverFooter({ onClear }: { onClear: () => void }) {
+    return (
+        <div className="mt-1 border-t border-[#E2E8F0] pt-2">
+            <button
+                type="button"
+                onClick={onClear}
+                className="w-full rounded-md px-3 py-1.5 text-left text-xs font-medium text-zinc-600 transition-colors hover:bg-zinc-50 hover:text-zinc-900"
+            >
+                Clear
+            </button>
+        </div>
+    );
+}
+
+interface CheckRowProps {
+    checked: boolean;
+    onSelect: () => void;
+    label: string;
+    rounded?: boolean;
+}
+
+function CheckRow({ checked, onSelect, label, rounded }: CheckRowProps) {
+    return (
+        <button
+            type="button"
+            onClick={onSelect}
+            className={cn(
+                'flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-sm text-[#0F172A] transition-colors hover:bg-[#F8FAFC]',
+            )}
+        >
+            <span
+                className={cn(
+                    'grid h-4 w-4 place-items-center border transition-colors',
+                    rounded ? 'rounded-full' : 'rounded',
+                    checked
+                        ? 'border-[#5B619D] bg-[#5B619D] text-white'
+                        : 'border-zinc-300 bg-white text-transparent',
+                )}
+            >
+                <HugeiconsIcon icon={Tick02Icon} size={10} strokeWidth={3} />
+            </span>
+            <span className="truncate">{label}</span>
+        </button>
+    );
+}
+
+function DateInput({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+    return (
+        <label className="flex items-center justify-between gap-2 text-xs text-zinc-600">
+            <span className="w-12 shrink-0">{label}</span>
+            <input
+                type="date"
+                value={value}
+                onChange={(event) => onChange(event.target.value)}
+                className="w-full rounded-md border border-[#E2E8F0] bg-white px-2 py-1 text-xs text-[#0F172A] focus:border-[#5B619D] focus:outline-none focus:ring-2 focus:ring-[#5B619D]/20"
+            />
+        </label>
     );
 }

--- a/resources/js/components/scp/TicketFilterChips.tsx
+++ b/resources/js/components/scp/TicketFilterChips.tsx
@@ -1,0 +1,64 @@
+import { HugeiconsIcon } from '@hugeicons/react';
+import {
+    AlertCircleIcon,
+    ArrowDown01Icon,
+    Calendar01Icon,
+    FilterIcon,
+    InboxIcon,
+    Layers01Icon,
+} from '@hugeicons/core-free-icons';
+
+import { cn } from '@/lib/utils';
+
+interface FilterChip {
+    id: string;
+    label: string;
+    icon: typeof FilterIcon;
+}
+
+const CHIPS: FilterChip[] = [
+    { id: 'type', label: 'Type', icon: Layers01Icon },
+    { id: 'source', label: 'Source', icon: InboxIcon },
+    { id: 'priority', label: 'Priority', icon: AlertCircleIcon },
+    { id: 'date', label: 'Date Added', icon: Calendar01Icon },
+];
+
+export function TicketFilterChips({ disabled = true }: { disabled?: boolean }) {
+    return (
+        <div className="flex items-center gap-5">
+            {CHIPS.map(({ id, label, icon }) => (
+                <button
+                    key={id}
+                    type="button"
+                    disabled={disabled}
+                    aria-disabled={disabled}
+                    title={disabled ? 'Coming soon' : undefined}
+                    className={cn(
+                        'inline-flex items-center gap-1.5 text-sm transition-colors',
+                        disabled
+                            ? 'cursor-not-allowed text-zinc-400'
+                            : 'text-zinc-600 hover:text-zinc-900',
+                    )}
+                >
+                    <HugeiconsIcon icon={icon} size={16} />
+                    {label}
+                    <HugeiconsIcon icon={ArrowDown01Icon} size={12} className="opacity-60" />
+                </button>
+            ))}
+            <span className="h-4 w-px bg-zinc-200" aria-hidden />
+            <button
+                type="button"
+                disabled={disabled}
+                aria-disabled={disabled}
+                title={disabled ? 'Coming soon' : undefined}
+                className={cn(
+                    'inline-flex items-center gap-1.5 text-sm transition-colors',
+                    disabled ? 'cursor-not-allowed text-zinc-400' : 'text-zinc-600 hover:text-zinc-900',
+                )}
+            >
+                <HugeiconsIcon icon={FilterIcon} size={16} />
+                Ticket Filters
+            </button>
+        </div>
+    );
+}

--- a/resources/js/components/scp/queue-types.ts
+++ b/resources/js/components/scp/queue-types.ts
@@ -1,0 +1,16 @@
+export interface QueueNode {
+    id: number;
+    title: string;
+    children?: QueueNode[];
+}
+
+export interface SavedSearch {
+    id: number;
+    title: string;
+}
+
+export interface QueueNavigation {
+    queues: QueueNode[];
+    personal: QueueNode[];
+    savedSearches: SavedSearch[];
+}

--- a/resources/js/components/ui/popover.tsx
+++ b/resources/js/components/ui/popover.tsx
@@ -1,0 +1,46 @@
+import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
+
+import { cn } from '@/lib/utils';
+
+function Popover(props: PopoverPrimitive.Root.Props) {
+    return <PopoverPrimitive.Root {...props} />;
+}
+
+function PopoverTrigger(props: PopoverPrimitive.Trigger.Props) {
+    return <PopoverPrimitive.Trigger {...props} />;
+}
+
+function PopoverContent({
+    className,
+    side = 'bottom',
+    sideOffset = 6,
+    align = 'start',
+    alignOffset = 0,
+    ...props
+}: PopoverPrimitive.Popup.Props &
+    Pick<PopoverPrimitive.Positioner.Props, 'side' | 'sideOffset' | 'align' | 'alignOffset'>) {
+    return (
+        <PopoverPrimitive.Portal>
+            <PopoverPrimitive.Positioner
+                side={side}
+                sideOffset={sideOffset}
+                align={align}
+                alignOffset={alignOffset}
+                className="isolate z-50"
+            >
+                <PopoverPrimitive.Popup
+                    data-slot="popover-content"
+                    className={cn(
+                        'z-50 min-w-44 origin-(--transform-origin) rounded-xl border border-[#E2E8F0] bg-white p-2 text-[#0F172A] shadow-lg shadow-black/5 outline-none',
+                        'data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1',
+                        'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+                        className,
+                    )}
+                    {...props}
+                />
+            </PopoverPrimitive.Positioner>
+        </PopoverPrimitive.Portal>
+    );
+}
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/resources/js/components/ui/select.tsx
+++ b/resources/js/components/ui/select.tsx
@@ -3,7 +3,7 @@ import { Select as SelectPrimitive } from "@base-ui/react/select"
 
 import { cn } from "@/lib/utils"
 import { HugeiconsIcon } from "@hugeicons/react"
-import { UnfoldMoreIcon, Tick02Icon, ArrowUp01Icon, ArrowDown01Icon } from "@hugeicons/core-free-icons"
+import { ArrowDown01Icon, Tick02Icon, ArrowUp01Icon } from "@hugeicons/core-free-icons"
 
 const Select = SelectPrimitive.Root
 
@@ -48,7 +48,7 @@ function SelectTrigger({
       {children}
       <SelectPrimitive.Icon
         render={
-          <HugeiconsIcon icon={UnfoldMoreIcon} strokeWidth={2} className="pointer-events-none size-4 text-muted-foreground" />
+          <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} className="pointer-events-none size-4 text-muted-foreground" />
         }
       />
     </SelectPrimitive.Trigger>

--- a/resources/js/components/ui/skeleton.tsx
+++ b/resources/js/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@/lib/utils';
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div
+            className={cn('animate-pulse rounded-md bg-[#F1F5F9]', className)}
+            {...props}
+        />
+    );
+}
+
+export { Skeleton };

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -112,12 +112,13 @@ function DefaultHeaderActions() {
             >
                 {t('dashboard.layout.my_queue')}
             </Link>
-            <Link
-                href="/scp/tickets/create"
-                className={cn(buttonVariants({ size: 'sm' }), "rounded-[4px] bg-[#5B619D] px-4 text-xs font-medium uppercase tracking-[0.12em] text-white hover:bg-[#4F548C] shadow-[0_10px_25px_-20px_rgba(91,97,157,0.7)]")}
+            <button
+                type="button"
+                disabled
+                className={cn(buttonVariants({ size: 'sm' }), "rounded-[4px] bg-[#5B619D] px-4 text-xs font-medium uppercase tracking-[0.12em] text-white hover:bg-[#4F548C] disabled:cursor-not-allowed disabled:opacity-60 shadow-[0_10px_25px_-20px_rgba(91,97,157,0.7)]")}
             >
                 {t('dashboard.layout.new_ticket')}
-            </Link>
+            </button>
         </>
     );
 }

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -1,15 +1,18 @@
-import { Children, useRef, useState, type ReactNode } from 'react';
+import { Children, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Link, router } from '@inertiajs/react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { useTranslation } from 'react-i18next';
 import {
+    ArrowLeft01Icon,
     ArrowRight01Icon,
     BarChartIcon,
     BookOpen01Icon,
+    Cancel01Icon,
     CustomerService01Icon,
     DashboardSquare01Icon,
     InboxIcon,
     LogoutSquare01Icon,
+    Menu01Icon,
     Message01Icon,
     Notification01Icon,
     Search01Icon,
@@ -30,6 +33,7 @@ import {
 } from '@/components/ui/input-group';
 import { Kbd } from '@/components/ui/kbd';
 import { Separator } from '@/components/ui/separator';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 interface DashboardLayoutProps {
@@ -73,23 +77,21 @@ const PINNED_TICKETS = [
     { label: '+1 678-908-78...' },
 ] as const;
 
+const COLLAPSE_STORAGE_KEY = 'scp.sidebar.collapsed';
+const MOBILE_BREAKPOINT = '(max-width: 1023px)';
+
 const navBaseClass = 'flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium font-body transition-colors duration-150';
-const navActiveClass = `${navBaseClass} bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
-const navInactiveClass = `${navBaseClass} text-[#64748B] hover:bg-white hover:text-[#0F172A]`;
-const navDisabledClass = `${navBaseClass} cursor-not-allowed text-[#94A3B8] opacity-50`;
+const navCollapsedBaseClass = 'flex items-center justify-center rounded-md p-2.5 transition-colors duration-150';
+const navActiveBg = 'bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]';
+const navInactiveBg = 'text-[#64748B] hover:bg-white hover:text-[#0F172A]';
+const navDisabledBg = 'cursor-not-allowed text-[#94A3B8] opacity-50';
+
 const footerActionBaseClass = 'inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-xs font-medium transition-colors';
 const footerActionActiveClass = `${footerActionBaseClass} border-[#CBD5E1] bg-[#F1F5F9] text-[#0F172A] shadow-[inset_0_0_0_1px_rgba(226,232,240,0.8)]`;
 const footerActionInactiveClass = `${footerActionBaseClass} border-[#E2E8F0] bg-white text-[#64748B] hover:text-[#0F172A]`;
 
-function getNavClasses(activeNav: string | undefined, navItem: string, disabled = false): string {
-    if (disabled) return navDisabledClass;
-
-    return activeNav === navItem ? navActiveClass : navInactiveClass;
-}
-
-function getNavIconColor(activeNav: string | undefined, navItem: string, disabled = false): string {
+function navIconColor(activeNav: string | undefined, navItem: string, disabled = false): string {
     if (disabled) return '#CBD5E1';
-
     return activeNav === navItem ? '#5B619D' : '#94A3B8';
 }
 
@@ -99,6 +101,28 @@ function getFooterActionClasses(activeNav: string | undefined, navItem: string):
 
 function getFooterActionIconColor(activeNav: string | undefined, navItem: string): string {
     return activeNav === navItem ? '#5B619D' : '#94A3B8';
+}
+
+function useMediaQuery(query: string): boolean {
+    const getInitial = () => {
+        if (typeof window === 'undefined') return false;
+        return window.matchMedia(query).matches;
+    };
+
+    const [matches, setMatches] = useState<boolean>(getInitial);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+
+        const mql = window.matchMedia(query);
+        const onChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+
+        setMatches(mql.matches);
+        mql.addEventListener('change', onChange);
+        return () => mql.removeEventListener('change', onChange);
+    }, [query]);
+
+    return matches;
 }
 
 function DefaultHeaderActions() {
@@ -149,6 +173,392 @@ function SearchField({ defaultQuery = '' }: { defaultQuery?: string }) {
     );
 }
 
+interface NavLinkProps {
+    item: NavItem;
+    activeNav: string | undefined;
+    collapsed: boolean;
+    onNavigate?: () => void;
+}
+
+function NavLink({ item, activeNav, collapsed, onNavigate }: NavLinkProps) {
+    const { t } = useTranslation();
+    const { id, labelKey, icon, href } = item;
+    const isActive = activeNav === id;
+    const disabled = !href;
+
+    const baseClass = collapsed ? navCollapsedBaseClass : navBaseClass;
+    const stateClass = disabled ? navDisabledBg : isActive ? navActiveBg : navInactiveBg;
+    const className = cn(baseClass, stateClass, !collapsed && disabled && 'w-full text-left');
+
+    const content = (
+        <>
+            <HugeiconsIcon icon={icon} size={18} color={navIconColor(activeNav, id, disabled)} />
+            {!collapsed && <span>{t(labelKey)}</span>}
+        </>
+    );
+
+    const inner = href ? (
+        <Link href={href} className={className} onClick={onNavigate} aria-label={collapsed ? t(labelKey) : undefined}>
+            {content}
+        </Link>
+    ) : (
+        <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            aria-label={collapsed ? t(labelKey) : undefined}
+            className={className}
+        >
+            {content}
+        </button>
+    );
+
+    if (!collapsed) return inner;
+
+    return (
+        <Tooltip>
+            <TooltipTrigger render={inner} />
+            <TooltipContent side="right">{t(labelKey)}</TooltipContent>
+        </Tooltip>
+    );
+}
+
+interface SidebarBodyProps {
+    activeNav: string | undefined;
+    collapsed: boolean;
+    isLoggingOut: boolean;
+    onLogout: () => void;
+    onToggleCollapse?: () => void;
+    onClose?: () => void;
+    showCollapseToggle: boolean;
+    showCloseButton: boolean;
+    searchQuery?: string;
+}
+
+function SidebarBody({
+    activeNav,
+    collapsed,
+    isLoggingOut,
+    onLogout,
+    onToggleCollapse,
+    onClose,
+    showCollapseToggle,
+    showCloseButton,
+    searchQuery,
+}: SidebarBodyProps) {
+    const { t } = useTranslation();
+
+    return (
+        <>
+            <div className={cn('transition-colors hover:bg-white/70', collapsed ? 'px-3 py-5' : 'px-5 py-5')}>
+                <div className={cn('flex items-center gap-3', collapsed ? 'justify-center' : 'justify-between')}>
+                    {!collapsed && (
+                        <div className="flex items-center gap-3">
+                            <div className="auth-gradient flex h-9 w-9 items-center justify-center rounded-full text-[11px] font-semibold tracking-[0.02em] text-white shadow-[0_12px_24px_-18px_rgba(91,97,157,0.9)]">
+                                SCP
+                            </div>
+                            <div>
+                                <div className="font-body text-sm font-medium leading-none text-[#0F172A]">osTicket SCP</div>
+                                <div className="mt-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[#94A3B8]">Agent Admin</div>
+                            </div>
+                        </div>
+                    )}
+                    {collapsed && (
+                        <div className="auth-gradient flex h-9 w-9 items-center justify-center rounded-full text-[11px] font-semibold tracking-[0.02em] text-white shadow-[0_12px_24px_-18px_rgba(91,97,157,0.9)]">
+                            SCP
+                        </div>
+                    )}
+                    {showCloseButton && (
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            aria-label={t('dashboard.layout.close_menu', { defaultValue: 'Close menu' })}
+                            className="grid h-8 w-8 place-items-center rounded-md text-[#64748B] transition-colors hover:bg-white hover:text-[#0F172A]"
+                        >
+                            <HugeiconsIcon icon={Cancel01Icon} size={18} />
+                        </button>
+                    )}
+                    {!showCloseButton && showCollapseToggle && (
+                        <Tooltip>
+                            <TooltipTrigger
+                                render={
+                                    <button
+                                        type="button"
+                                        onClick={onToggleCollapse}
+                                        aria-pressed={collapsed}
+                                        aria-label={collapsed
+                                            ? t('dashboard.layout.expand_sidebar', { defaultValue: 'Expand sidebar' })
+                                            : t('dashboard.layout.collapse_sidebar', { defaultValue: 'Collapse sidebar' })
+                                        }
+                                        className={cn(
+                                            'grid h-8 w-8 place-items-center rounded-md text-[#94A3B8] transition-colors hover:bg-white hover:text-[#0F172A]',
+                                            collapsed && 'mt-1',
+                                        )}
+                                    >
+                                        <HugeiconsIcon icon={collapsed ? ArrowRight01Icon : ArrowLeft01Icon} size={16} />
+                                    </button>
+                                }
+                            />
+                            <TooltipContent side="right">
+                                {collapsed
+                                    ? t('dashboard.layout.expand_sidebar', { defaultValue: 'Expand sidebar' })
+                                    : t('dashboard.layout.collapse_sidebar', { defaultValue: 'Collapse sidebar' })
+                                }
+                            </TooltipContent>
+                        </Tooltip>
+                    )}
+                </div>
+            </div>
+
+            <Separator className="bg-[#E2E8F0]" />
+
+            {!collapsed && (
+                <div className="px-5 py-4">
+                    <SearchField defaultQuery={searchQuery} />
+                </div>
+            )}
+
+            <div className="custom-scrollbar flex-1 overflow-y-auto pb-6">
+                <nav className={cn('space-y-0.5', collapsed ? 'px-2' : 'px-3')}>
+                    {NAV_ITEMS.map((item) => (
+                        <NavLink
+                            key={item.id}
+                            item={item}
+                            activeNav={activeNav}
+                            collapsed={collapsed}
+                            onNavigate={onClose}
+                        />
+                    ))}
+                </nav>
+
+                {!collapsed && (
+                    <>
+                        <section className="mt-7 px-6">
+                            <div className="auth-caption mb-3">{t('dashboard.layout.conversation')}</div>
+                            <div className="space-y-2">
+                                {CONVERSATION_ITEMS.map(({ id, label, subtitle, icon, badge, badgeActive }) => (
+                                    <Card key={id} className={cn(
+                                        'rounded-xl border py-0 opacity-70 ring-0 shadow-none transition-colors',
+                                        id === 'side-conversation'
+                                            ? 'border-[#E2E8F0] bg-white shadow-sm shadow-[#0F172A]/[0.03]'
+                                            : 'border-transparent bg-transparent',
+                                    )}>
+                                        <CardContent className="px-4 py-3">
+                                            <button
+                                                type="button"
+                                                disabled
+                                                aria-disabled="true"
+                                                className="flex w-full cursor-not-allowed items-center justify-between gap-3 text-left"
+                                            >
+                                                <div className="flex items-center gap-3">
+                                                    <div className={cn(
+                                                        'flex h-9 w-9 items-center justify-center rounded-lg',
+                                                        id === 'side-conversation' ? 'bg-[#F1F5F9]' : 'border border-[#E2E8F0] bg-white',
+                                                    )}>
+                                                        <HugeiconsIcon icon={icon} size={18} color={id === 'side-conversation' ? '#64748B' : '#5B619D'} />
+                                                    </div>
+                                                    <div>
+                                                        <div className="font-body text-sm font-medium text-[#0F172A]">{label}</div>
+                                                        <div className="text-xs text-[#94A3B8]">{subtitle}</div>
+                                                    </div>
+                                                </div>
+                                                <span className={cn(
+                                                    'inline-flex min-w-5 items-center justify-center rounded-full px-1.5 py-1 text-[10px] font-semibold leading-none',
+                                                    badgeActive ? 'bg-[#C4A5F3] text-[#0F172A]' : 'bg-[#E2E8F0] text-[#64748B]',
+                                                )}>
+                                                    {badge}
+                                                </span>
+                                            </button>
+                                        </CardContent>
+                                    </Card>
+                                ))}
+                            </div>
+                        </section>
+
+                        <section className="mt-7 px-6">
+                            <div className="auth-caption mb-2">{t('dashboard.layout.favorites')}</div>
+                            <p className="max-w-47.5 text-xs leading-5 text-[#94A3B8]">
+                                {t('dashboard.layout.favorites_hint')}
+                            </p>
+                        </section>
+
+                        <section className="mt-7 px-6">
+                            <div className="mb-3 flex items-center justify-between gap-3">
+                                <div className="auth-caption">{t('dashboard.layout.pinned_tickets')}</div>
+                                <Button
+                                    variant="ghost"
+                                    size="xs"
+                                    disabled
+                                    aria-disabled="true"
+                                    className="h-auto rounded-[4px] px-0 text-[11px] text-[#94A3B8] hover:bg-transparent hover:text-[#94A3B8]"
+                                >
+                                    {t('dashboard.layout.unpin_all')}
+                                </Button>
+                            </div>
+                            <div className="space-y-3">
+                                {PINNED_TICKETS.map(({ label }, index) => (
+                                    <button
+                                        key={label}
+                                        type="button"
+                                        disabled
+                                        aria-disabled="true"
+                                        className="flex w-full cursor-not-allowed items-center justify-between gap-3 text-left opacity-70"
+                                    >
+                                        <div className="flex min-w-0 items-center gap-2">
+                                            <div className={cn(
+                                                'flex h-4 w-4 items-center justify-center rounded-full',
+                                                index < 2 ? 'bg-[#22C55E] text-white' : 'bg-[#F1F5F9] text-[#64748B]',
+                                            )}>
+                                                <span className="text-[9px] leading-none">•</span>
+                                            </div>
+                                            <span className="truncate font-body text-sm font-medium text-[#64748B] transition-colors">
+                                                {label}
+                                            </span>
+                                        </div>
+                                        <span className="text-xs text-[#CBD5E1] transition-colors">⌁</span>
+                                    </button>
+                                ))}
+
+                                <Button
+                                    variant="ghost"
+                                    disabled
+                                    aria-disabled="true"
+                                    className="mt-1 h-auto justify-start rounded-[4px] px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#0F172A]"
+                                >
+                                    <span className="text-lg leading-none">+</span>
+                                    {t('dashboard.layout.add_new')}
+                                </Button>
+                            </div>
+                        </section>
+                    </>
+                )}
+            </div>
+
+            <Separator className="bg-[#E2E8F0]" />
+
+            <div className={cn('mt-auto', collapsed ? 'flex flex-col items-center gap-2 px-2 py-4' : 'px-5 py-5')}>
+                {collapsed ? (
+                    <>
+                        <Tooltip>
+                            <TooltipTrigger
+                                render={
+                                    <Link
+                                        href="/scp/preferences"
+                                        aria-label={t('dashboard.layout.preferences')}
+                                        className={cn(
+                                            'grid h-9 w-9 place-items-center rounded-md transition-colors',
+                                            activeNav === 'preferences'
+                                                ? 'bg-[#F1F5F9] text-[#0F172A]'
+                                                : 'text-[#64748B] hover:bg-white hover:text-[#0F172A]',
+                                        )}
+                                        aria-current={activeNav === 'preferences' ? 'page' : undefined}
+                                    >
+                                        <HugeiconsIcon icon={Settings01Icon} size={18} color={activeNav === 'preferences' ? '#5B619D' : '#94A3B8'} />
+                                    </Link>
+                                }
+                            />
+                            <TooltipContent side="right">{t('dashboard.layout.preferences')}</TooltipContent>
+                        </Tooltip>
+
+                        <Tooltip>
+                            <TooltipTrigger
+                                render={
+                                    <Link
+                                        href="/scp/account/security"
+                                        aria-label={t('dashboard.layout.security')}
+                                        className={cn(
+                                            'grid h-9 w-9 place-items-center rounded-md transition-colors',
+                                            activeNav === 'security'
+                                                ? 'bg-[#F1F5F9] text-[#0F172A]'
+                                                : 'text-[#64748B] hover:bg-white hover:text-[#0F172A]',
+                                        )}
+                                        aria-current={activeNav === 'security' ? 'page' : undefined}
+                                    >
+                                        <HugeiconsIcon icon={ShieldCheck} size={16} color={activeNav === 'security' ? '#5B619D' : '#94A3B8'} />
+                                    </Link>
+                                }
+                            />
+                            <TooltipContent side="right">{t('dashboard.layout.security')}</TooltipContent>
+                        </Tooltip>
+
+                        <Tooltip>
+                            <TooltipTrigger
+                                render={
+                                    <button
+                                        type="button"
+                                        disabled={isLoggingOut}
+                                        onClick={onLogout}
+                                        aria-label={t('actions.logout')}
+                                        className="grid h-9 w-9 place-items-center rounded-md text-[#64748B] transition-colors hover:bg-white hover:text-red-600 disabled:opacity-60"
+                                    >
+                                        <HugeiconsIcon icon={LogoutSquare01Icon} size={16} color="#94A3B8" />
+                                    </button>
+                                }
+                            />
+                            <TooltipContent side="right">{t('actions.logout')}</TooltipContent>
+                        </Tooltip>
+                    </>
+                ) : (
+                    <>
+                        <Link
+                            href="/scp/preferences"
+                            className={cn(
+                                'mb-4 inline-flex h-auto items-center gap-2 rounded-md px-0 text-sm transition-colors',
+                                activeNav === 'preferences'
+                                    ? 'text-[#0F172A]'
+                                    : 'text-[#64748B] hover:text-[#0F172A]',
+                            )}
+                            aria-current={activeNav === 'preferences' ? 'page' : undefined}
+                            onClick={onClose}
+                        >
+                            <HugeiconsIcon
+                                icon={Settings01Icon}
+                                size={18}
+                                color={activeNav === 'preferences' ? '#5B619D' : '#94A3B8'}
+                            />
+                            <span>{t('dashboard.layout.preferences')}</span>
+                        </Link>
+
+                        <Card className="mb-4 rounded-[7px] border-[#E2E8F0] py-0 shadow-sm shadow-[#0F172A]/[0.03] ring-0">
+                            <CardContent className="flex items-center justify-between gap-3 px-3 py-3">
+                                <div>
+                                    <div className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">{t('dashboard.layout.powered_by')}</div>
+                                    <div className="mt-1 font-display text-lg font-medium tracking-tight text-[#0F172A]">osTicket 2.0</div>
+                                </div>
+                                <div className="flex h-8 w-8 items-center justify-center rounded-[4px] bg-[#F1F5F9] text-[#5B619D]">
+                                    <HugeiconsIcon icon={DashboardSquare01Icon} size={18} color="#5B619D" />
+                                </div>
+                            </CardContent>
+                        </Card>
+
+                        <div className="grid grid-cols-2 gap-2">
+                            <Link
+                                href="/scp/account/security"
+                                className={getFooterActionClasses(activeNav, 'security')}
+                                aria-current={activeNav === 'security' ? 'page' : undefined}
+                                onClick={onClose}
+                            >
+                                <HugeiconsIcon icon={ShieldCheck} size={14} color={getFooterActionIconColor(activeNav, 'security')} />
+                                {t('dashboard.layout.security')}
+                            </Link>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={isLoggingOut}
+                                onClick={onLogout}
+                                className="cursor-pointer rounded-[4px] border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:bg-[#F8FAFC] hover:text-red-600"
+                            >
+                                <HugeiconsIcon icon={LogoutSquare01Icon} size={14} color="#94A3B8" />
+                                {t('actions.logout')}
+                            </Button>
+                        </div>
+                    </>
+                )}
+            </div>
+        </>
+    );
+}
+
 export default function DashboardLayout({
     title,
     subtitle,
@@ -167,14 +577,36 @@ export default function DashboardLayout({
     const [isLoggingOut, setIsLoggingOut] = useState(false);
     const isLoggingOutRef = useRef(false);
 
-    function logout() {
-        if (isLoggingOutRef.current) {
-            return;
-        }
+    const isMobile = useMediaQuery(MOBILE_BREAKPOINT);
 
+    const [desktopCollapsed, setDesktopCollapsed] = useState<boolean>(() => {
+        if (typeof window === 'undefined') return false;
+        try {
+            return window.localStorage.getItem(COLLAPSE_STORAGE_KEY) === '1';
+        } catch {
+            return false;
+        }
+    });
+
+    const [mobileOpen, setMobileOpen] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        try {
+            window.localStorage.setItem(COLLAPSE_STORAGE_KEY, desktopCollapsed ? '1' : '0');
+        } catch {
+            /* ignore quota / private mode */
+        }
+    }, [desktopCollapsed]);
+
+    useEffect(() => {
+        if (!isMobile) setMobileOpen(false);
+    }, [isMobile]);
+
+    function logout() {
+        if (isLoggingOutRef.current) return;
         isLoggingOutRef.current = true;
         setIsLoggingOut(true);
-
         router.post('/scp/logout', {}, {
             onFinish: () => {
                 isLoggingOutRef.current = false;
@@ -183,238 +615,101 @@ export default function DashboardLayout({
         });
     }
 
+    const sidebarCollapsed = isMobile ? false : desktopCollapsed;
+    const sidebarWidthClass = sidebarCollapsed ? 'w-16' : 'w-72';
+
     return (
-        <div className="auth-theme relative flex h-screen overflow-hidden bg-[#E9ECEF] text-[#0F172A]">
-            <div className="auth-mesh pointer-events-none absolute inset-0" aria-hidden />
-            <div className="auth-grain pointer-events-none absolute inset-0" aria-hidden />
+        <TooltipProvider delay={150}>
+            <div className="auth-theme relative flex h-screen overflow-hidden bg-[#E9ECEF] text-[#0F172A]">
+                <div className="auth-mesh pointer-events-none absolute inset-0" aria-hidden />
+                <div className="auth-grain pointer-events-none absolute inset-0" aria-hidden />
 
-            <div className="relative z-10 flex h-full w-full">
-                <div className="flex h-full w-full overflow-hidden bg-white">
-                    <aside className="flex w-72 shrink-0 flex-col border-r border-[#E2E8F0] bg-[#F8FAFC]/90">
-                        <div className="px-5 py-5 transition-colors hover:bg-white/70">
-                            <div className="flex items-center justify-between gap-3">
-                                <div className="flex items-center gap-3">
-                                    <div className="auth-gradient flex h-9 w-9 items-center justify-center rounded-full text-[11px] font-semibold tracking-[0.02em] text-white shadow-[0_12px_24px_-18px_rgba(91,97,157,0.9)]">
-                                        SCP
-                                    </div>
-                                    <div>
-                                        <div className="font-body text-sm font-medium leading-none text-[#0F172A]">osTicket SCP</div>
-                                        <div className="mt-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[#94A3B8]">Agent Admin</div>
-                                    </div>
-                                </div>
-                                <HugeiconsIcon icon={ArrowRight01Icon} size={16} color="#94A3B8" className="rotate-90" />
-                            </div>
-                        </div>
-
-                        <Separator className="bg-[#E2E8F0]" />
-
-                        <div className="px-5 py-4">
-                            <SearchField defaultQuery={searchQuery} />
-                        </div>
-
-                        <div className="custom-scrollbar flex-1 overflow-y-auto pb-6">
-                            <nav className="space-y-0.5 px-3">
-                                {NAV_ITEMS.map(({ id, labelKey, icon, href }) => {
-                                    const content = (
-                                        <>
-                                            <HugeiconsIcon icon={icon} size={18} color={getNavIconColor(activeNav, id, !href)} />
-                                            <span>{t(labelKey)}</span>
-                                        </>
-                                    );
-
-                                    return href ? (
-                                        <Link key={id} href={href} className={getNavClasses(activeNav, id)}>
-                                            {content}
-                                        </Link>
-                                    ) : (
-                                        <button
-                                            key={id}
-                                            type="button"
-                                            disabled
-                                            aria-disabled="true"
-                                            className={`${getNavClasses(activeNav, id, true)} w-full text-left`}
-                                        >
-                                            {content}
-                                        </button>
-                                    );
-                                })}
-                            </nav>
-
-                            <section className="mt-7 px-6">
-                                <div className="auth-caption mb-3">{t('dashboard.layout.conversation')}</div>
-                                <div className="space-y-2">
-                                    {CONVERSATION_ITEMS.map(({ id, label, subtitle, icon, badge, badgeActive }) => (
-                                        <Card key={id} className={cn(
-                                            'rounded-xl border py-0 opacity-70 ring-0 shadow-none transition-colors',
-                                            id === 'side-conversation'
-                                                ? 'border-[#E2E8F0] bg-white shadow-sm shadow-[#0F172A]/[0.03]'
-                                                : 'border-transparent bg-transparent',
-                                        )}>
-                                            <CardContent className="px-4 py-3">
-                                                <button
-                                                    type="button"
-                                                    disabled
-                                                    aria-disabled="true"
-                                                    className="flex w-full cursor-not-allowed items-center justify-between gap-3 text-left"
-                                                >
-                                                    <div className="flex items-center gap-3">
-                                                        <div className={cn(
-                                                            'flex h-9 w-9 items-center justify-center rounded-lg',
-                                                            id === 'side-conversation' ? 'bg-[#F1F5F9]' : 'border border-[#E2E8F0] bg-white',
-                                                        )}>
-                                                            <HugeiconsIcon icon={icon} size={18} color={id === 'side-conversation' ? '#64748B' : '#5B619D'} />
-                                                        </div>
-                                                        <div>
-                                                            <div className="font-body text-sm font-medium text-[#0F172A]">{label}</div>
-                                                            <div className="text-xs text-[#94A3B8]">{subtitle}</div>
-                                                        </div>
-                                                    </div>
-                                                    <span className={cn(
-                                                        'inline-flex min-w-5 items-center justify-center rounded-full px-1.5 py-1 text-[10px] font-semibold leading-none',
-                                                        badgeActive ? 'bg-[#C4A5F3] text-[#0F172A]' : 'bg-[#E2E8F0] text-[#64748B]',
-                                                    )}>
-                                                        {badge}
-                                                    </span>
-                                                </button>
-                                            </CardContent>
-                                        </Card>
-                                    ))}
-                                </div>
-                            </section>
-
-                            <section className="mt-7 px-6">
-                                <div className="auth-caption mb-2">{t('dashboard.layout.favorites')}</div>
-                                <p className="max-w-47.5 text-xs leading-5 text-[#94A3B8]">
-                                    {t('dashboard.layout.favorites_hint')}
-                                </p>
-                            </section>
-
-                            <section className="mt-7 px-6">
-                                <div className="mb-3 flex items-center justify-between gap-3">
-                                    <div className="auth-caption">{t('dashboard.layout.pinned_tickets')}</div>
-                                    <Button
-                                        variant="ghost"
-                                        size="xs"
-                                        disabled
-                                        aria-disabled="true"
-                                        className="h-auto rounded-[4px] px-0 text-[11px] text-[#94A3B8] hover:bg-transparent hover:text-[#94A3B8]"
-                                    >
-                                        {t('dashboard.layout.unpin_all')}
-                                    </Button>
-                                </div>
-                                <div className="space-y-3">
-                                    {PINNED_TICKETS.map(({ label }, index) => (
-                                        <button
-                                            key={label}
-                                            type="button"
-                                            disabled
-                                            aria-disabled="true"
-                                            className="flex w-full cursor-not-allowed items-center justify-between gap-3 text-left opacity-70"
-                                        >
-                                            <div className="flex min-w-0 items-center gap-2">
-                                                <div className={cn(
-                                                    'flex h-4 w-4 items-center justify-center rounded-full',
-                                                    index < 2 ? 'bg-[#22C55E] text-white' : 'bg-[#F1F5F9] text-[#64748B]',
-                                                )}>
-                                                    <span className="text-[9px] leading-none">•</span>
-                                                </div>
-                                                <span className="truncate font-body text-sm font-medium text-[#64748B] transition-colors">
-                                                    {label}
-                                                </span>
-                                            </div>
-                                            <span className="text-xs text-[#CBD5E1] transition-colors">⌁</span>
-                                        </button>
-                                    ))}
-
-                                    <Button
-                                        variant="ghost"
-                                        disabled
-                                        aria-disabled="true"
-                                        className="mt-1 h-auto justify-start rounded-[4px] px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#0F172A]"
-                                    >
-                                        <span className="text-lg leading-none">+</span>
-                                        {t('dashboard.layout.add_new')}
-                                    </Button>
-                                </div>
-                            </section>
-                        </div>
-
-                        <Separator className="bg-[#E2E8F0]" />
-
-                        <div className="mt-auto px-5 py-5">
-                            <Link
-                                href="/scp/preferences"
-                                className={cn(
-                                    'mb-4 inline-flex h-auto items-center gap-2 rounded-md px-0 text-sm transition-colors',
-                                    activeNav === 'preferences'
-                                        ? 'text-[#0F172A]'
-                                        : 'text-[#64748B] hover:text-[#0F172A]',
-                                )}
-                                aria-current={activeNav === 'preferences' ? 'page' : undefined}
-                            >
-                                <HugeiconsIcon
-                                    icon={Settings01Icon}
-                                    size={18}
-                                    color={activeNav === 'preferences' ? '#5B619D' : '#94A3B8'}
+                <div className="relative z-10 flex h-full w-full">
+                    <div className="flex h-full w-full overflow-hidden bg-white">
+                        {/* Mobile slide-in sidebar */}
+                        {isMobile && (
+                            <>
+                                <div
+                                    className={cn(
+                                        'pointer-events-none fixed inset-0 z-40 bg-[#0F172A]/40 transition-opacity duration-200',
+                                        mobileOpen ? 'pointer-events-auto opacity-100' : 'opacity-0',
+                                    )}
+                                    aria-hidden
+                                    onClick={() => setMobileOpen(false)}
                                 />
-                                <span>{t('dashboard.layout.preferences')}</span>
-                            </Link>
-
-                            <Card className="mb-4 rounded-[7px] border-[#E2E8F0] py-0 shadow-sm shadow-[#0F172A]/[0.03] ring-0">
-                                <CardContent className="flex items-center justify-between gap-3 px-3 py-3">
-                                    <div>
-                                        <div className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">{t('dashboard.layout.powered_by')}</div>
-                                        <div className="mt-1 font-display text-lg font-medium tracking-tight text-[#0F172A]">osTicket 2.0</div>
-                                    </div>
-                                    <div className="flex h-8 w-8 items-center justify-center rounded-[4px] bg-[#F1F5F9] text-[#5B619D]">
-                                        <HugeiconsIcon icon={DashboardSquare01Icon} size={18} color="#5B619D" />
-                                    </div>
-                                </CardContent>
-                            </Card>
-
-                            <div className="grid grid-cols-2 gap-2">
-                                <Link
-                                    href="/scp/account/security"
-                                    className={getFooterActionClasses(activeNav, 'security')}
-                                    aria-current={activeNav === 'security' ? 'page' : undefined}
+                                <aside
+                                    aria-label="Sidebar"
+                                    className={cn(
+                                        'fixed inset-y-0 left-0 z-50 flex w-72 max-w-[85vw] flex-col border-r border-[#E2E8F0] bg-[#F8FAFC] shadow-2xl shadow-black/10 transition-transform duration-200',
+                                        mobileOpen ? 'translate-x-0' : '-translate-x-full',
+                                    )}
                                 >
-                                    <HugeiconsIcon icon={ShieldCheck} size={14} color={getFooterActionIconColor(activeNav, 'security')} />
-                                    {t('dashboard.layout.security')}
-                                </Link>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    disabled={isLoggingOut}
-                                    onClick={logout}
-                                    className="cursor-pointer rounded-[4px] border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:bg-[#F8FAFC] hover:text-red-600"
-                                >
-                                    <HugeiconsIcon icon={LogoutSquare01Icon} size={14} color="#94A3B8" />
-                                    {t('actions.logout')}
-                                </Button>
-                            </div>
+                                    <SidebarBody
+                                        activeNav={activeNav}
+                                        collapsed={false}
+                                        isLoggingOut={isLoggingOut}
+                                        onLogout={() => { setMobileOpen(false); logout(); }}
+                                        onClose={() => setMobileOpen(false)}
+                                        showCloseButton
+                                        showCollapseToggle={false}
+                                        searchQuery={searchQuery}
+                                    />
+                                </aside>
+                            </>
+                        )}
+
+                        {/* Desktop sidebar */}
+                        {!isMobile && (
+                            <aside className={cn(
+                                'flex shrink-0 flex-col border-r border-[#E2E8F0] bg-[#F8FAFC]/90 transition-[width] duration-200',
+                                sidebarWidthClass,
+                            )}>
+                                <SidebarBody
+                                    activeNav={activeNav}
+                                    collapsed={sidebarCollapsed}
+                                    isLoggingOut={isLoggingOut}
+                                    onLogout={logout}
+                                    onToggleCollapse={() => setDesktopCollapsed((value) => !value)}
+                                    showCollapseToggle
+                                    showCloseButton={false}
+                                    searchQuery={searchQuery}
+                                />
+                            </aside>
+                        )}
+
+                        <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
+                            <header className="relative z-10 flex shrink-0 items-center justify-between gap-4 border-b border-[#E2E8F0] bg-white px-4 py-4 sm:px-6 sm:py-5 xl:px-10">
+                                <div className="flex min-w-0 flex-1 items-center gap-3">
+                                    {isMobile && (
+                                        <button
+                                            type="button"
+                                            onClick={() => setMobileOpen(true)}
+                                            aria-label={t('dashboard.layout.open_menu', { defaultValue: 'Open menu' })}
+                                            className="grid h-9 w-9 shrink-0 place-items-center rounded-md border border-[#E2E8F0] bg-white text-[#64748B] transition-colors hover:bg-[#F8FAFC] hover:text-[#0F172A]"
+                                        >
+                                            <HugeiconsIcon icon={Menu01Icon} size={18} />
+                                        </button>
+                                    )}
+                                    <div className="min-w-0 flex-1">
+                                        {headerLeft ?? (
+                                            <>
+                                                {eyebrow && <div className="auth-eyebrow mb-2 text-[#94A3B8]">{eyebrow}</div>}
+                                                {title && <h1 className="font-display text-xl font-medium tracking-[-0.02em] text-[#0F172A]">{title}</h1>}
+                                                {subtitle && <p className="mt-1 font-body text-sm text-[#94A3B8]">{subtitle}</p>}
+                                            </>
+                                        )}
+                                    </div>
+                                </div>
+                                <div className="flex shrink-0 items-center gap-2 sm:gap-3">{resolvedHeaderActions}</div>
+                            </header>
+
+                            <main className="custom-scrollbar relative flex-1 overflow-y-auto bg-white px-4 py-5 sm:px-6 sm:py-6 lg:px-8 xl:px-10 xl:py-8">
+                                <div className={contentClassName}>{children}</div>
+                            </main>
                         </div>
-                    </aside>
-
-                    <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
-                        <header className="relative z-10 flex shrink-0 items-center justify-between gap-6 border-b border-[#E2E8F0] bg-white px-8 py-5 xl:px-10">
-                            <div>
-                                {headerLeft ?? (
-                                    <>
-                                        {eyebrow && <div className="auth-eyebrow mb-2 text-[#94A3B8]">{eyebrow}</div>}
-                                        {title && <h1 className="font-display text-xl font-medium tracking-[-0.02em] text-[#0F172A]">{title}</h1>}
-                                        {subtitle && <p className="mt-1 font-body text-sm text-[#94A3B8]">{subtitle}</p>}
-                                    </>
-                                )}
-                            </div>
-                            <div className="flex items-center gap-3">{resolvedHeaderActions}</div>
-                        </header>
-
-                        <main className="custom-scrollbar relative flex-1 overflow-y-auto bg-white px-6 py-6 lg:px-8 xl:px-10 xl:py-8">
-                            <div className={contentClassName}>{children}</div>
-                        </main>
                     </div>
                 </div>
             </div>
-        </div>
+        </TooltipProvider>
     );
 }

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -163,7 +163,13 @@ function SearchField({ defaultQuery = '' }: { defaultQuery?: string }) {
                 <InputGroupAddon align="inline-start">
                     <HugeiconsIcon icon={Search01Icon} size={16} />
                 </InputGroupAddon>
-                <InputGroupInput name="q" defaultValue={defaultQuery} aria-label={t('dashboard.layout.search_tickets')} placeholder={t('dashboard.layout.search_placeholder')} />
+                <InputGroupInput
+                    key={defaultQuery}
+                    name="q"
+                    defaultValue={defaultQuery}
+                    aria-label={t('dashboard.layout.search_tickets')}
+                    placeholder={t('dashboard.layout.search_placeholder')}
+                />
                 <InputGroupAddon align="inline-end">
                     <Kbd>⌘</Kbd>
                     <Kbd>K</Kbd>

--- a/resources/js/layouts/DashboardLayout.tsx
+++ b/resources/js/layouts/DashboardLayout.tsx
@@ -1,23 +1,24 @@
 import { Children, useRef, useState, type ReactNode } from 'react';
 import { Link, router } from '@inertiajs/react';
 import { HugeiconsIcon } from '@hugeicons/react';
+import { useTranslation } from 'react-i18next';
 import {
     ArrowRight01Icon,
     BarChartIcon,
     BookOpen01Icon,
     CustomerService01Icon,
     DashboardSquare01Icon,
-    HelpCircleIcon,
     InboxIcon,
     LogoutSquare01Icon,
     Message01Icon,
     Notification01Icon,
     Search01Icon,
+    Settings01Icon,
     ShieldCheck,
     Ticket01Icon,
 } from '@hugeicons/core-free-icons';
 
-import { Button } from '@/components/ui/button';
+import { Button, buttonVariants } from '@/components/ui/button';
 import {
     Card,
     CardContent,
@@ -32,31 +33,33 @@ import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
 interface DashboardLayoutProps {
-    title: string;
+    title?: string;
     subtitle?: string;
     eyebrow?: string;
     activeNav?: string;
+    headerLeft?: ReactNode;
     headerActions?: ReactNode;
     contentClassName?: string;
+    searchQuery?: string;
     children: ReactNode;
 }
 
 interface NavItem {
     id: string;
-    label: string;
+    labelKey: string;
     icon: typeof DashboardSquare01Icon;
     href?: string;
 }
 
 const NAV_ITEMS: NavItem[] = [
-    { id: 'dashboard', label: 'Dashboard', icon: DashboardSquare01Icon, href: '/scp' },
-    { id: 'inbox', label: 'Inbox', icon: InboxIcon },
-    { id: 'notifications', label: 'Notifications', icon: Notification01Icon },
-    { id: 'tickets', label: 'Tickets', icon: Ticket01Icon },
-    { id: 'knowledge', label: 'Knowledge Base', icon: BookOpen01Icon },
-    { id: 'customers', label: 'Customers', icon: CustomerService01Icon },
-    { id: 'forum', label: 'Forum', icon: Message01Icon },
-    { id: 'reports', label: 'Reports', icon: BarChartIcon },
+    { id: 'dashboard', labelKey: 'nav.dashboard', icon: DashboardSquare01Icon, href: '/scp' },
+    { id: 'queues', labelKey: 'nav.tickets', icon: Ticket01Icon, href: '/scp/queues' },
+    { id: 'inbox', labelKey: 'nav.inbox', icon: InboxIcon },
+    { id: 'notifications', labelKey: 'nav.notifications', icon: Notification01Icon },
+    { id: 'knowledge', labelKey: 'nav.knowledgebase', icon: BookOpen01Icon },
+    { id: 'customers', labelKey: 'nav.customers', icon: CustomerService01Icon },
+    { id: 'forum', labelKey: 'nav.forum', icon: Message01Icon },
+    { id: 'reports', labelKey: 'nav.reports', icon: BarChartIcon },
 ];
 
 const CONVERSATION_ITEMS = [
@@ -99,53 +102,49 @@ function getFooterActionIconColor(activeNav: string | undefined, navItem: string
 }
 
 function DefaultHeaderActions() {
+    const { t } = useTranslation();
+
     return (
         <>
-            <Button
-                variant="outline"
-                size="icon"
-                disabled
-                aria-disabled="true"
-                className="rounded-md border-[#E2E8F0] bg-white text-[#64748B] hover:bg-white"
-                aria-label="Open dashboard actions"
+            <Link
+                href="/scp/queues"
+                className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), "rounded-[4px] border-[#E2E8F0] bg-white text-xs font-medium uppercase tracking-[0.12em] text-[#64748B] hover:border-[#C4A5F3] hover:bg-[#F8FAFC] hover:text-[#0F172A]")}
             >
-                <span className="text-lg leading-none">•••</span>
-            </Button>
-
-            <div className="flex overflow-hidden rounded-md shadow-[0_10px_25px_-20px_rgba(91,97,157,0.7)]">
-                <Button
-                    disabled
-                    aria-disabled="true"
-                    className="rounded-none rounded-l-md bg-[#5B619D] px-4 text-sm text-white hover:bg-[#5B619D]"
-                >
-                    Export CSV
-                </Button>
-                <Button
-                    size="icon"
-                    disabled
-                    aria-disabled="true"
-                    className="rounded-none rounded-r-md border-l border-white/15 bg-[#5B619D] text-white hover:bg-[#5B619D]"
-                    aria-label="Open export options"
-                >
-                    <HugeiconsIcon icon={ArrowRight01Icon} size={14} className="rotate-90" />
-                </Button>
-            </div>
+                {t('dashboard.layout.my_queue')}
+            </Link>
+            <Link
+                href="/scp/tickets/create"
+                className={cn(buttonVariants({ size: 'sm' }), "rounded-[4px] bg-[#5B619D] px-4 text-xs font-medium uppercase tracking-[0.12em] text-white hover:bg-[#4F548C] shadow-[0_10px_25px_-20px_rgba(91,97,157,0.7)]")}
+            >
+                {t('dashboard.layout.new_ticket')}
+            </Link>
         </>
     );
 }
 
-function SearchField() {
+function SearchField({ defaultQuery = '' }: { defaultQuery?: string }) {
+    const { t } = useTranslation();
+
     return (
-        <InputGroup>
-            <InputGroupAddon align="inline-start">
-                <HugeiconsIcon icon={Search01Icon} size={16} />
-            </InputGroupAddon>
-            <InputGroupInput aria-label="Search dashboard" placeholder="Search..." />
-            <InputGroupAddon align="inline-end">
-                <Kbd>⌘</Kbd>
-                <Kbd>K</Kbd>
-            </InputGroupAddon>
-        </InputGroup>
+        <form
+            role="search"
+            onSubmit={(event) => {
+                event.preventDefault();
+                const query = new FormData(event.currentTarget).get('q')?.toString().trim() ?? '';
+                router.get('/scp/search', query === '' ? {} : { q: query });
+            }}
+        >
+            <InputGroup>
+                <InputGroupAddon align="inline-start">
+                    <HugeiconsIcon icon={Search01Icon} size={16} />
+                </InputGroupAddon>
+                <InputGroupInput name="q" defaultValue={defaultQuery} aria-label={t('dashboard.layout.search_tickets')} placeholder={t('dashboard.layout.search_placeholder')} />
+                <InputGroupAddon align="inline-end">
+                    <Kbd>⌘</Kbd>
+                    <Kbd>K</Kbd>
+                </InputGroupAddon>
+            </InputGroup>
+        </form>
     );
 }
 
@@ -154,10 +153,13 @@ export default function DashboardLayout({
     subtitle,
     eyebrow,
     activeNav = 'dashboard',
+    headerLeft,
     headerActions,
     contentClassName = 'w-full',
+    searchQuery,
     children,
 }: DashboardLayoutProps) {
+    const { t } = useTranslation();
     const resolvedHeaderActions = headerActions === undefined
         ? <DefaultHeaderActions />
         : (Children.count(headerActions) > 0 ? headerActions : null);
@@ -182,8 +184,8 @@ export default function DashboardLayout({
 
     return (
         <div className="auth-theme relative flex h-screen overflow-hidden bg-[#E9ECEF] text-[#0F172A]">
-            <div className="auth-mesh pointer-events-none absolute inset-0"></div>
-            <div className="auth-grain pointer-events-none absolute inset-0"></div>
+            <div className="auth-mesh pointer-events-none absolute inset-0" aria-hidden />
+            <div className="auth-grain pointer-events-none absolute inset-0" aria-hidden />
 
             <div className="relative z-10 flex h-full w-full">
                 <div className="flex h-full w-full overflow-hidden bg-white">
@@ -191,12 +193,12 @@ export default function DashboardLayout({
                         <div className="px-5 py-5 transition-colors hover:bg-white/70">
                             <div className="flex items-center justify-between gap-3">
                                 <div className="flex items-center gap-3">
-                                    <div className="auth-gradient flex h-10 w-10 items-center justify-center rounded-full text-xs font-semibold tracking-[0.14em] text-white shadow-[0_12px_24px_-18px_rgba(91,97,157,0.9)]">
+                                    <div className="auth-gradient flex h-9 w-9 items-center justify-center rounded-full text-[11px] font-semibold tracking-[0.02em] text-white shadow-[0_12px_24px_-18px_rgba(91,97,157,0.9)]">
                                         SCP
                                     </div>
                                     <div>
-                                        <div className="font-body text-sm font-semibold leading-none text-[#0F172A]">osTicket SCP</div>
-                                        <div className="mt-1 text-xs text-[#94A3B8]">Agent Admin</div>
+                                        <div className="font-body text-sm font-medium leading-none text-[#0F172A]">osTicket SCP</div>
+                                        <div className="mt-1 text-[10px] font-medium uppercase tracking-[0.1em] text-[#94A3B8]">Agent Admin</div>
                                     </div>
                                 </div>
                                 <HugeiconsIcon icon={ArrowRight01Icon} size={16} color="#94A3B8" className="rotate-90" />
@@ -206,16 +208,16 @@ export default function DashboardLayout({
                         <Separator className="bg-[#E2E8F0]" />
 
                         <div className="px-5 py-4">
-                            <SearchField />
+                            <SearchField defaultQuery={searchQuery} />
                         </div>
 
                         <div className="custom-scrollbar flex-1 overflow-y-auto pb-6">
                             <nav className="space-y-0.5 px-3">
-                                {NAV_ITEMS.map(({ id, label, icon, href }) => {
+                                {NAV_ITEMS.map(({ id, labelKey, icon, href }) => {
                                     const content = (
                                         <>
                                             <HugeiconsIcon icon={icon} size={18} color={getNavIconColor(activeNav, id, !href)} />
-                                            <span>{label}</span>
+                                            <span>{t(labelKey)}</span>
                                         </>
                                     );
 
@@ -238,7 +240,7 @@ export default function DashboardLayout({
                             </nav>
 
                             <section className="mt-7 px-6">
-                                <div className="auth-caption mb-3">Conversation</div>
+                                <div className="auth-caption mb-3">{t('dashboard.layout.conversation')}</div>
                                 <div className="space-y-2">
                                     {CONVERSATION_ITEMS.map(({ id, label, subtitle, icon, badge, badgeActive }) => (
                                         <Card key={id} className={cn(
@@ -280,23 +282,23 @@ export default function DashboardLayout({
                             </section>
 
                             <section className="mt-7 px-6">
-                                <div className="auth-caption mb-2">Favorites</div>
+                                <div className="auth-caption mb-2">{t('dashboard.layout.favorites')}</div>
                                 <p className="max-w-47.5 text-xs leading-5 text-[#94A3B8]">
-                                    Hover over any table and click the star to add it here.
+                                    {t('dashboard.layout.favorites_hint')}
                                 </p>
                             </section>
 
                             <section className="mt-7 px-6">
                                 <div className="mb-3 flex items-center justify-between gap-3">
-                                    <div className="auth-caption">Pinned Tickets</div>
+                                    <div className="auth-caption">{t('dashboard.layout.pinned_tickets')}</div>
                                     <Button
                                         variant="ghost"
                                         size="xs"
                                         disabled
                                         aria-disabled="true"
-                                        className="h-auto rounded-md px-0 text-[11px] text-[#94A3B8] hover:bg-transparent hover:text-[#94A3B8]"
+                                        className="h-auto rounded-[4px] px-0 text-[11px] text-[#94A3B8] hover:bg-transparent hover:text-[#94A3B8]"
                                     >
-                                        Unpin all
+                                        {t('dashboard.layout.unpin_all')}
                                     </Button>
                                 </div>
                                 <div className="space-y-3">
@@ -327,10 +329,10 @@ export default function DashboardLayout({
                                         variant="ghost"
                                         disabled
                                         aria-disabled="true"
-                                        className="mt-1 h-auto justify-start rounded-md px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#64748B]"
+                                        className="mt-1 h-auto justify-start rounded-[4px] px-0 text-sm font-medium text-[#64748B] hover:bg-transparent hover:text-[#0F172A]"
                                     >
                                         <span className="text-lg leading-none">+</span>
-                                        Add new
+                                        {t('dashboard.layout.add_new')}
                                     </Button>
                                 </div>
                             </section>
@@ -339,23 +341,31 @@ export default function DashboardLayout({
                         <Separator className="bg-[#E2E8F0]" />
 
                         <div className="mt-auto px-5 py-5">
-                            <Button
-                                variant="ghost"
-                                disabled
-                                aria-disabled="true"
-                                className="mb-4 h-auto justify-start rounded-md px-0 text-sm text-[#64748B] hover:bg-transparent hover:text-[#64748B]"
+                            <Link
+                                href="/scp/preferences"
+                                className={cn(
+                                    'mb-4 inline-flex h-auto items-center gap-2 rounded-md px-0 text-sm transition-colors',
+                                    activeNav === 'preferences'
+                                        ? 'text-[#0F172A]'
+                                        : 'text-[#64748B] hover:text-[#0F172A]',
+                                )}
+                                aria-current={activeNav === 'preferences' ? 'page' : undefined}
                             >
-                                <HugeiconsIcon icon={HelpCircleIcon} size={18} color="#94A3B8" />
-                                <span>Help &amp; Support</span>
-                            </Button>
+                                <HugeiconsIcon
+                                    icon={Settings01Icon}
+                                    size={18}
+                                    color={activeNav === 'preferences' ? '#5B619D' : '#94A3B8'}
+                                />
+                                <span>{t('dashboard.layout.preferences')}</span>
+                            </Link>
 
-                            <Card className="mb-4 rounded-xl border-[#E2E8F0] py-0 shadow-sm shadow-[#0F172A]/[0.03] ring-0">
+                            <Card className="mb-4 rounded-[7px] border-[#E2E8F0] py-0 shadow-sm shadow-[#0F172A]/[0.03] ring-0">
                                 <CardContent className="flex items-center justify-between gap-3 px-3 py-3">
                                     <div>
-                                        <div className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">Powered by</div>
+                                        <div className="text-[9px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">{t('dashboard.layout.powered_by')}</div>
                                         <div className="mt-1 font-display text-lg font-medium tracking-tight text-[#0F172A]">osTicket 2.0</div>
                                     </div>
-                                    <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#F1F5F9] text-[#5B619D]">
+                                    <div className="flex h-8 w-8 items-center justify-center rounded-[4px] bg-[#F1F5F9] text-[#5B619D]">
                                         <HugeiconsIcon icon={DashboardSquare01Icon} size={18} color="#5B619D" />
                                     </div>
                                 </CardContent>
@@ -368,17 +378,17 @@ export default function DashboardLayout({
                                     aria-current={activeNav === 'security' ? 'page' : undefined}
                                 >
                                     <HugeiconsIcon icon={ShieldCheck} size={14} color={getFooterActionIconColor(activeNav, 'security')} />
-                                    Security
+                                    {t('dashboard.layout.security')}
                                 </Link>
                                 <Button
                                     variant="outline"
                                     size="sm"
                                     disabled={isLoggingOut}
                                     onClick={logout}
-                                    className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:text-red-600 cursor-pointer"
+                                    className="cursor-pointer rounded-[4px] border-[#E2E8F0] bg-white text-xs text-[#64748B] hover:bg-[#F8FAFC] hover:text-red-600"
                                 >
                                     <HugeiconsIcon icon={LogoutSquare01Icon} size={14} color="#94A3B8" />
-                                    Sign out
+                                    {t('actions.logout')}
                                 </Button>
                             </div>
                         </div>
@@ -387,9 +397,13 @@ export default function DashboardLayout({
                     <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
                         <header className="relative z-10 flex shrink-0 items-center justify-between gap-6 border-b border-[#E2E8F0] bg-white px-8 py-5 xl:px-10">
                             <div>
-                                {eyebrow && <div className="auth-eyebrow mb-2 text-[#94A3B8]">{eyebrow}</div>}
-                                <h1 className="font-display text-[28px] font-medium tracking-tight text-[#0F172A]">{title}</h1>
-                                {subtitle && <p className="mt-1 font-body text-sm text-[#94A3B8]">{subtitle}</p>}
+                                {headerLeft ?? (
+                                    <>
+                                        {eyebrow && <div className="auth-eyebrow mb-2 text-[#94A3B8]">{eyebrow}</div>}
+                                        {title && <h1 className="font-display text-xl font-medium tracking-[-0.02em] text-[#0F172A]">{title}</h1>}
+                                        {subtitle && <p className="mt-1 font-body text-sm text-[#94A3B8]">{subtitle}</p>}
+                                    </>
+                                )}
                             </div>
                             <div className="flex items-center gap-3">{resolvedHeaderActions}</div>
                         </header>

--- a/resources/js/lib/datetime.ts
+++ b/resources/js/lib/datetime.ts
@@ -1,0 +1,82 @@
+const RELATIVE = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+const DATE = new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+});
+
+const DATE_TIME = new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+});
+
+const UNITS: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> = [
+    { unit: 'year', ms: 365 * 24 * 60 * 60 * 1000 },
+    { unit: 'month', ms: 30 * 24 * 60 * 60 * 1000 },
+    { unit: 'week', ms: 7 * 24 * 60 * 60 * 1000 },
+    { unit: 'day', ms: 24 * 60 * 60 * 1000 },
+    { unit: 'hour', ms: 60 * 60 * 1000 },
+    { unit: 'minute', ms: 60 * 1000 },
+];
+
+function toDate(value: string | null | undefined): Date | null {
+    if (!value) return null;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatRelative(value: string | null | undefined, now: Date = new Date()): string | null {
+    const date = toDate(value);
+    if (!date) return null;
+
+    const diff = date.getTime() - now.getTime();
+    const abs = Math.abs(diff);
+
+    for (const { unit, ms } of UNITS) {
+        if (abs >= ms) {
+            return RELATIVE.format(Math.round(diff / ms), unit);
+        }
+    }
+
+    return RELATIVE.format(Math.round(diff / 1000), 'second');
+}
+
+export function formatDate(value: string | null | undefined): string | null {
+    const date = toDate(value);
+    return date ? DATE.format(date) : null;
+}
+
+export function formatDateTime(value: string | null | undefined): string | null {
+    const date = toDate(value);
+    return date ? DATE_TIME.format(date) : null;
+}
+
+export function formatTicketDate(value: string | null | undefined): string | null {
+    const date = toDate(value);
+    if (!date) return null;
+
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getFullYear();
+    const hours24 = date.getHours();
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    const period = hours24 >= 12 ? 'PM' : 'AM';
+    const hours12 = ((hours24 + 11) % 12) + 1;
+
+    return `${day}/${month}/${year}, ${String(hours12).padStart(2, '0')}:${minutes}${period}`;
+}
+
+export function formatBytes(bytes: number | null | undefined): string | null {
+    if (bytes === null || bytes === undefined) return null;
+    if (bytes === 0) return '0 B';
+
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / Math.pow(1024, exponent);
+
+    return `${value < 10 && exponent > 0 ? value.toFixed(1) : Math.round(value)} ${units[exponent]}`;
+}

--- a/resources/js/lib/sanitize-html.ts
+++ b/resources/js/lib/sanitize-html.ts
@@ -1,112 +1,46 @@
-const ALLOWED_TAGS = new Set([
+import DOMPurify from 'dompurify';
+
+const ALLOWED_TAGS = [
     'p', 'div', 'span', 'br', 'a', 'ul', 'ol', 'li',
     'b', 'i', 'em', 'strong', 'u', 's', 'code', 'pre',
     'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th',
     'hr', 'img', 'figure', 'figcaption', 'small', 'sub', 'sup',
-]);
+];
 
-const REMOVE_TAGS = new Set([
-    'script', 'style', 'iframe', 'object', 'embed', 'meta', 'link',
-    'form', 'input', 'button', 'textarea', 'select', 'option',
-    'svg', 'math', 'noscript',
-]);
+const ALLOWED_ATTR = [
+    'href', 'title',
+    'src', 'alt', 'width', 'height',
+    'colspan', 'rowspan',
+    'border',
+];
 
-const ALLOWED_ATTRS: Record<string, Set<string>> = {
-    a: new Set(['href', 'title']),
-    img: new Set(['src', 'alt', 'title', 'width', 'height']),
-    td: new Set(['colspan', 'rowspan']),
-    th: new Set(['colspan', 'rowspan']),
-    table: new Set(['border']),
-};
+function applyLinkPolicy(html: string): string {
+    const template = document.createElement('template');
+    template.innerHTML = html;
 
-const URL_ATTRS = new Set(['href', 'src']);
+    template.content.querySelectorAll('a[href]').forEach((link) => {
+        link.setAttribute('rel', 'noopener noreferrer nofollow');
+        link.setAttribute('target', '_blank');
+    });
 
-function decodeHtmlEntities(value: string): string {
-    let decoded = value;
-
-    for (let index = 0; index < 3; index += 1) {
-        const textarea = document.createElement('textarea');
-        textarea.innerHTML = decoded;
-        const next = textarea.value;
-
-        if (next === decoded) break;
-
-        decoded = next;
-    }
-
-    return decoded;
-}
-
-function isUnsafeUrl(value: string): boolean {
-    const normalized = decodeHtmlEntities(value)
-        .replace(/[\u0000-\u001F\u007F\s]+/g, '')
-        .trim()
-        .toLowerCase();
-    const schemeEnd = normalized.indexOf(':');
-
-    if (schemeEnd === -1) return false;
-
-    const scheme = normalized.slice(0, schemeEnd);
-
-    if (scheme === 'javascript') return true;
-    if (scheme === 'vbscript') return true;
-    if (scheme === 'data' && !normalized.startsWith('data:image/')) return true;
-
-    return false;
-}
-
-function sanitizeNode(node: Element): void {
-    const children = Array.from(node.children);
-    for (const child of children) {
-        const tag = child.tagName.toLowerCase();
-
-        if (REMOVE_TAGS.has(tag)) {
-            child.remove();
-            continue;
-        }
-
-        if (!ALLOWED_TAGS.has(tag)) {
-            // Unwrap unknown tag — keep its children inline.
-            sanitizeNode(child);
-            while (child.firstChild) node.insertBefore(child.firstChild, child);
-            child.remove();
-            continue;
-        }
-
-        const allowed = ALLOWED_ATTRS[tag] ?? new Set<string>();
-        for (const attr of Array.from(child.attributes)) {
-            const name = attr.name.toLowerCase();
-            if (name.startsWith('on') || name === 'style' || name === 'srcset') {
-                child.removeAttribute(attr.name);
-                continue;
-            }
-            if (!allowed.has(name)) {
-                child.removeAttribute(attr.name);
-                continue;
-            }
-            if (URL_ATTRS.has(name) && isUnsafeUrl(attr.value)) {
-                child.removeAttribute(attr.name);
-            }
-        }
-
-        if (tag === 'a' && child.hasAttribute('href')) {
-            child.setAttribute('rel', 'noopener noreferrer nofollow');
-            child.setAttribute('target', '_blank');
-        }
-
-        sanitizeNode(child);
-    }
+    return template.innerHTML;
 }
 
 export function sanitizeHtml(input: string): string {
     if (typeof window === 'undefined' || !input) return '';
 
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(`<div data-root>${input}</div>`, 'text/html');
-    const root = doc.querySelector('[data-root]');
-    if (!root) return '';
+    const sanitized = DOMPurify.sanitize(input, {
+        ALLOWED_TAGS,
+        ALLOWED_ATTR,
+        ALLOW_DATA_ATTR: false,
+        FORBID_ATTR: ['style', 'srcset'],
+        FORBID_TAGS: [
+            'script', 'style', 'iframe', 'object', 'embed', 'meta', 'link',
+            'form', 'input', 'button', 'textarea', 'select', 'option',
+            'svg', 'math', 'noscript',
+        ],
+    });
 
-    sanitizeNode(root);
-    return root.innerHTML;
+    return applyLinkPolicy(sanitized);
 }

--- a/resources/js/lib/sanitize-html.ts
+++ b/resources/js/lib/sanitize-html.ts
@@ -1,0 +1,85 @@
+const ALLOWED_TAGS = new Set([
+    'p', 'div', 'span', 'br', 'a', 'ul', 'ol', 'li',
+    'b', 'i', 'em', 'strong', 'u', 's', 'code', 'pre',
+    'blockquote', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th',
+    'hr', 'img', 'figure', 'figcaption', 'small', 'sub', 'sup',
+]);
+
+const REMOVE_TAGS = new Set([
+    'script', 'style', 'iframe', 'object', 'embed', 'meta', 'link',
+    'form', 'input', 'button', 'textarea', 'select', 'option',
+    'svg', 'math', 'noscript',
+]);
+
+const ALLOWED_ATTRS: Record<string, Set<string>> = {
+    a: new Set(['href', 'title']),
+    img: new Set(['src', 'alt', 'title', 'width', 'height']),
+    td: new Set(['colspan', 'rowspan']),
+    th: new Set(['colspan', 'rowspan']),
+    table: new Set(['border']),
+};
+
+const URL_ATTRS = new Set(['href', 'src']);
+
+function isUnsafeUrl(value: string): boolean {
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed.startsWith('javascript:')) return true;
+    if (trimmed.startsWith('vbscript:')) return true;
+    if (trimmed.startsWith('data:') && !trimmed.startsWith('data:image/')) return true;
+    return false;
+}
+
+function sanitizeNode(node: Element): void {
+    const children = Array.from(node.children);
+    for (const child of children) {
+        const tag = child.tagName.toLowerCase();
+
+        if (REMOVE_TAGS.has(tag)) {
+            child.remove();
+            continue;
+        }
+
+        if (!ALLOWED_TAGS.has(tag)) {
+            // Unwrap unknown tag — keep its children inline.
+            while (child.firstChild) node.insertBefore(child.firstChild, child);
+            child.remove();
+            continue;
+        }
+
+        const allowed = ALLOWED_ATTRS[tag] ?? new Set<string>();
+        for (const attr of Array.from(child.attributes)) {
+            const name = attr.name.toLowerCase();
+            if (name.startsWith('on') || name === 'style' || name === 'srcset') {
+                child.removeAttribute(attr.name);
+                continue;
+            }
+            if (!allowed.has(name)) {
+                child.removeAttribute(attr.name);
+                continue;
+            }
+            if (URL_ATTRS.has(name) && isUnsafeUrl(attr.value)) {
+                child.removeAttribute(attr.name);
+            }
+        }
+
+        if (tag === 'a' && child.hasAttribute('href')) {
+            child.setAttribute('rel', 'noopener noreferrer nofollow');
+            child.setAttribute('target', '_blank');
+        }
+
+        sanitizeNode(child);
+    }
+}
+
+export function sanitizeHtml(input: string): string {
+    if (typeof window === 'undefined' || !input) return '';
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(`<div data-root>${input}</div>`, 'text/html');
+    const root = doc.querySelector('[data-root]');
+    if (!root) return '';
+
+    sanitizeNode(root);
+    return root.innerHTML;
+}

--- a/resources/js/lib/sanitize-html.ts
+++ b/resources/js/lib/sanitize-html.ts
@@ -68,6 +68,7 @@ function sanitizeNode(node: Element): void {
 
         if (!ALLOWED_TAGS.has(tag)) {
             // Unwrap unknown tag — keep its children inline.
+            sanitizeNode(child);
             while (child.firstChild) node.insertBefore(child.firstChild, child);
             child.remove();
             continue;

--- a/resources/js/lib/sanitize-html.ts
+++ b/resources/js/lib/sanitize-html.ts
@@ -22,11 +22,37 @@ const ALLOWED_ATTRS: Record<string, Set<string>> = {
 
 const URL_ATTRS = new Set(['href', 'src']);
 
+function decodeHtmlEntities(value: string): string {
+    let decoded = value;
+
+    for (let index = 0; index < 3; index += 1) {
+        const textarea = document.createElement('textarea');
+        textarea.innerHTML = decoded;
+        const next = textarea.value;
+
+        if (next === decoded) break;
+
+        decoded = next;
+    }
+
+    return decoded;
+}
+
 function isUnsafeUrl(value: string): boolean {
-    const trimmed = value.trim().toLowerCase();
-    if (trimmed.startsWith('javascript:')) return true;
-    if (trimmed.startsWith('vbscript:')) return true;
-    if (trimmed.startsWith('data:') && !trimmed.startsWith('data:image/')) return true;
+    const normalized = decodeHtmlEntities(value)
+        .replace(/[\u0000-\u001F\u007F\s]+/g, '')
+        .trim()
+        .toLowerCase();
+    const schemeEnd = normalized.indexOf(':');
+
+    if (schemeEnd === -1) return false;
+
+    const scheme = normalized.slice(0, schemeEnd);
+
+    if (scheme === 'javascript') return true;
+    if (scheme === 'vbscript') return true;
+    if (scheme === 'data' && !normalized.startsWith('data:image/')) return true;
+
     return false;
 }
 

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -1,30 +1,34 @@
-import * as React from 'react';
-import type { ReactElement, ReactNode } from 'react';
+import { router, usePage } from '@inertiajs/react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
-    ArrowDown01Icon,
-    ArrowUp01Icon,
+    Activity01Icon,
+    ArrowDownRight01Icon,
+    ArrowUpRight01Icon,
+    Clock01Icon,
+    InboxIcon,
 } from '@hugeicons/core-free-icons';
+import { useCallback, useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
     Bar,
     BarChart,
-    Label,
     CartesianGrid,
     Cell,
+    Label,
     Pie,
     PieChart,
     Sector,
     XAxis,
     YAxis,
 } from 'recharts';
-import type { PieSectorDataItem, PieSectorShapeProps } from 'recharts/types/polar/Pie';
+import type { PieSectorShapeProps } from 'recharts/types/polar/Pie';
 
-import { MigrationBanner } from '@/components/auth/MigrationBanner';
+import LanguageSwitcher from '@/components/LanguageSwitcher';
+import { Button } from '@/components/ui/button';
 import {
     Card,
     CardContent,
     CardDescription,
-    CardFooter,
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
@@ -33,7 +37,6 @@ import {
     type ChartConfig,
     ChartLegend,
     ChartLegendContent,
-    ChartStyle,
     ChartTooltip,
     ChartTooltipContent,
 } from '@/components/ui/chart';
@@ -44,111 +47,220 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
 import DashboardLayout from '@/layouts/DashboardLayout';
 import { cn } from '@/lib/utils';
 
-type StatCardItem = {
+type DashboardMetrics = {
+    open: number;
+    assignedToMe: number;
+    unassigned: number;
+    overdue: number;
+    trend: Record<MetricKey, MetricTrend>;
+    statusComparison: StatusComparison;
+    channelDistribution: ChannelDistribution;
+    recentActivity: ActivityItem[];
+    generatedAt: string;
+};
+
+type MetricKey = 'open' | 'assignedToMe' | 'unassigned' | 'overdue';
+
+type MetricTrend = {
+    previous: number;
+    change: number;
+    percent: number | null;
+    direction: 'up' | 'down' | 'flat' | 'new';
+};
+
+type StatusComparison = {
+    rangeStart: string;
+    rangeEnd: string;
+    openTotal: number;
+    solvedTotal: number;
+    months: Array<{
+        month: string;
+        label: string;
+        open: number;
+        solved: number;
+    }>;
+};
+
+type ChannelDistribution = {
+    rangeStart: string;
+    rangeEnd: string;
+    total: number;
+    channels: Array<{
+        key: string;
+        label: string;
+        count: number;
+        percent: number;
+    }>;
+};
+
+type ActivityItem = {
+    id: number;
+    thread_id: number;
+    event_id: number;
+    event: string | null;
+    ticket_id: number | null;
+    ticket_number: string | null;
+    ticket_subject: string | null;
+    username: string | null;
+    timestamp: string | null;
+};
+
+type MetricCard = {
     label: string;
-    value: string;
-    suffix?: string;
-    trend: string;
-    positive: boolean;
+    value: number;
+    helper: string;
+    trend: MetricTrend;
 };
 
-type BarChartDatum = {
-    day: string;
-    created: number;
-    solved: number;
-    highlighted?: boolean;
-};
+type Translation = ReturnType<typeof useTranslation>['t'];
 
-const DATE_RANGE_OPTIONS = [
-    { value: 'dec-1-7', label: 'Dec 1 - 7' },
-    { value: 'dec-8-14', label: 'Dec 8 - 14' },
-    { value: 'dec-15-21', label: 'Dec 15 - 21' },
-] as const;
+interface DashboardProps {
+    metrics: DashboardMetrics;
+    range?: string;
+}
 
-type DateRangeValue = (typeof DATE_RANGE_OPTIONS)[number]['value'];
+function numberFormat(value: number, locale: string): string {
+    return new Intl.NumberFormat(locale).format(value);
+}
 
-const STAT_CARDS: StatCardItem[] = [
-    { label: 'Created Tickets', value: '24,208', trend: '-5%', positive: false },
-    { label: 'Unsolved Tickets', value: '4,564', trend: '+2%', positive: false },
-    { label: 'Solved Tickets', value: '18,208', trend: '+8%', positive: true },
-    { label: 'Average First Time Reply', value: '12:01', suffix: 'min', trend: '+8 min', positive: false },
-];
+function percent(part: number, total: number, locale: string): string {
+    if (total <= 0) {
+        return new Intl.NumberFormat(locale, { style: 'percent', maximumFractionDigits: 0 }).format(0);
+    }
 
-const BAR_CHART_DATA: Record<DateRangeValue, BarChartDatum[]> = {
-    'dec-1-7': [
-        { day: 'Dec 1', created: 4120, solved: 3100 },
-        { day: 'Dec 2', created: 3450, solved: 2890 },
-        { day: 'Dec 3', created: 3890, solved: 2950 },
-        { day: 'Dec 4', created: 4300, solved: 3800, highlighted: true },
-        { day: 'Dec 5', created: 3650, solved: 2400 },
-        { day: 'Dec 6', created: 3520, solved: 2860 },
-        { day: 'Dec 7', created: 3780, solved: 3010 },
-    ],
-    'dec-8-14': [
-        { day: 'Dec 8', created: 3840, solved: 3180 },
-        { day: 'Dec 9', created: 4020, solved: 3370 },
-        { day: 'Dec 10', created: 4210, solved: 3620 },
-        { day: 'Dec 11', created: 3960, solved: 3510 },
-        { day: 'Dec 12', created: 4380, solved: 3890, highlighted: true },
-        { day: 'Dec 13', created: 3670, solved: 3040 },
-        { day: 'Dec 14', created: 3540, solved: 2980 },
-    ],
-    'dec-15-21': [
-        { day: 'Dec 15', created: 3310, solved: 2840 },
-        { day: 'Dec 16', created: 3750, solved: 3290 },
-        { day: 'Dec 17', created: 3920, solved: 3460 },
-        { day: 'Dec 18', created: 4480, solved: 4020, highlighted: true },
-        { day: 'Dec 19', created: 4160, solved: 3710 },
-        { day: 'Dec 20', created: 3580, solved: 3120 },
-        { day: 'Dec 21', created: 3420, solved: 3060 },
-    ],
-};
+    return new Intl.NumberFormat(locale, { style: 'percent', maximumFractionDigits: 0 }).format(part / total);
+}
 
-const REPLY_TIME_DATA = [
-    { name: '0-1 Hours', value: 81, fill: '#22C55E' },
-    { name: '1-8 Hours', value: 9, fill: '#C4A5F3' },
-    { name: '8-24 Hours', value: 4, fill: '#5B619D' },
-    { name: '> 24 Hours', value: 4, fill: '#94A3B8' },
-    { name: 'No Replies', value: 2, fill: '#F43F5E' },
-] as const;
+function trendPercent(value: number, locale: string): string {
+    return new Intl.NumberFormat(locale, { style: 'percent', maximumFractionDigits: 1 }).format(Math.abs(value) / 100);
+}
 
-type ReplyTimeName = (typeof REPLY_TIME_DATA)[number]['name'];
+function formatMonth(value: string, locale: string): string {
+    const date = new Date(`${value}T00:00:00`);
 
-const CHANNEL_DATA = [
-    { name: 'Email', value: 940, fill: '#5B619D' },
-    { name: 'Live Chat', value: 720, fill: '#C4A5F3' },
-    { name: 'Contact Form', value: 610, fill: '#22C55E' },
-    { name: 'Messenger', value: 420, fill: '#94A3B8' },
-    { name: 'WhatsApp', value: 312, fill: '#CBD5E1' },
-] as const;
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
 
-const SATISFACTION_ROWS = [
-    { icon: '👍', label: 'Positive', percent: '80%', helper: '72%', fill: '80%', tone: 'bg-emerald-500', iconTone: 'bg-emerald-50' },
-    { icon: '✋', label: 'Neutral', percent: '15%', helper: '24%', fill: '15%', tone: 'bg-[#C4A5F3]', iconTone: 'bg-[#F3ECFF]' },
-    { icon: '👎', label: 'Negative', percent: '5%', helper: '4%', fill: '5%', tone: 'bg-rose-500', iconTone: 'bg-rose-50' },
-] as const;
+    return new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
+}
 
-const ticketChartConfig = {
-    created: { label: 'Avg. Ticket Create', color: '#C4A5F3' },
-    solved: { label: 'Avg. Ticket Solved', color: '#5B619D' },
-} satisfies ChartConfig;
+function getTrendLabel(trend: MetricTrend, t: Translation, locale: string): string {
+    if (trend.direction === 'new') {
+        return t('dashboard.metrics.trend.new');
+    }
 
-const channelChartConfig = Object.fromEntries(
-    CHANNEL_DATA.map(({ name, fill }) => [name, { label: name, color: fill }]),
-) satisfies ChartConfig;
+    if (trend.direction === 'flat') {
+        return t('dashboard.metrics.trend.flat');
+    }
 
-const replyTimeInteractiveChartConfig = {
-    visitors: {
-        label: 'Tickets',
-    },
-    ...Object.fromEntries(
-        REPLY_TIME_DATA.map(({ name, fill }) => [name, { label: name, color: fill }]),
-    ),
-} satisfies ChartConfig;
+    return t(`dashboard.metrics.trend.${trend.direction}`, {
+        percent: trendPercent(trend.percent ?? 0, locale),
+    });
+}
+
+function getTrendClass(direction: MetricTrend['direction']): string {
+    if (direction === 'up') {
+        return 'bg-[#F0FDF4] text-[#16A34A]';
+    }
+
+    if (direction === 'down') {
+        return 'bg-[#FEF2F2] text-[#DC2626]';
+    }
+
+    if (direction === 'new') {
+        return 'bg-[#F0FDF4] text-[#16A34A]';
+    }
+
+    return 'bg-[#F8FAFC] text-[#64748B]';
+}
+
+function getTrendIcon(trend: MetricTrend) {
+    if (trend.direction === 'up' || trend.direction === 'new') {
+        return ArrowUpRight01Icon;
+    }
+
+    if (trend.direction === 'down') {
+        return ArrowDownRight01Icon;
+    }
+
+    return null;
+}
+
+function formatDashboardDateTime(value: string | null | undefined, locale: string): string | null {
+    if (!value) return null;
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+
+    return new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    }).format(date);
+}
+
+function formatDashboardRelative(value: string | null | undefined, locale: string): string | null {
+    if (!value) return null;
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+
+    const diff = date.getTime() - Date.now();
+    const abs = Math.abs(diff);
+    const units: Array<{ unit: Intl.RelativeTimeFormatUnit; ms: number }> = [
+        { unit: 'year', ms: 365 * 24 * 60 * 60 * 1000 },
+        { unit: 'month', ms: 30 * 24 * 60 * 60 * 1000 },
+        { unit: 'week', ms: 7 * 24 * 60 * 60 * 1000 },
+        { unit: 'day', ms: 24 * 60 * 60 * 1000 },
+        { unit: 'hour', ms: 60 * 60 * 1000 },
+        { unit: 'minute', ms: 60 * 1000 },
+    ];
+    const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+
+    for (const { unit, ms } of units) {
+        if (abs >= ms) {
+            return formatter.format(Math.round(diff / ms), unit);
+        }
+    }
+
+    return formatter.format(Math.round(diff / 1000), 'second');
+}
+
+function getMetricCards(metrics: DashboardMetrics, t: Translation, locale: string): MetricCard[] {
+    return [
+        {
+            label: t('dashboard.metrics.open_tickets.label'),
+            value: metrics.open,
+            helper: t('dashboard.metrics.open_tickets.helper'),
+            trend: metrics.trend.open,
+        },
+        {
+            label: t('dashboard.metrics.assigned_to_me.label'),
+            value: metrics.assignedToMe,
+            helper: t('dashboard.metrics.assigned_to_me.helper', { percent: percent(metrics.assignedToMe, metrics.open, locale) }),
+            trend: metrics.trend.assignedToMe,
+        },
+        {
+            label: t('dashboard.metrics.unassigned.label'),
+            value: metrics.unassigned,
+            helper: t('dashboard.metrics.unassigned.helper'),
+            trend: metrics.trend.unassigned,
+        },
+        {
+            label: t('dashboard.metrics.overdue.label'),
+            value: metrics.overdue,
+            helper: t('dashboard.metrics.overdue.helper', { percent: percent(metrics.overdue, metrics.open, locale) }),
+            trend: metrics.trend.overdue,
+        },
+    ];
+}
 
 function getStatCardBorderClass(index: number): string {
     return cn(
@@ -158,336 +270,576 @@ function getStatCardBorderClass(index: number): string {
     );
 }
 
-function getDateRangeLabel(dateRange: DateRangeValue): string {
-    return (
-        DATE_RANGE_OPTIONS.find((option) => option.value === dateRange)?.label ??
-        DATE_RANGE_OPTIONS[0].label
-    );
-}
+function StatCard({ label, value, helper, trend, locale }: MetricCard & { locale: string }) {
+    const { t } = useTranslation();
+    const trendIcon = getTrendIcon(trend);
 
-function getBarChartDataForRange(dateRange: DateRangeValue): BarChartDatum[] {
-    return BAR_CHART_DATA[dateRange];
-}
-
-function StatCard({ label, value, suffix, trend, positive }: StatCardItem) {
     return (
         <Card className="rounded-none border-0 py-0 shadow-none ring-0">
-            <CardContent className="flex min-h-[150px] flex-col p-6 xl:p-8">
-                <div className="font-body text-[13px] font-medium text-[#64748B]">{label}</div>
-                <div className="mt-3 flex items-baseline gap-3">
-                    <div className="font-display text-[30px] font-medium tracking-tight text-[#0F172A] xl:text-[34px]">{value}</div>
-                    {suffix && <span className="font-body text-base font-medium text-[#0F172A]">{suffix}</span>}
-                    <span className={cn(
-                        'inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-semibold',
-                        positive ? 'bg-emerald-50 text-emerald-600' : 'bg-rose-50 text-rose-600',
-                    )}>
-                        {trend}
-                        <HugeiconsIcon icon={positive ? ArrowUp01Icon : ArrowDown01Icon} size={12} />
-                    </span>
+            <CardContent className="flex min-h-[132px] flex-col px-7 py-6">
+                <div className="flex items-center justify-between gap-3">
+                    <div className="font-body text-[10px] font-medium uppercase tracking-[0.1em] text-[#94A3B8]">{label}</div>
                 </div>
-                <p className="mt-auto pt-3 text-xs text-[#94A3B8]">Compare to last month</p>
+                <div className="mt-3 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                    <div className="font-display text-[30px] font-medium leading-none tracking-tight text-[#0F172A]">
+                        {numberFormat(value, locale)}
+                    </div>
+                    <div className={cn('inline-flex items-center gap-1 rounded-[4px] px-1.5 py-1 font-mono text-[10px] font-medium leading-none tracking-[0.05em]', getTrendClass(trend.direction))}>
+                        {getTrendLabel(trend, t, locale)}
+                        {trendIcon && <HugeiconsIcon icon={trendIcon} size={10} />}
+                    </div>
+                </div>
+                <p className="mt-auto pt-2 text-xs text-[#94A3B8]" title={helper}>{t('dashboard.metrics.trend.compare_to_last_month')}</p>
             </CardContent>
         </Card>
     );
 }
 
 function SectionFrame({ children, className }: { children: ReactNode; className?: string }) {
-    return <Card className={cn('overflow-hidden rounded-[18px] border-[#E2E8F0] py-0 shadow-none ring-0', className)}>{children}</Card>;
+    return <Card className={cn('overflow-hidden rounded-none border-0 py-0 shadow-none ring-0', className)}>{children}</Card>;
 }
 
-function TicketChartFooter({ dateRangeLabel }: { dateRangeLabel: string }) {
+function WorkloadChart({ metrics, locale, t }: { metrics: DashboardMetrics; locale: string; t: Translation }) {
+    const comparison = metrics.statusComparison;
+    const rangeStart = formatMonth(comparison.rangeStart, locale);
+    const rangeEnd = formatMonth(comparison.rangeEnd, locale);
+    const data = comparison.months.map((item) => ({
+        ...item,
+        label: new Intl.DateTimeFormat(locale, { month: 'short' }).format(new Date(`${item.month}T00:00:00`)),
+    }));
+    const workloadChartConfig = {
+        open: { label: t('dashboard.ticket_status_chart.open'), color: '#C4A5F3' },
+        solved: { label: t('dashboard.ticket_status_chart.solved'), color: '#5B619D' },
+    } satisfies ChartConfig;
+
     return (
-        <CardFooter className="flex-col items-start gap-2 border-t border-[#E2E8F0] px-6 py-4 text-sm xl:px-8">
-            <div className="flex items-center gap-2 leading-none font-medium text-[#0F172A]">
-                Ticket creation remains ahead of resolutions for this range
-                <HugeiconsIcon icon={ArrowUp01Icon} size={14} />
-            </div>
-            <div className="leading-none text-[#94A3B8]">
-                Showing created versus solved tickets for {dateRangeLabel}
-            </div>
-        </CardFooter>
+        <SectionFrame className="xl:col-span-2 xl:rounded-r-none xl:border-r-0">
+            <CardHeader className="px-7 pt-7">
+                <CardTitle className="font-body text-sm font-medium text-[#0F172A]">{t('dashboard.ticket_status_chart.title')}</CardTitle>
+                <CardDescription className="mt-1 text-xs text-[#94A3B8]">
+                    {t('dashboard.ticket_status_chart.description', { rangeStart, rangeEnd })}
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="px-7 pb-7">
+                <ChartContainer config={workloadChartConfig} className="h-[310px] min-h-0 w-full aspect-auto!">
+                    <BarChart accessibilityLayer data={data} margin={{ top: 16, right: 8, left: 0, bottom: 8 }}>
+                        <CartesianGrid vertical={false} strokeDasharray="3 5" stroke="#E2E8F0" />
+                        <XAxis dataKey="label" tickLine={false} axisLine={false} tickMargin={10} />
+                        <YAxis tickLine={false} axisLine={false} tickMargin={12} allowDecimals={false} />
+                        <ChartTooltip
+                            content={(
+                                <ChartTooltipContent
+                                    labelFormatter={(_value, payload) => {
+                                        const month = payload?.[0]?.payload?.month;
+
+                                        return month ? formatMonth(month, locale) : null;
+                                    }}
+                                    formatter={(value) => numberFormat(Number(value), locale)}
+                                />
+                            )}
+                        />
+                        <ChartLegend content={<ChartLegendContent />} />
+                        <Bar dataKey="open" stackId="tickets" fill="var(--color-open)" radius={[0, 0, 3, 3]} maxBarSize={34} />
+                        <Bar dataKey="solved" stackId="tickets" fill="var(--color-solved)" radius={[3, 3, 0, 0]} maxBarSize={34} />
+                    </BarChart>
+                </ChartContainer>
+                <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-[#94A3B8]">
+                    <span>{t('dashboard.ticket_status_chart.open_total', { count: numberFormat(comparison.openTotal, locale) })}</span>
+                    <span>{t('dashboard.ticket_status_chart.solved_total', { count: numberFormat(comparison.solvedTotal, locale) })}</span>
+                </div>
+            </CardContent>
+        </SectionFrame>
     );
 }
 
-function ReplyTimeInteractiveChart() {
-    const chartId = 'reply-time-interactive';
-    const [activeSegment, setActiveSegment] = React.useState<ReplyTimeName>(REPLY_TIME_DATA[0].name);
+function AssignmentChart({ metrics, locale, t }: { metrics: DashboardMetrics; locale: string; t: Translation }) {
+    const assignedElsewhere = Math.max(metrics.open - metrics.assignedToMe - metrics.unassigned, 0);
+    const [activeSegment, setActiveSegment] = useState('assignedToMe');
+    const assignmentChartConfig = {
+        assignedToMe: { label: t('dashboard.ownership.assigned_to_me'), color: '#C4A5F3' },
+        assignedElsewhere: { label: t('dashboard.ownership.assigned_elsewhere'), color: '#5B619D' },
+        unassigned: { label: t('dashboard.ownership.unassigned'), color: '#22C55E' },
+    } satisfies ChartConfig;
+    const data = useMemo(() => [
+        { key: 'assignedToMe', name: t('dashboard.ownership.assigned_to_me'), value: metrics.assignedToMe, fill: '#C4A5F3' },
+        { key: 'assignedElsewhere', name: t('dashboard.ownership.assigned_elsewhere'), value: assignedElsewhere, fill: '#5B619D' },
+        { key: 'unassigned', name: t('dashboard.ownership.unassigned'), value: metrics.unassigned, fill: '#22C55E' },
+    ].filter((item) => item.value > 0), [assignedElsewhere, metrics.assignedToMe, metrics.unassigned, t]);
+    const activeIndex = useMemo(() => data.findIndex((item) => item.key === activeSegment), [activeSegment, data]);
+    const activeItem = activeIndex >= 0 ? data[activeIndex] : data[0];
+    const resolvedActiveSegment = activeItem?.key ?? '';
+    const renderActiveShape = useCallback(({ index, outerRadius = 0, ...props }: PieSectorShapeProps) => {
+        if (index === activeIndex) {
+            return (
+                <g>
+                    <Sector {...props} outerRadius={outerRadius + 8} />
+                    <Sector {...props} innerRadius={outerRadius + 11} outerRadius={outerRadius + 20} />
+                </g>
+            );
+        }
 
-    const activeIndex = React.useMemo(
-        () => REPLY_TIME_DATA.findIndex((item) => item.name === activeSegment),
-        [activeSegment],
-    );
+        return <Sector {...props} outerRadius={outerRadius} />;
+    }, [activeIndex]);
 
-    const activeItem = REPLY_TIME_DATA[activeIndex] ?? REPLY_TIME_DATA[0];
-
-    const renderPieShape = React.useCallback(
-        ({ index, outerRadius = 0, ...props }: PieSectorDataItem & PieSectorShapeProps) => {
-            if (index === activeIndex) {
-                return (
-                    <g>
-                        <Sector {...props} outerRadius={outerRadius + 10} />
-                        <Sector {...props} outerRadius={outerRadius + 25} innerRadius={outerRadius + 12} />
-                    </g>
-                );
-            }
-
-            return <Sector {...props} outerRadius={outerRadius} />;
-        },
-        [activeIndex],
-    );
+    useEffect(() => {
+        if (data.length > 0 && activeIndex < 0) {
+            setActiveSegment(data[0].key);
+        }
+    }, [activeIndex, data]);
 
     return (
-        <Card data-chart={chartId} className="flex min-h-[430px] flex-col rounded-none border-0 py-0 shadow-none ring-0">
-            <ChartStyle id={chartId} config={replyTimeInteractiveChartConfig} />
-            <CardHeader className="px-6 pt-6 pb-0 xl:px-8 xl:pt-8">
-                <div className="flex items-start">
-                    <div className="grid gap-1">
-                        <CardTitle className="font-body text-base font-medium text-[#0F172A]">Ticket By First Reply Time</CardTitle>
-                        <CardDescription className="text-sm text-[#94A3B8]">Interactive reply-time breakdown</CardDescription>
-                    </div>
-                    <Select value={activeSegment} onValueChange={(value) => value && setActiveSegment(value as ReplyTimeName)}>
+        <SectionFrame className="border-t border-[#E2E8F0] xl:rounded-l-none xl:border-l xl:border-t-0 xl:border-[#E2E8F0]">
+            <CardHeader className="flex flex-row items-start justify-between gap-4 px-7 pt-7 pb-0">
+                <div>
+                    <CardTitle className="font-body text-sm font-medium text-[#0F172A]">{t('dashboard.ownership.title')}</CardTitle>
+                    <CardDescription className="mt-1 text-xs text-[#94A3B8]">
+                        {t('dashboard.ownership.description')}
+                    </CardDescription>
+                </div>
+                {data.length > 0 && (
+                    <Select value={resolvedActiveSegment} onValueChange={(value) => value && setActiveSegment(value)}>
                         <SelectTrigger
                             size="sm"
-                            className="ml-auto h-7 w-[130px] rounded-lg border-[#E2E8F0] bg-white pl-2.5 text-xs text-[#64748B]"
-                            aria-label="Select reply time segment"
+                            className="h-7 w-[150px] rounded-[4px] border-[#E2E8F0] bg-white px-2.5 text-xs text-[#64748B]"
+                            aria-label={t('dashboard.ownership.select_segment')}
                         >
-                            <SelectValue placeholder="Select segment" />
+                            {activeItem ? (
+                                <span className="flex min-w-0 items-center gap-2">
+                                    <span className="h-2.5 w-2.5 shrink-0 rounded-[3px]" style={{ backgroundColor: activeItem.fill }} />
+                                    <span className="truncate">{activeItem.name}</span>
+                                </span>
+                            ) : (
+                                <span>{t('dashboard.ownership.select_segment')}</span>
+                            )}
                         </SelectTrigger>
                         <SelectContent align="end" className="rounded-xl">
-                            {REPLY_TIME_DATA.map(({ fill, name }) => (
-                                <SelectItem key={name} value={name} className="rounded-lg [&_span]:flex">
-                                    <div className="flex items-center gap-2 text-xs">
-                                        <span
-                                            className="flex h-3 w-3 shrink-0 rounded-[2px]"
-                                            style={{ backgroundColor: fill }}
-                                        />
-                                        {name}
-                                    </div>
+                            {data.map((item) => (
+                                <SelectItem key={item.key} value={item.key} className="rounded-lg text-xs">
+                                    <span className="flex items-center gap-2">
+                                        <span className="h-2.5 w-2.5 shrink-0 rounded-[3px]" style={{ backgroundColor: item.fill }} />
+                                        {item.name}
+                                    </span>
                                 </SelectItem>
                             ))}
                         </SelectContent>
                     </Select>
-                </div>
+                )}
             </CardHeader>
-            <CardContent className="flex flex-1 flex-col items-center justify-center gap-8 p-6 pt-4 xl:p-8 xl:pt-4 2xl:flex-row 2xl:justify-between">
-                <ChartContainer
-                    id={chartId}
-                    config={replyTimeInteractiveChartConfig}
-                    className="mx-auto aspect-square w-full max-w-[300px]"
-                >
-                    <PieChart>
-                        <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel formatter={(value) => `${value}%`} />} />
-                        <Pie
-                            data={REPLY_TIME_DATA}
-                            dataKey="value"
-                            nameKey="name"
-                            innerRadius={58}
-                            strokeWidth={5}
-                            shape={renderPieShape}
-                        >
-                            {REPLY_TIME_DATA.map((entry) => (
-                                <Cell key={entry.name} fill={entry.fill} />
-                            ))}
-                            <Label
-                                content={({ viewBox }) => {
-                                    if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
-                                        return (
-                                            <text
-                                                x={viewBox.cx}
-                                                y={viewBox.cy}
-                                                textAnchor="middle"
-                                                dominantBaseline="middle"
-                                            >
-                                                <tspan
-                                                    x={viewBox.cx}
-                                                    y={viewBox.cy}
-                                                    className="fill-foreground text-3xl font-bold"
-                                                >
-                                                    {activeItem.value}%
-                                                </tspan>
-                                                <tspan
-                                                    x={viewBox.cx}
-                                                    y={(viewBox.cy || 0) + 24}
-                                                    className="fill-muted-foreground"
-                                                >
-                                                    {activeItem.name}
-                                                </tspan>
-                                            </text>
-                                        );
-                                    }
+            <CardContent className="flex min-h-[352px] flex-col items-center justify-center p-7">
+                {data.length === 0 ? (
+                    <p className="text-sm text-[#64748B]">{t('dashboard.ownership.empty')}</p>
+                ) : (
+                    <>
+                        <ChartContainer id="dashboard-ownership" config={assignmentChartConfig} className="mx-auto aspect-square w-full max-w-[260px]">
+                            <PieChart>
+                                <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel formatter={(value) => numberFormat(Number(value), locale)} />} />
+                                <Pie
+                                    data={data}
+                                    dataKey="value"
+                                    nameKey="key"
+                                    innerRadius={58}
+                                    outerRadius={86}
+                                    stroke="transparent"
+                                    strokeWidth={5}
+                                    paddingAngle={2}
+                                    shape={renderActiveShape}
+                                >
+                                    <Label
+                                        content={({ viewBox }) => {
+                                            if (viewBox && 'cx' in viewBox && 'cy' in viewBox && activeItem) {
+                                                return (
+                                                    <text x={viewBox.cx} y={viewBox.cy} textAnchor="middle" dominantBaseline="middle">
+                                                        <tspan x={viewBox.cx} y={viewBox.cy} className="fill-[#0F172A] font-display text-3xl font-medium">
+                                                            {numberFormat(activeItem.value, locale)}
+                                                        </tspan>
+                                                        <tspan x={viewBox.cx} y={(viewBox.cy ?? 0) + 23} className="fill-[#94A3B8] text-xs">
+                                                            {activeItem.name}
+                                                        </tspan>
+                                                    </text>
+                                                );
+                                            }
 
-                                    return null;
-                                }}
-                            />
-                        </Pie>
-                    </PieChart>
-                </ChartContainer>
+                                            return null;
+                                        }}
+                                    />
+                                    {data.map((entry) => (
+                                        <Cell key={entry.key} fill={entry.fill} />
+                                    ))}
+                                </Pie>
+                            </PieChart>
+                        </ChartContainer>
+                        <div className="mt-6 grid w-full gap-3 text-[13px] text-[#64748B]">
+                            {data.map((item) => (
+                                <button
+                                    key={item.key}
+                                    type="button"
+                                    onClick={() => setActiveSegment(item.key)}
+                                    className={cn(
+                                        'flex items-center justify-between gap-3 rounded-[4px] px-2 py-1.5 text-left transition',
+                                        resolvedActiveSegment === item.key ? 'bg-[#F8FAFC] text-[#0F172A]' : 'hover:bg-[#F8FAFC]',
+                                    )}
+                                >
+                                    <span className="flex items-center gap-2">
+                                        <span className="h-2 w-2 rounded-sm" style={{ backgroundColor: item.fill }} />
+                                        {item.name}
+                                    </span>
+                                    <span className="font-mono text-xs font-semibold text-[#0F172A]">{numberFormat(item.value, locale)}</span>
+                                </button>
+                            ))}
+                        </div>
+                    </>
+                )}
             </CardContent>
-        </Card>
+        </SectionFrame>
     );
 }
 
-export default function Dashboard() {
-    const [dateRange, setDateRange] = React.useState<DateRangeValue>('dec-1-7');
-    const dateRangeLabel = getDateRangeLabel(dateRange);
-    const ticketChartData = getBarChartDataForRange(dateRange);
+const CHANNEL_COLORS = ['#5B619D', '#C4A5F3', '#22C55E', '#E11D48', '#F59E0B', '#06B6D4', '#0F172A', '#84CC16', '#EC4899', '#64748B', '#8B5CF6', '#14B8A6'];
+
+function ChannelRadialChart({ distribution, locale, t }: { distribution: ChannelDistribution; locale: string; t: Translation }) {
+    const channels = distribution.channels.map((channel, index) => ({
+        ...channel,
+        color: CHANNEL_COLORS[index % CHANNEL_COLORS.length],
+    }));
+    const rangeStart = formatMonth(distribution.rangeStart, locale);
+    const rangeEnd = formatMonth(distribution.rangeEnd, locale);
+    const chartConfig = channels.reduce<ChartConfig>((config, channel) => {
+        config[channel.key] = {
+            label: channel.label,
+            color: channel.color,
+        };
+
+        return config;
+    }, {});
 
     return (
-        <>
-            <MigrationBanner />
-
-            <div className="space-y-6 xl:space-y-8">
-                <div className="flex flex-wrap items-center justify-between gap-3 rounded-[14px] border border-dashed border-[#C4A5F3]/50 bg-[#F8FAFC] px-4 py-3">
-                    <div>
-                        <p className="font-body text-sm font-medium text-[#0F172A]">Analytics preview</p>
-                        <p className="mt-0.5 text-xs text-[#64748B]">Dashboard metrics are sample values until live reporting endpoints are connected.</p>
+        <SectionFrame className="xl:rounded-r-none xl:border-r-0">
+            <CardHeader className="px-7 pt-7 pb-0">
+                <CardTitle className="font-body text-sm font-medium text-[#0F172A]">{t('dashboard.channels.title')}</CardTitle>
+                <CardDescription className="mt-1 text-xs text-[#94A3B8]">
+                    {t('dashboard.channels.description', { rangeStart, rangeEnd })}
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="flex min-h-[360px] flex-col px-7 pb-7 pt-5">
+                {distribution.total === 0 || channels.length === 0 ? (
+                    <div className="flex flex-1 items-center justify-center rounded-[6px] border border-dashed border-[#E2E8F0] bg-[#F8FAFC] px-5 py-10 text-center text-sm text-[#64748B]">
+                        {t('dashboard.channels.empty')}
                     </div>
-                    <span className="rounded-full bg-[#F3ECFF] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-[#5B619D]">
-                        Sample data
-                    </span>
-                </div>
+                ) : (
+                    <>
+                        <div className="relative mx-auto h-[180px] w-full max-w-[300px]">
+                            <ChartContainer config={chartConfig} className="h-full w-full aspect-auto!">
+                                <PieChart>
+                                    <ChartTooltip
+                                        cursor={false}
+                                        content={(
+                                            <ChartTooltipContent
+                                                hideLabel
+                                                formatter={(value, name, item) => {
+                                                    const channel = channels.find((entry) => entry.key === item.payload?.key || entry.key === name);
 
+                                                    if (!channel) {
+                                                        return numberFormat(Number(value), locale);
+                                                    }
+
+                                                    return (
+                                                        <div className="flex min-w-32 flex-1 items-center justify-between gap-3 leading-none">
+                                                            <span className="text-muted-foreground">{channel.label}</span>
+                                                            <span className="font-mono font-medium text-foreground tabular-nums">
+                                                                {numberFormat(channel.count, locale)}
+                                                            </span>
+                                                        </div>
+                                                    );
+                                                }}
+                                            />
+                                        )}
+                                    />
+                                    <Pie
+                                        data={channels}
+                                        dataKey="count"
+                                        nameKey="key"
+                                        startAngle={180}
+                                        endAngle={0}
+                                        innerRadius={72}
+                                        outerRadius={108}
+                                        cx="50%"
+                                        cy="100%"
+                                        paddingAngle={1}
+                                        stroke="transparent"
+                                    >
+                                        {channels.map((channel) => (
+                                            <Cell key={channel.key} fill={channel.color} />
+                                        ))}
+                                    </Pie>
+                                </PieChart>
+                            </ChartContainer>
+                            <div className="pointer-events-none absolute inset-x-0 bottom-0 text-center">
+                                <div className="font-display text-2xl font-medium text-[#0F172A]">{numberFormat(distribution.total, locale)}</div>
+                                <div className="mt-0.5 text-xs text-[#94A3B8]">{t('dashboard.channels.total')}</div>
+                            </div>
+                        </div>
+                        <div className="mt-3 flex flex-wrap justify-center gap-x-4 gap-y-2 text-xs">
+                            {channels.map((channel) => (
+                                <div key={channel.key} className="flex min-w-0 items-center gap-2 text-[#64748B]">
+                                    <span className="h-2.5 w-2.5 shrink-0 rounded-[3px]" style={{ backgroundColor: channel.color }} />
+                                    <span className="truncate">{channel.label}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </>
+                )}
+            </CardContent>
+        </SectionFrame>
+    );
+}
+
+function getActivityDotClass(event: string | null): string {
+    const value = event?.toLowerCase() ?? '';
+
+    if (value.includes('closed') || value.includes('resolved')) {
+        return 'bg-[#22C55E] ring-[#DCFCE7]';
+    }
+
+    if (value.includes('overdue') || value.includes('reopened')) {
+        return 'bg-[#DC2626] ring-[#FEE2E2]';
+    }
+
+    if (value.includes('assigned') || value.includes('transferred')) {
+        return 'bg-[#C4A5F3] ring-[#F3E8FF]';
+    }
+
+    return 'bg-[#5B619D] ring-[#E0E7FF]';
+}
+
+function RecentActivity({ items, locale, t }: { items: ActivityItem[]; locale: string; t: Translation }) {
+    return (
+        <SectionFrame className="border-t border-[#E2E8F0] xl:rounded-l-none xl:border-l xl:border-t-0 xl:border-[#E2E8F0]">
+            <CardHeader className="flex flex-row items-start justify-between gap-4 px-7 pt-7 pb-0">
+                <div>
+                    <CardTitle className="font-body text-sm font-medium text-[#0F172A]">{t('dashboard.recent_activity.title')}</CardTitle>
+                    <CardDescription className="mt-1 text-xs text-[#94A3B8]">{t('dashboard.recent_activity.description')}</CardDescription>
+                </div>
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[5px] bg-[#F1F5F9] text-[#5B619D]">
+                    <HugeiconsIcon icon={Activity01Icon} size={17} />
+                </div>
+            </CardHeader>
+            <CardContent className="flex flex-col px-7 pb-7 pt-5">
+                {items.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center rounded-[6px] border border-dashed border-[#E2E8F0] bg-[#F8FAFC] px-5 py-12 text-center">
+                        <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-[#F1F5F9] text-[#94A3B8]">
+                            <HugeiconsIcon icon={InboxIcon} size={20} />
+                        </div>
+                        <p className="text-sm font-medium text-[#64748B]">{t('dashboard.recent_activity.empty')}</p>
+                    </div>
+                ) : (
+                    <div className="relative">
+                        <div className="absolute bottom-6 left-[1px] top-6 w-[2px] bg-[#F1F5F9]" aria-hidden />
+                        <div className="grid gap-3">
+                            {items.map((item) => {
+                                const title = item.ticket_number ? `#${item.ticket_number}` : t('dashboard.recent_activity.thread', { id: item.thread_id });
+                                const time = formatDashboardRelative(item.timestamp, locale) ?? formatDashboardDateTime(item.timestamp, locale) ?? t('dashboard.recent_activity.unknown_time');
+                                const event = item.event ?? t('dashboard.recent_activity.ticket_activity');
+
+                                const dotClass = getActivityDotClass(item.event);
+                                const borderColor = dotClass.split(' ')[0].replace('bg-', 'border-');
+                                const textColor = dotClass.split(' ')[0].replace('bg-', 'text-');
+                                const lightBgColor = dotClass.split(' ')[1].replace('ring-', 'bg-');
+
+                                return (
+                                    <button
+                                        key={item.id}
+                                        type="button"
+                                        onClick={() => item.ticket_id && router.get(`/scp/tickets/${item.ticket_id}`)}
+                                        disabled={!item.ticket_id}
+                                        className="group relative flex w-full text-left transition disabled:cursor-default"
+                                    >
+                                        <div className={cn('relative z-10 w-full min-w-0 rounded-[6px] border border-[#F1F5F9] bg-white p-4 shadow-[0_1px_2px_0_rgba(15,23,42,0.02)] transition group-hover:border-[#E2E8F0] group-hover:bg-[#F8FAFC]', 'border-l-[4px]', borderColor)}>
+                                            <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+                                                <div className="flex min-w-0 items-center gap-2">
+                                                    <span className="rounded-[4px] bg-[#F1F5F9] px-2 py-0.5 font-mono text-[11px] font-medium text-[#64748B] transition group-hover:bg-white">{title}</span>
+                                                    <span className={cn('rounded-[4px] px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.05em]', lightBgColor, textColor)}>
+                                                        {event}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <p className="line-clamp-1 font-medium text-sm text-[#0F172A]">
+                                                {item.ticket_subject ?? t('dashboard.recent_activity.untitled_ticket')}
+                                            </p>
+                                            <div className="mt-3 flex items-center gap-2 text-[11px] font-medium text-[#94A3B8]">
+                                                {item.username && (
+                                                    <span className="text-[#64748B]">
+                                                        {t('dashboard.recent_activity.actor', { username: item.username })}
+                                                    </span>
+                                                )}
+                                                {item.username && <span>&middot;</span>}
+                                                <span className="flex shrink-0 items-center gap-1 font-mono">
+                                                    <HugeiconsIcon icon={Clock01Icon} size={12} />
+                                                    {time}
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        <div className="mt-4 text-center">
+                            <button
+                                type="button"
+                                onClick={() => router.get('/scp/tickets')}
+                                className="font-body text-xs font-medium text-[#94A3B8] transition hover:text-[#5B619D]"
+                            >
+                                View all activity &rarr;
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </SectionFrame>
+    );
+}
+
+
+
+export function DashboardSkeleton() {
+    return (
+        <div className="overflow-hidden rounded-[8px] border border-[#E2E8F0] bg-white shadow-sm shadow-[#0F172A]/[0.03]">
+            {/* Stat cards row */}
+            <div className="border-b border-[#E2E8F0]">
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <div key={i} className={getStatCardBorderClass(i)}>
+                            <div className="flex min-h-[132px] flex-col px-7 py-6">
+                                <Skeleton className="h-3 w-24" />
+                                <div className="mt-3 flex items-center gap-2">
+                                    <Skeleton className="h-8 w-16" />
+                                    <Skeleton className="h-5 w-12 rounded-[4px]" />
+                                </div>
+                                <Skeleton className="mt-auto pt-2 h-3 w-32" />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+            {/* Charts row */}
+            <div className="grid grid-cols-1 border-b border-[#E2E8F0] xl:grid-cols-3">
+                <div className="px-7 py-7 xl:col-span-2">
+                    <Skeleton className="h-4 w-40 mb-2" />
+                    <Skeleton className="h-3 w-60 mb-6" />
+                    <Skeleton className="h-[310px] w-full rounded-lg" />
+                </div>
+                <div className="border-t border-[#E2E8F0] px-7 py-7 xl:border-l xl:border-t-0">
+                    <Skeleton className="h-4 w-32 mb-2" />
+                    <Skeleton className="h-3 w-48 mb-6" />
+                    <Skeleton className="mx-auto aspect-square w-[220px] rounded-full" />
+                </div>
+            </div>
+            {/* Bottom row */}
+            <div className="grid grid-cols-1 xl:grid-cols-2">
+                <div className="px-7 py-7">
+                    <Skeleton className="h-4 w-36 mb-2" />
+                    <Skeleton className="h-3 w-52 mb-4" />
+                    <Skeleton className="h-[180px] w-full rounded-lg" />
+                </div>
+                <div className="border-t border-[#E2E8F0] px-7 py-7 xl:border-l xl:border-t-0">
+                    <Skeleton className="h-4 w-32 mb-2" />
+                    <Skeleton className="h-3 w-48 mb-4" />
+                    {Array.from({ length: 5 }).map((_, i) => (
+                        <div key={i} className="mb-3 grid grid-cols-[22px_1fr] gap-3">
+                            <Skeleton className="mt-3 h-[22px] w-[22px] rounded-full" />
+                            <Skeleton className="h-[72px] rounded-[6px]" />
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function Dashboard({ metrics, range }: DashboardProps) {
+    const { t, i18n } = useTranslation();
+    const locale = i18n.resolvedLanguage ?? i18n.language;
+    const cards = getMetricCards(metrics, t, locale);
+
+    return (
+        <div className="overflow-hidden rounded-[8px] border border-[#E2E8F0] bg-white shadow-sm shadow-[#0F172A]/[0.03]">
+            <div className="border-b border-[#E2E8F0]">
                 <SectionFrame>
                     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4">
-                        {STAT_CARDS.map((card, index) => (
+                        {cards.map((card, index) => (
                             <div key={card.label} className={getStatCardBorderClass(index)}>
-                                <StatCard {...card} />
+                                <StatCard {...card} locale={locale} />
                             </div>
                         ))}
                     </div>
                 </SectionFrame>
-
-                <div className="grid grid-cols-1 gap-6 xl:grid-cols-3 xl:gap-0">
-                    <SectionFrame className="xl:col-span-2 xl:rounded-r-none xl:border-r-0">
-                        <CardHeader className="px-6 pt-6 xl:px-8 xl:pt-8">
-                            <div className="flex items-center justify-between gap-4">
-                                <div>
-                                    <CardTitle className="font-body text-base font-medium text-[#0F172A]">Average Tickets Created</CardTitle>
-                                    <CardDescription className="mt-1 text-sm text-[#94A3B8]">{dateRangeLabel}</CardDescription>
-                                </div>
-                                <Select value={dateRange} onValueChange={(value) => value && setDateRange(value as DateRangeValue)}>
-                                    <SelectTrigger
-                                        size="sm"
-                                        className="rounded-md border-[#E2E8F0] bg-white text-xs text-[#64748B]"
-                                        aria-label="Select ticket date range"
-                                    >
-                                        <SelectValue placeholder="Select date range" />
-                                    </SelectTrigger>
-                                    <SelectContent align="end" className="rounded-xl">
-                                        {DATE_RANGE_OPTIONS.map(({ value, label }) => (
-                                            <SelectItem key={value} value={value} className="rounded-lg text-xs">
-                                                {label}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </div>
-                        </CardHeader>
-                        <CardContent className="px-6 pb-6 xl:px-8 xl:pb-8">
-                            <ChartContainer config={ticketChartConfig} className="h-[360px] min-h-0 w-full aspect-auto!">
-                                <BarChart accessibilityLayer data={ticketChartData} margin={{ top: 16, right: 8, left: 0, bottom: 8 }}>
-                                    <CartesianGrid vertical={false} strokeDasharray="3 5" />
-                                    <XAxis dataKey="day" tickLine={false} axisLine={false} tickMargin={10} />
-                                    <YAxis tickLine={false} axisLine={false} tickMargin={12} domain={[0, 5000]} ticks={[0, 1000, 2000, 3000, 4000, 5000]} />
-                                    <ChartTooltip content={<ChartTooltipContent hideLabel />} />
-                                    <ChartLegend content={<ChartLegendContent />} />
-                                    <Bar dataKey="solved" stackId="a" radius={[0, 0, 4, 4]} maxBarSize={32}>
-                                        {ticketChartData.map((item) => (
-                                            <Cell key={`solved-${item.day}`} fill="var(--color-solved)" fillOpacity={item.highlighted ? 1 : 0.92} />
-                                        ))}
-                                    </Bar>
-                                    <Bar dataKey="created" stackId="a" radius={[4, 4, 0, 0]} maxBarSize={32}>
-                                        {ticketChartData.map((item) => (
-                                            <Cell key={`created-${item.day}`} fill={item.highlighted ? '#C4A5F3' : 'var(--color-created)'} fillOpacity={item.highlighted ? 1 : 0.9} />
-                                        ))}
-                                    </Bar>
-                                </BarChart>
-                            </ChartContainer>
-                        </CardContent>
-                        <TicketChartFooter dateRangeLabel={dateRangeLabel} />
-                    </SectionFrame>
-
-                    <SectionFrame className="xl:rounded-l-none">
-                        <ReplyTimeInteractiveChart />
-                    </SectionFrame>
-                </div>
-
-                <div className="grid grid-cols-1 gap-6 xl:grid-cols-2 xl:gap-0">
-                    <SectionFrame className="xl:rounded-r-none xl:border-r-0">
-                        <CardHeader className="px-6 pt-6 pb-0 xl:px-8 xl:pt-8">
-                            <CardTitle className="font-body text-base font-medium text-[#0F172A]">Ticket by Channels</CardTitle>
-                        </CardHeader>
-                        <CardContent className="flex flex-col items-center p-6 xl:p-8">
-                            <div className="relative mb-8 h-40 w-72 max-w-full">
-                                <ChartContainer config={channelChartConfig} className="h-full w-full aspect-auto!">
-                                    <PieChart>
-                                        <ChartTooltip content={<ChartTooltipContent hideLabel formatter={(value) => value?.toLocaleString?.() ?? String(value)} />} />
-                                        <Pie data={CHANNEL_DATA} dataKey="value" nameKey="name" startAngle={180} endAngle={0} innerRadius={72} outerRadius={96} cx="50%" cy="100%" stroke="transparent" paddingAngle={2}>
-                                            {CHANNEL_DATA.map((entry) => (
-                                                <Cell key={entry.name} fill={entry.fill} />
-                                            ))}
-                                        </Pie>
-                                    </PieChart>
-                                </ChartContainer>
-
-                                <div className="absolute bottom-0 left-1/2 w-full -translate-x-1/2 text-center">
-                                    <p className="text-[11px] text-[#94A3B8]">Total Active ticket</p>
-                                    <p className="font-display text-[30px] font-medium tracking-tight text-[#0F172A]">3002</p>
-                                </div>
-                            </div>
-
-                            <div className="flex flex-wrap justify-center gap-x-6 gap-y-3 text-xs text-[#64748B]">
-                                {CHANNEL_DATA.map(({ fill, name }) => (
-                                    <div key={name} className="flex items-center gap-2">
-                                        <div className="h-2 w-2 rounded-sm" style={{ backgroundColor: fill }}></div>
-                                        {name}
-                                    </div>
-                                ))}
-                            </div>
-                        </CardContent>
-                    </SectionFrame>
-
-                    <SectionFrame className="xl:rounded-l-none">
-                        <CardHeader className="px-6 pt-6 pb-0 xl:px-8 xl:pt-8">
-                            <CardTitle className="font-body text-base font-medium text-[#0F172A]">Customer Satisfaction</CardTitle>
-                        </CardHeader>
-                        <CardContent className="p-6 xl:p-8">
-                            <div className="grid gap-8 lg:grid-cols-2 lg:gap-6">
-                                <div className="flex items-center lg:pr-8">
-                                    <div className="w-full">
-                                        <p className="mb-2 text-sm text-[#64748B]">Responses Received</p>
-                                        <p className="font-display text-[30px] font-medium tracking-tight text-[#0F172A]">156 Customers</p>
-                                    </div>
-                                    <Separator orientation="vertical" className="ml-8 hidden bg-[#E2E8F0] lg:block" />
-                                </div>
-
-                                <div className="space-y-6">
-                                    {SATISFACTION_ROWS.map(({ icon, label, percent, helper, fill, tone, iconTone }) => (
-                                        <div key={label}>
-                                            <div className="mb-2 flex items-center gap-3">
-                                                <div className={cn('flex h-11 w-11 items-center justify-center rounded-full text-xl', iconTone)}>
-                                                    <span>{icon}</span>
-                                                </div>
-                                                <div>
-                                                    <p className="text-xs text-[#64748B]">{label}</p>
-                                                    <p className="mt-0.5 text-xl font-semibold leading-none text-[#0F172A]">{percent}</p>
-                                                </div>
-                                            </div>
-
-                                            <div className="flex items-center gap-3">
-                                                <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[#E2E8F0]">
-                                                    <div className={cn('h-full rounded-full', tone)} style={{ width: fill }}></div>
-                                                </div>
-                                                <span className="text-[10px] font-medium text-[#94A3B8]">{helper}</span>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        </CardContent>
-                    </SectionFrame>
-                </div>
             </div>
+
+            <div className="grid grid-cols-1 border-b border-[#E2E8F0] xl:grid-cols-3">
+                <WorkloadChart metrics={metrics} locale={locale} t={t} />
+                <AssignmentChart metrics={metrics} locale={locale} t={t} />
+            </div>
+
+            <div className="grid grid-cols-1 xl:grid-cols-2">
+                <ChannelRadialChart distribution={metrics.channelDistribution} locale={locale} t={t} />
+                <RecentActivity items={metrics.recentActivity} locale={locale} t={t} />
+            </div>
+        </div>
+    );
+}
+
+function DashboardHeaderTitle() {
+    const { t } = useTranslation();
+
+    return (
+        <div className="flex items-baseline gap-2.5">
+            <h1 className="font-display text-xl font-medium tracking-[-0.02em] text-[#0F172A]">{t('nav.dashboard')}</h1>
+            <span className="text-[#94A3B8]">·</span>
+            <span className="font-body text-[11px] font-medium uppercase tracking-[0.12em] text-[#94A3B8]">{t('dashboard.overview')}</span>
+        </div>
+    );
+}
+
+function DashboardHeaderActions() {
+    const { t } = useTranslation();
+    const { range } = usePage<{ range?: string }>().props;
+    const [activeRange, setActiveRange] = useState(range ?? 'last_6_months');
+    const rangeLabels: Record<string, string> = {
+        last_7_days: t('dashboard.date_range.last_7_days'),
+        last_30_days: t('dashboard.date_range.last_30_days'),
+        last_3_months: t('dashboard.date_range.last_3_months'),
+        last_6_months: t('dashboard.date_range.last_6_months'),
+    };
+
+    return (
+        <>
+            <Select
+                defaultValue={activeRange}
+                onValueChange={(value) => {
+                    if (!value) return;
+                    setActiveRange(value);
+                    router.reload({ data: { range: value }, only: ['metrics'] });
+                }}
+            >
+                <SelectTrigger className="h-7 w-[160px] rounded-[4px] border-[#E2E8F0] bg-white text-xs text-[#64748B]">
+                    <span className="truncate">{rangeLabels[activeRange] ?? t('dashboard.date_range.label')}</span>
+                </SelectTrigger>
+                <SelectContent align="end" className="rounded-xl">
+                    <SelectItem value="last_7_days" className="rounded-lg text-xs">{t('dashboard.date_range.last_7_days')}</SelectItem>
+                    <SelectItem value="last_30_days" className="rounded-lg text-xs">{t('dashboard.date_range.last_30_days')}</SelectItem>
+                    <SelectItem value="last_3_months" className="rounded-lg text-xs">{t('dashboard.date_range.last_3_months')}</SelectItem>
+                    <SelectItem value="last_6_months" className="rounded-lg text-xs">{t('dashboard.date_range.last_6_months')}</SelectItem>
+                </SelectContent>
+            </Select>
+            <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 rounded-[4px] border-[#E2E8F0] bg-white px-3 text-xs font-medium uppercase tracking-[0.12em] text-[#64748B] hover:border-[#C4A5F3] hover:bg-[#F8FAFC] hover:text-[#0F172A]"
+                onClick={() => router.reload({ only: ['metrics'] })}
+            >
+                {t('actions.refresh')}
+            </Button>
+            <LanguageSwitcher />
         </>
     );
 }
@@ -497,7 +849,12 @@ type DashboardPageComponent = typeof Dashboard & {
 };
 
 (Dashboard as DashboardPageComponent).layout = (page: ReactElement) => (
-    <DashboardLayout title="Dashboard" activeNav="dashboard" contentClassName="w-full">
+    <DashboardLayout
+        activeNav="dashboard"
+        contentClassName="w-full"
+        headerLeft={<DashboardHeaderTitle />}
+        headerActions={<DashboardHeaderActions />}
+    >
         {page}
     </DashboardLayout>
 );

--- a/resources/js/pages/Scp/Preferences/Index.tsx
+++ b/resources/js/pages/Scp/Preferences/Index.tsx
@@ -1,0 +1,188 @@
+import { useForm, usePage } from '@inertiajs/react';
+import type { ReactElement, ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+    Field,
+    FieldDescription,
+    FieldGroup,
+    FieldLabel,
+    FieldLegend,
+    FieldSet,
+} from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import DashboardLayout from '@/layouts/DashboardLayout';
+
+const THEME_OPTIONS = [
+    { value: 'system', label: 'Match system' },
+    { value: 'light', label: 'Light' },
+    { value: 'dark', label: 'Dark' },
+] as const;
+
+const NOTIFICATION_CHANNELS = [
+    { id: 'desktop', label: 'Desktop alerts', description: 'Toast notifications inside the agent panel.' },
+    { id: 'email', label: 'Email digests', description: 'Receive summary emails for new assignments.' },
+    { id: 'sound', label: 'Sound effects', description: 'Audible cue when a new ticket arrives.' },
+] as const;
+
+type ThemeValue = (typeof THEME_OPTIONS)[number]['value'];
+type NotificationChannel = (typeof NOTIFICATION_CHANNELS)[number]['id'];
+type NotificationPreferences = Record<NotificationChannel, boolean>;
+
+interface StaffPreferences {
+    theme: ThemeValue;
+    language: string | null;
+    timezone: string | null;
+    notifications: NotificationPreferences;
+}
+
+interface PreferencesPageProps {
+    preferences: StaffPreferences;
+}
+
+interface SharedProps extends Record<string, unknown> {
+    status?: string;
+}
+
+type FormSubmitHandler = NonNullable<React.ComponentProps<'form'>['onSubmit']>;
+
+export default function PreferencesIndex({ preferences }: PreferencesPageProps) {
+    const { props } = usePage<SharedProps>();
+    const form = useForm({
+        theme: preferences.theme,
+        language: preferences.language ?? '',
+        timezone: preferences.timezone ?? '',
+        notifications: {
+            desktop: preferences.notifications?.desktop ?? true,
+            email: preferences.notifications?.email ?? false,
+            sound: preferences.notifications?.sound ?? false,
+        },
+    });
+
+    const save: FormSubmitHandler = (event) => {
+        event.preventDefault();
+        form.patch('/scp/preferences', { preserveScroll: true });
+    };
+
+    function toggleChannel(channel: NotificationChannel, enabled: boolean) {
+        form.setData('notifications', {
+            ...form.data.notifications,
+            [channel]: enabled,
+        });
+    }
+
+    return (
+        <div className="mx-auto max-w-3xl">
+            {props.status && (
+                <div className="mb-6 rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+                    {props.status}
+                </div>
+            )}
+
+            <form
+                onSubmit={save}
+                className="rounded-[18px] border border-[#E2E8F0] bg-white p-6 shadow-sm shadow-[#0F172A]/[0.03] xl:p-8"
+            >
+                <FieldGroup>
+                    <Field>
+                        <FieldLabel htmlFor="preferences-theme">Theme</FieldLabel>
+                        <Select
+                            value={form.data.theme}
+                            onValueChange={(value) => value && form.setData('theme', value as ThemeValue)}
+                        >
+                            <SelectTrigger id="preferences-theme" className="w-full">
+                                <SelectValue placeholder="Select a theme" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {THEME_OPTIONS.map(({ value, label }) => (
+                                    <SelectItem key={value} value={value}>
+                                        {label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <FieldDescription>Controls the appearance for your agent workspace.</FieldDescription>
+                    </Field>
+
+                    <Field>
+                        <FieldLabel htmlFor="preferences-language">Language</FieldLabel>
+                        <Input
+                            id="preferences-language"
+                            value={form.data.language}
+                            placeholder="en"
+                            onChange={(event) => form.setData('language', event.target.value)}
+                        />
+                        <FieldDescription>IETF language tag, e.g. <span className="font-mono">en</span> or <span className="font-mono">vi-VN</span>.</FieldDescription>
+                    </Field>
+
+                    <Field>
+                        <FieldLabel htmlFor="preferences-timezone">Timezone</FieldLabel>
+                        <Input
+                            id="preferences-timezone"
+                            value={form.data.timezone}
+                            placeholder="America/New_York"
+                            onChange={(event) => form.setData('timezone', event.target.value)}
+                        />
+                        <FieldDescription>IANA zone name. Leave empty to inherit from the system.</FieldDescription>
+                    </Field>
+
+                    <FieldSet>
+                        <FieldLegend variant="label">Notifications</FieldLegend>
+                        <FieldDescription>Choose how you want to be alerted to new ticket activity.</FieldDescription>
+                        <div className="grid gap-3">
+                            {NOTIFICATION_CHANNELS.map(({ id, label, description }) => (
+                                <Label
+                                    key={id}
+                                    htmlFor={`preferences-notify-${id}`}
+                                    className="flex items-start gap-3 rounded-md border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-3 cursor-pointer hover:border-[#CBD5E1]"
+                                >
+                                    <input
+                                        id={`preferences-notify-${id}`}
+                                        type="checkbox"
+                                        checked={form.data.notifications[id]}
+                                        onChange={(event) => toggleChannel(id, event.target.checked)}
+                                        className="mt-1 h-4 w-4 rounded border-[#CBD5E1] text-[#5B619D] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5B619D]"
+                                    />
+                                    <span className="flex flex-col gap-1">
+                                        <span className="text-sm font-medium text-[#0F172A]">{label}</span>
+                                        <span className="text-xs text-[#64748B]">{description}</span>
+                                    </span>
+                                </Label>
+                            ))}
+                        </div>
+                    </FieldSet>
+                </FieldGroup>
+
+                <div className="mt-8 flex justify-end gap-3">
+                    <Button type="submit" disabled={form.processing}>
+                        {form.processing ? 'Saving…' : 'Save preferences'}
+                    </Button>
+                </div>
+            </form>
+        </div>
+    );
+}
+
+type PreferencesPageComponent = typeof PreferencesIndex & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(PreferencesIndex as PreferencesPageComponent).layout = (page: ReactElement) => (
+    <DashboardLayout
+        title="Preferences"
+        subtitle="Personalize how the agent workspace looks and notifies you."
+        eyebrow="Account"
+        activeNav="preferences"
+        headerActions={null}
+    >
+        {page}
+    </DashboardLayout>
+);

--- a/resources/js/pages/Scp/Queues/Index.tsx
+++ b/resources/js/pages/Scp/Queues/Index.tsx
@@ -1,0 +1,47 @@
+import type { ReactElement, ReactNode } from 'react';
+
+import { type QueueNavigation } from '@/components/scp/queue-types';
+import { QueueSelector } from '@/components/scp/QueueSelector';
+import DashboardLayout from '@/layouts/DashboardLayout';
+
+interface QueuesIndexProps {
+    navigation: QueueNavigation;
+}
+
+export default function QueuesIndex({ navigation }: QueuesIndexProps) {
+    return (
+        <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-4 px-1">
+                <QueueSelector navigation={navigation} placeholder="Pick a queue" />
+                <span className="text-xs text-zinc-400">
+                    Pick a queue from the list above to see its ticket table.
+                </span>
+            </div>
+
+            <section className="flex min-h-[320px] flex-col items-center justify-center rounded-[18px] border border-dashed border-zinc-200 bg-white px-6 py-12 text-center">
+                <h2 className="font-display text-lg font-medium text-zinc-900">No queue selected</h2>
+                <p className="mt-2 max-w-md text-sm text-zinc-500">
+                    Each queue carries its own filters, columns, and sort order. Personal queues and saved searches
+                    sync from your legacy osTicket profile and stay private to you.
+                </p>
+            </section>
+        </div>
+    );
+}
+
+type QueuesIndexComponent = typeof QueuesIndex & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(QueuesIndex as QueuesIndexComponent).layout = (page: ReactElement) => (
+    <DashboardLayout
+        title="Tickets"
+        subtitle="Browse the legacy ticket queues you have access to."
+        eyebrow="Tickets"
+        activeNav="queues"
+        contentClassName="w-full"
+        headerActions={null}
+    >
+        {page}
+    </DashboardLayout>
+);

--- a/resources/js/pages/Scp/Queues/Show.tsx
+++ b/resources/js/pages/Scp/Queues/Show.tsx
@@ -3,7 +3,6 @@ import { HugeiconsIcon } from '@hugeicons/react';
 import {
     Add01Icon,
     Download01Icon,
-    MaximizeScreenIcon,
     Search01Icon,
 } from '@hugeicons/core-free-icons';
 
@@ -13,7 +12,12 @@ import {
     type PaginationState,
     type TicketRow,
 } from '@/components/scp/QueueTicketTable';
-import { TicketFilterChips } from '@/components/scp/TicketFilterChips';
+import {
+    TicketFilterChips,
+    type QueueFilterOptions,
+    type QueueFilters,
+    type QueueSortState,
+} from '@/components/scp/TicketFilterChips';
 import { type QueueNavigation } from '@/components/scp/queue-types';
 import { Button, buttonVariants } from '@/components/ui/button';
 import {
@@ -36,6 +40,9 @@ interface QueueShowProps {
     pagination: PaginationState;
     unsupported: boolean;
     unsupportedReasons?: string[];
+    filters: QueueFilters;
+    filterOptions: QueueFilterOptions;
+    sort: QueueSortState;
 }
 
 interface QueueShowLayoutProps extends QueueShowProps {
@@ -56,17 +63,6 @@ function QueueShowLayout({ queue, navigation, children }: QueueShowLayoutProps) 
             }
             headerActions={
                 <>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        disabled
-                        aria-disabled="true"
-                        title="Coming soon"
-                        className="rounded-md border-zinc-200 text-zinc-700"
-                    >
-                        <HugeiconsIcon icon={MaximizeScreenIcon} size={14} />
-                        Focus Mode
-                    </Button>
                     <a
                         href={`/scp/queues/${queue.id}/export`}
                         className={buttonVariants({ variant: 'outline', size: 'sm' })}
@@ -100,6 +96,9 @@ export default function QueueShow({
     pagination,
     unsupported,
     unsupportedReasons = [],
+    filters,
+    filterOptions,
+    sort,
 }: QueueShowProps) {
     return (
         <div className="space-y-4">
@@ -116,7 +115,7 @@ export default function QueueShow({
                 </div>
             )}
 
-            <div className="flex flex-wrap items-center gap-6 border-y border-zinc-100 px-1 py-3">
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-3 border-y border-zinc-100 px-1 py-3">
                 <form
                     role="search"
                     onSubmit={(event) => {
@@ -126,7 +125,7 @@ export default function QueueShow({
                             window.location.href = `/scp/search?queue=${queue.id}&q=${encodeURIComponent(value)}`;
                         }
                     }}
-                    className="w-64"
+                    className="w-full sm:w-64"
                 >
                     <InputGroup>
                         <InputGroupAddon align="inline-start">
@@ -144,13 +143,20 @@ export default function QueueShow({
                     {pagination.total} {pagination.total === 1 ? 'ticket' : 'tickets'}
                 </span>
 
-                <TicketFilterChips />
+                <TicketFilterChips
+                    queueId={queue.id}
+                    filters={filters}
+                    filterOptions={filterOptions}
+                    sort={sort}
+                />
             </div>
 
             <QueueTicketTable
                 queueId={queue.id}
                 tickets={tickets}
                 pagination={pagination}
+                sort={sort}
+                filters={filters}
             />
         </div>
     );

--- a/resources/js/pages/Scp/Queues/Show.tsx
+++ b/resources/js/pages/Scp/Queues/Show.tsx
@@ -1,0 +1,160 @@
+import type { ReactNode } from 'react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import {
+    Add01Icon,
+    Download01Icon,
+    MaximizeScreenIcon,
+    Search01Icon,
+} from '@hugeicons/core-free-icons';
+
+import { QueueSelector } from '@/components/scp/QueueSelector';
+import {
+    QueueTicketTable,
+    type PaginationState,
+    type TicketRow,
+} from '@/components/scp/QueueTicketTable';
+import { TicketFilterChips } from '@/components/scp/TicketFilterChips';
+import { type QueueNavigation } from '@/components/scp/queue-types';
+import { Button, buttonVariants } from '@/components/ui/button';
+import {
+    InputGroup,
+    InputGroupAddon,
+    InputGroupInput,
+} from '@/components/ui/input-group';
+import { Kbd } from '@/components/ui/kbd';
+import DashboardLayout from '@/layouts/DashboardLayout';
+
+interface Queue {
+    id: number;
+    title: string;
+}
+
+interface QueueShowProps {
+    navigation: QueueNavigation;
+    queue: Queue;
+    tickets: TicketRow[];
+    pagination: PaginationState;
+    unsupported: boolean;
+    unsupportedReasons?: string[];
+}
+
+interface QueueShowLayoutProps extends QueueShowProps {
+    children: ReactNode;
+}
+
+// Named function (not arrow) so Inertia treats it as a layout component, not a layout resolver.
+// Arrow functions have prototype===undefined, triggering a speculative call with raw props that
+// causes "TypeError: e.props is undefined". Named functions have a prototype, avoiding that path.
+function QueueShowLayout({ queue, navigation, children }: QueueShowLayoutProps) {
+    return (
+        <DashboardLayout
+            headerLeft={
+                <div>
+                    <QueueSelector navigation={navigation} activeQueueId={queue.id} variant="heading" label={queue.title} />
+                    <p className="mt-1 font-body text-sm text-[#94A3B8]">Tickets</p>
+                </div>
+            }
+            headerActions={
+                <>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        disabled
+                        aria-disabled="true"
+                        title="Coming soon"
+                        className="rounded-md border-zinc-200 text-zinc-700"
+                    >
+                        <HugeiconsIcon icon={MaximizeScreenIcon} size={14} />
+                        Focus Mode
+                    </Button>
+                    <a
+                        href={`/scp/queues/${queue.id}/export`}
+                        className={buttonVariants({ variant: 'outline', size: 'sm' })}
+                    >
+                        <HugeiconsIcon icon={Download01Icon} size={14} />
+                        Export CSV
+                    </a>
+                    <Button
+                        size="sm"
+                        disabled
+                        aria-disabled="true"
+                        title="Ticket creation lands in a later phase"
+                        className="rounded-md bg-emerald-500 text-white hover:bg-emerald-600 disabled:opacity-100"
+                    >
+                        <HugeiconsIcon icon={Add01Icon} size={14} />
+                        Add Ticket
+                    </Button>
+                </>
+            }
+            activeNav="queues"
+            contentClassName="w-full"
+        >
+            {children}
+        </DashboardLayout>
+    );
+}
+
+export default function QueueShow({
+    queue,
+    tickets,
+    pagination,
+    unsupported,
+    unsupportedReasons = [],
+}: QueueShowProps) {
+    return (
+        <div className="space-y-4">
+            {unsupported && (
+                <div className="rounded-[14px] border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-900">
+                    <p className="font-medium">This queue uses legacy criteria that are not fully supported yet.</p>
+                    {unsupportedReasons.length > 0 && (
+                        <ul className="mt-2 list-disc space-y-1 pl-5 text-xs">
+                            {unsupportedReasons.map((reason) => (
+                                <li key={reason}>{reason}</li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            )}
+
+            <div className="flex flex-wrap items-center gap-6 border-y border-zinc-100 px-1 py-3">
+                <form
+                    role="search"
+                    onSubmit={(event) => {
+                        event.preventDefault();
+                        const value = new FormData(event.currentTarget).get('q')?.toString().trim() ?? '';
+                        if (value !== '') {
+                            window.location.href = `/scp/search?queue=${queue.id}&q=${encodeURIComponent(value)}`;
+                        }
+                    }}
+                    className="w-64"
+                >
+                    <InputGroup>
+                        <InputGroupAddon align="inline-start">
+                            <HugeiconsIcon icon={Search01Icon} size={14} />
+                        </InputGroupAddon>
+                        <InputGroupInput name="q" placeholder="Search" aria-label="Search this queue" />
+                        <InputGroupAddon align="inline-end">
+                            <Kbd>⌘</Kbd>
+                            <Kbd>K</Kbd>
+                        </InputGroupAddon>
+                    </InputGroup>
+                </form>
+
+                <span className="text-xs text-zinc-400">
+                    {pagination.total} {pagination.total === 1 ? 'ticket' : 'tickets'}
+                </span>
+
+                <TicketFilterChips />
+            </div>
+
+            <QueueTicketTable
+                queueId={queue.id}
+                tickets={tickets}
+                pagination={pagination}
+            />
+        </div>
+    );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(QueueShow as any).layout = QueueShowLayout;

--- a/resources/js/pages/Scp/Search/Index.tsx
+++ b/resources/js/pages/Scp/Search/Index.tsx
@@ -1,0 +1,87 @@
+import { router } from '@inertiajs/react';
+import type { ReactElement, ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import DashboardLayout from '@/layouts/DashboardLayout';
+
+interface SearchIndexProps {
+    query: string;
+    results: Array<{
+        id: number;
+        number: string;
+        title: string | null;
+        subject: string | null;
+        requester: string | null;
+        score: number;
+        created: string | null;
+    }>;
+}
+
+export default function SearchIndex({ query, results }: SearchIndexProps) {
+    return (
+        <div className="space-y-6">
+            <form
+                role="search"
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    const value = new FormData(event.currentTarget).get('q')?.toString().trim() ?? '';
+                    router.get('/scp/search', value === '' ? {} : { q: value });
+                }}
+                className="rounded-[18px] border border-[#E2E8F0] bg-white p-6 shadow-sm shadow-[#0F172A]/[0.03] xl:p-8"
+            >
+                <label htmlFor="search-query" className="text-xs font-medium uppercase tracking-[0.14em] text-[#94A3B8]">
+                    Query
+                </label>
+                <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+                    <Input
+                        id="search-query"
+                        name="q"
+                        defaultValue={query}
+                        placeholder="Search tickets, users, or threads"
+                        autoFocus
+                    />
+                    <Button type="submit">Search</Button>
+                </div>
+            </form>
+
+            <section className="rounded-[18px] border border-[#E2E8F0] bg-white shadow-sm shadow-[#0F172A]/[0.03]">
+                {results.length === 0 ? (
+                    <div className="px-6 py-12 text-center text-sm text-[#64748B]">
+                        {query ? `No tickets matched “${query}”.` : 'Enter a query above to search across tickets and threads.'}
+                    </div>
+                ) : (
+                    <div className="divide-y divide-[#F1F5F9]">
+                        {results.map((result) => (
+                            <a key={result.id} href={`/scp/tickets/${result.id}`} className="block px-6 py-4 hover:bg-[#F8FAFC]">
+                                <div className="flex flex-wrap items-center justify-between gap-3">
+                                    <h2 className="font-display text-base font-medium text-[#0F172A]">
+                                        #{result.number} · {result.title ?? result.subject ?? 'Untitled ticket'}
+                                    </h2>
+                                    <span className="text-xs text-[#94A3B8]">{result.created ?? '—'}</span>
+                                </div>
+                                {result.requester && <p className="mt-1 text-sm text-[#64748B]">{result.requester}</p>}
+                            </a>
+                        ))}
+                    </div>
+                )}
+            </section>
+        </div>
+    );
+}
+
+type SearchIndexComponent = typeof SearchIndex & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(SearchIndex as SearchIndexComponent).layout = (page) => (
+    <DashboardLayout
+        title="Search"
+        subtitle="Find tickets, threads, and users across the workspace."
+        eyebrow="Workspace"
+        activeNav="search"
+        headerActions={null}
+    >
+        {page}
+    </DashboardLayout>
+);

--- a/resources/js/pages/Scp/Tickets/Show.tsx
+++ b/resources/js/pages/Scp/Tickets/Show.tsx
@@ -1,10 +1,20 @@
-import { Link } from '@inertiajs/react';
-import type { ReactElement, ReactNode } from 'react';
+import { Link, usePage } from '@inertiajs/react';
+import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
+    AlertCircleIcon,
+    ArrowDown01Icon,
     Calendar01Icon,
+    Cancel01Icon,
+    CheckmarkCircle02Icon,
     Clock01Icon,
+    Copy01Icon,
+    Download01Icon,
     File01Icon,
+    Image01Icon,
+    Link01Icon,
+    Link02Icon,
     Mail01Icon,
     Note01Icon,
     UserGroupIcon,
@@ -14,6 +24,7 @@ import { PriorityBadge } from '@/components/scp/PriorityBadge';
 import { StatusBadge } from '@/components/scp/StatusBadge';
 import DashboardLayout from '@/layouts/DashboardLayout';
 import { formatBytes, formatDateTime, formatRelative } from '@/lib/datetime';
+import { sanitizeHtml } from '@/lib/sanitize-html';
 import { cn } from '@/lib/utils';
 
 interface Ticket {
@@ -99,28 +110,106 @@ const ENTRY_DEFAULT = {
     icon: Mail01Icon,
 };
 
-function stripHtml(value: string | null | undefined): string {
-    if (!value) return '';
-    return value
-        .replace(/<style[\s\S]*?<\/style>/gi, '')
-        .replace(/<script[\s\S]*?<\/script>/gi, '')
-        .replace(/<br\s*\/?>(\s|&nbsp;)*/gi, '\n')
-        .replace(/<\/p>\s*/gi, '\n\n')
-        .replace(/<[^>]+>/g, '')
-        .replace(/&nbsp;/g, ' ')
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/\n{3,}/g, '\n\n')
-        .trim();
-}
-
 function entryMeta(type: string | null) {
     if (!type) return ENTRY_DEFAULT;
     return ENTRY_KIND_META[type.toUpperCase()] ?? ENTRY_DEFAULT;
 }
 
-function Metric({ label, value, helper }: { label: string; value: ReactNode; helper?: string }) {
+function entryAnchor(id: number): string {
+    return `entry-${id}`;
+}
+
+function eventAnchor(id: number): string {
+    return `event-${id}`;
+}
+
+function isImage(mime: string | null | undefined): boolean {
+    return typeof mime === 'string' && mime.toLowerCase().startsWith('image/');
+}
+
+function isPdf(mime: string | null | undefined): boolean {
+    return typeof mime === 'string' && mime.toLowerCase() === 'application/pdf';
+}
+
+function useCopy(timeoutMs = 1500) {
+    const [copied, setCopied] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (copied === null) return;
+        const handle = window.setTimeout(() => setCopied(null), timeoutMs);
+        return () => window.clearTimeout(handle);
+    }, [copied, timeoutMs]);
+
+    async function copy(value: string, key: string): Promise<void> {
+        try {
+            await navigator.clipboard.writeText(value);
+            setCopied(key);
+        } catch {
+            /* clipboard unavailable */
+        }
+    }
+
+    return { copied, copy };
+}
+
+interface SlaProgress {
+    label: string;
+    percent: number;
+    tone: 'safe' | 'warn' | 'danger' | 'overdue' | 'closed';
+    helper: string | null;
+}
+
+function computeSlaProgress(ticket: Ticket, now: Date): SlaProgress | null {
+    if (!ticket.duedate) return null;
+    const due = new Date(ticket.duedate);
+    const created = ticket.created ? new Date(ticket.created) : null;
+
+    if (Number.isNaN(due.getTime())) return null;
+
+    if (ticket.closed) {
+        return {
+            label: 'Closed',
+            percent: 100,
+            tone: 'closed',
+            helper: formatDateTime(ticket.closed),
+        };
+    }
+
+    const dueMs = due.getTime();
+    const nowMs = now.getTime();
+
+    if (nowMs >= dueMs) {
+        return {
+            label: 'Overdue',
+            percent: 100,
+            tone: 'overdue',
+            helper: `Was due ${formatRelative(ticket.duedate)}`,
+        };
+    }
+
+    if (created && !Number.isNaN(created.getTime())) {
+        const total = dueMs - created.getTime();
+        const elapsed = nowMs - created.getTime();
+        const percent = total > 0 ? Math.max(0, Math.min(100, (elapsed / total) * 100)) : 0;
+        const tone: SlaProgress['tone'] = percent >= 75 ? 'danger' : percent >= 50 ? 'warn' : 'safe';
+
+        return {
+            label: 'On track',
+            percent,
+            tone,
+            helper: `Due ${formatRelative(ticket.duedate)}`,
+        };
+    }
+
+    return {
+        label: 'On track',
+        percent: 0,
+        tone: 'safe',
+        helper: `Due ${formatRelative(ticket.duedate)}`,
+    };
+}
+
+function Metric({ label, value, helper }: { label: string; value: ReactNode; helper?: string | null }) {
     return (
         <div>
             <dt className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">{label}</dt>
@@ -130,13 +219,71 @@ function Metric({ label, value, helper }: { label: string; value: ReactNode; hel
     );
 }
 
+function SlaBar({ progress }: { progress: SlaProgress }) {
+    const trackColor = progress.tone === 'overdue'
+        ? 'bg-red-500'
+        : progress.tone === 'danger'
+        ? 'bg-amber-500'
+        : progress.tone === 'warn'
+        ? 'bg-yellow-400'
+        : progress.tone === 'closed'
+        ? 'bg-zinc-400'
+        : 'bg-emerald-500';
+
+    const labelTone = progress.tone === 'overdue'
+        ? 'text-red-600'
+        : progress.tone === 'danger'
+        ? 'text-amber-600'
+        : progress.tone === 'warn'
+        ? 'text-yellow-700'
+        : progress.tone === 'closed'
+        ? 'text-zinc-500'
+        : 'text-emerald-600';
+
+    return (
+        <div className="rounded-md bg-[#F8FAFC] px-3 py-2.5">
+            <div className="flex items-center justify-between gap-3 text-xs">
+                <span className={cn('font-semibold uppercase tracking-[0.14em]', labelTone)}>{progress.label}</span>
+                {progress.helper && <span className="text-[#64748B]">{progress.helper}</span>}
+            </div>
+            <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[#E2E8F0]">
+                <div className={cn('h-full rounded-full transition-all', trackColor)} style={{ width: `${progress.percent}%` }} />
+            </div>
+        </div>
+    );
+}
+
 function TicketHeader({ ticket }: { ticket: Ticket }) {
+    const { copied, copy } = useCopy();
+    const [now, setNow] = useState<Date>(() => new Date());
+
+    useEffect(() => {
+        const id = window.setInterval(() => setNow(new Date()), 60_000);
+        return () => window.clearInterval(id);
+    }, []);
+
+    const sla = computeSlaProgress(ticket, now);
+
     return (
         <header className="rounded-[18px] border border-[#E2E8F0] bg-white p-6 shadow-sm shadow-[#0F172A]/[0.03] xl:p-8">
             <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2 text-xs text-[#94A3B8]">
-                        <span className="font-mono text-[#0F172A]">#{ticket.number}</span>
+                    <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-1.5 text-xs text-[#94A3B8]">
+                        <Link href="/scp/queues" className="hover:text-[#0F172A]">Tickets</Link>
+                        <span className="text-[#CBD5E1]">/</span>
+                        <button
+                            type="button"
+                            onClick={() => copy(`#${ticket.number}`, 'number')}
+                            className="inline-flex items-center gap-1 font-mono text-[#0F172A] hover:text-[#5B619D]"
+                            title="Copy ticket number"
+                        >
+                            <span>#{ticket.number}</span>
+                            <HugeiconsIcon
+                                icon={copied === 'number' ? CheckmarkCircle02Icon : Copy01Icon}
+                                size={11}
+                                className={cn('transition-colors', copied === 'number' ? 'text-emerald-500' : 'text-[#94A3B8]')}
+                            />
+                        </button>
                         {ticket.created && (
                             <>
                                 <span className="text-[#CBD5E1]">·</span>
@@ -151,7 +298,7 @@ function TicketHeader({ ticket }: { ticket: Ticket }) {
                                 <span>by {ticket.requester}</span>
                             </>
                         )}
-                    </div>
+                    </nav>
                     <h1 className="mt-2 font-display text-2xl font-medium tracking-tight text-[#0F172A]">
                         {ticket.subject ?? `Ticket ${ticket.number}`}
                     </h1>
@@ -174,45 +321,84 @@ function TicketHeader({ ticket }: { ticket: Ticket }) {
                 <Metric
                     label="Due date"
                     value={ticket.duedate ? formatDateTime(ticket.duedate) : null}
-                    helper={ticket.duedate ? (formatRelative(ticket.duedate) ?? undefined) : undefined}
+                    helper={ticket.duedate ? formatRelative(ticket.duedate) : null}
                 />
                 <Metric
                     label="Updated"
                     value={ticket.updated ? formatRelative(ticket.updated) : null}
-                    helper={ticket.updated ? (formatDateTime(ticket.updated) ?? undefined) : undefined}
+                    helper={ticket.updated ? formatDateTime(ticket.updated) : null}
                 />
             </dl>
+
+            {sla && (
+                <div className="mt-5">
+                    <SlaBar progress={sla} />
+                </div>
+            )}
         </header>
     );
 }
 
 function TimelineEntry({ item }: { item: ThreadEntry }) {
     const meta = entryMeta(item.type);
-    const text = stripHtml(item.body);
+    const { copied, copy } = useCopy();
+    const anchorId = entryAnchor(item.id);
+
+    const safeHtml = useMemo(() => {
+        if (!item.body) return '';
+        if ((item.format ?? '').toLowerCase() === 'html') {
+            return sanitizeHtml(item.body);
+        }
+        return null;
+    }, [item.body, item.format]);
+
+    function shareLink() {
+        const url = `${window.location.pathname}#${anchorId}`;
+        copy(url, anchorId);
+    }
 
     return (
-        <article className="relative rounded-[14px] border border-[#E2E8F0] bg-white p-5 shadow-sm shadow-[#0F172A]/[0.02]">
+        <article id={anchorId} className="group relative scroll-mt-24 rounded-[14px] border border-[#E2E8F0] bg-white p-5 shadow-sm shadow-[#0F172A]/[0.02]">
             <header className="flex flex-wrap items-center justify-between gap-3">
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                     <span className={cn('inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]', meta.tone)}>
                         <HugeiconsIcon icon={meta.icon} size={10} />
                         {meta.label}
                     </span>
                     {item.author && <span className="text-sm font-medium text-[#0F172A]">{item.author}</span>}
                 </div>
-                {item.created && (
-                    <time
-                        dateTime={item.created}
-                        title={formatDateTime(item.created) ?? undefined}
-                        className="inline-flex items-center gap-1 text-xs text-[#94A3B8]"
+                <div className="flex items-center gap-2 text-xs text-[#94A3B8]">
+                    {item.created && (
+                        <time
+                            dateTime={item.created}
+                            title={formatDateTime(item.created) ?? undefined}
+                            className="inline-flex items-center gap-1"
+                        >
+                            <HugeiconsIcon icon={Clock01Icon} size={11} />
+                            {formatRelative(item.created)}
+                        </time>
+                    )}
+                    <button
+                        type="button"
+                        onClick={shareLink}
+                        title="Copy link to this entry"
+                        className="grid h-6 w-6 place-items-center rounded text-[#94A3B8] opacity-0 transition-all hover:bg-[#F1F5F9] hover:text-[#5B619D] group-hover:opacity-100 focus-visible:opacity-100"
                     >
-                        <HugeiconsIcon icon={Clock01Icon} size={11} />
-                        {formatRelative(item.created)}
-                    </time>
-                )}
+                        <HugeiconsIcon
+                            icon={copied === anchorId ? CheckmarkCircle02Icon : Link02Icon}
+                            size={12}
+                            className={copied === anchorId ? 'text-emerald-500' : undefined}
+                        />
+                    </button>
+                </div>
             </header>
-            {text ? (
-                <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-[#0F172A]">{text}</p>
+            {safeHtml ? (
+                <div
+                    className="prose-ticket mt-4 text-sm leading-relaxed text-[#0F172A]"
+                    dangerouslySetInnerHTML={{ __html: safeHtml }}
+                />
+            ) : item.body ? (
+                <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-[#0F172A]">{item.body}</p>
             ) : (
                 <p className="mt-4 text-sm italic text-[#94A3B8]">No content.</p>
             )}
@@ -221,8 +407,10 @@ function TimelineEntry({ item }: { item: ThreadEntry }) {
 }
 
 function TimelineEvent({ item }: { item: ThreadEvent }) {
+    const anchorId = eventAnchor(item.id);
+
     return (
-        <div className="flex items-start gap-3 rounded-md border border-dashed border-[#E2E8F0] bg-[#F8FAFC] px-4 py-3">
+        <div id={anchorId} className="flex scroll-mt-24 items-start gap-3 rounded-md border border-dashed border-[#E2E8F0] bg-[#F8FAFC] px-4 py-3">
             <div className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-white text-[#5B619D] ring-1 ring-[#E2E8F0]">
                 <HugeiconsIcon icon={Calendar01Icon} size={12} />
             </div>
@@ -241,11 +429,39 @@ function TimelineEvent({ item }: { item: ThreadEvent }) {
 }
 
 function Timeline({ items }: { items: TimelineItem[] }) {
+    const latestEntry = useMemo(() => {
+        for (let index = items.length - 1; index >= 0; index--) {
+            const item = items[index];
+            if (item.kind === 'entry') return item;
+        }
+        return null;
+    }, [items]);
+
+    function jumpToLatest() {
+        if (!latestEntry) return;
+        const target = document.getElementById(entryAnchor(latestEntry.id));
+        target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
     return (
         <section className="rounded-[18px] border border-[#E2E8F0] bg-white p-6 shadow-sm shadow-[#0F172A]/[0.03] xl:p-8">
-            <header className="flex items-center justify-between">
-                <h2 className="font-display text-lg font-medium text-[#0F172A]">Timeline</h2>
-                <span className="text-xs text-[#94A3B8]">{items.length} {items.length === 1 ? 'item' : 'items'}</span>
+            <header className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-3">
+                    <h2 className="font-display text-lg font-medium text-[#0F172A]">Timeline</h2>
+                    <span className="rounded-full bg-[#F1F5F9] px-2 py-0.5 text-[10px] font-semibold text-[#64748B]">
+                        {items.length} {items.length === 1 ? 'item' : 'items'}
+                    </span>
+                </div>
+                {latestEntry && items.length > 2 && (
+                    <button
+                        type="button"
+                        onClick={jumpToLatest}
+                        className="inline-flex items-center gap-1.5 rounded-md border border-[#E2E8F0] bg-white px-2.5 py-1.5 text-xs font-medium text-[#64748B] transition-colors hover:border-[#CBD5E1] hover:text-[#0F172A]"
+                    >
+                        <HugeiconsIcon icon={ArrowDown01Icon} size={12} />
+                        Jump to latest
+                    </button>
+                )}
             </header>
             {items.length === 0 ? (
                 <p className="mt-5 text-sm text-[#64748B]">No thread entries or events were found.</p>
@@ -286,41 +502,128 @@ function CustomFieldsPanel({ fields }: { fields: TicketShowProps['customFields']
 }
 
 function AttachmentsPanel({ attachments }: { attachments: Attachment[] }) {
+    const [preview, setPreview] = useState<Attachment | null>(null);
+
     return (
         <SidebarPanel title="Attachments" count={attachments.length}>
             {attachments.length === 0 ? (
                 <PanelEmpty text="No attachments." />
             ) : (
                 <ul className="space-y-2">
-                    {attachments.map((attachment) => (
-                        <li key={attachment.id}>
-                            <a
-                                href={attachment.download_url}
-                                className="flex items-start gap-3 rounded-md border border-[#E2E8F0] bg-[#F8FAFC] px-3 py-2.5 text-sm transition-colors hover:bg-white"
-                            >
-                                <span className="grid h-8 w-8 shrink-0 place-items-center rounded-md bg-white text-[#5B619D] ring-1 ring-[#E2E8F0]">
-                                    <HugeiconsIcon icon={File01Icon} size={14} />
-                                </span>
-                                <span className="min-w-0 flex-1">
-                                    <span className="block truncate font-medium text-[#0F172A]">
-                                        {attachment.name ?? `File ${attachment.file_id}`}
+                    {attachments.map((attachment) => {
+                        const previewable = isImage(attachment.mime) || isPdf(attachment.mime);
+                        const Icon = isImage(attachment.mime) ? Image01Icon : File01Icon;
+                        return (
+                            <li key={attachment.id}>
+                                <div className="group flex items-start gap-3 rounded-md border border-[#E2E8F0] bg-[#F8FAFC] px-3 py-2.5 text-sm transition-colors hover:bg-white">
+                                    <span className="grid h-8 w-8 shrink-0 place-items-center rounded-md bg-white text-[#5B619D] ring-1 ring-[#E2E8F0]">
+                                        <HugeiconsIcon icon={Icon} size={14} />
                                     </span>
-                                    <span className="mt-0.5 flex items-center gap-2 text-xs text-[#94A3B8]">
-                                        {attachment.mime && <span className="truncate">{attachment.mime}</span>}
-                                        {formatBytes(attachment.size) && (
-                                            <>
-                                                <span className="text-[#CBD5E1]">·</span>
-                                                <span>{formatBytes(attachment.size)}</span>
-                                            </>
+                                    <div className="min-w-0 flex-1">
+                                        <p className="truncate font-medium text-[#0F172A]">
+                                            {attachment.name ?? `File ${attachment.file_id}`}
+                                        </p>
+                                        <p className="mt-0.5 flex items-center gap-2 text-xs text-[#94A3B8]">
+                                            {attachment.mime && <span className="truncate">{attachment.mime}</span>}
+                                            {formatBytes(attachment.size) && (
+                                                <>
+                                                    <span className="text-[#CBD5E1]">·</span>
+                                                    <span>{formatBytes(attachment.size)}</span>
+                                                </>
+                                            )}
+                                        </p>
+                                    </div>
+                                    <div className="flex flex-col gap-1">
+                                        {previewable && (
+                                            <button
+                                                type="button"
+                                                onClick={() => setPreview(attachment)}
+                                                className="grid h-7 w-7 place-items-center rounded text-[#94A3B8] transition-colors hover:bg-[#F1F5F9] hover:text-[#5B619D]"
+                                                title="Preview"
+                                                aria-label="Preview attachment"
+                                            >
+                                                <HugeiconsIcon icon={Image01Icon} size={13} />
+                                            </button>
                                         )}
-                                    </span>
-                                </span>
-                            </a>
-                        </li>
-                    ))}
+                                        <a
+                                            href={attachment.download_url}
+                                            className="grid h-7 w-7 place-items-center rounded text-[#94A3B8] transition-colors hover:bg-[#F1F5F9] hover:text-[#5B619D]"
+                                            title="Download"
+                                            aria-label="Download attachment"
+                                            download
+                                        >
+                                            <HugeiconsIcon icon={Download01Icon} size={13} />
+                                        </a>
+                                    </div>
+                                </div>
+                            </li>
+                        );
+                    })}
                 </ul>
             )}
+            <AttachmentPreview attachment={preview} onClose={() => setPreview(null)} />
         </SidebarPanel>
+    );
+}
+
+function AttachmentPreview({ attachment, onClose }: { attachment: Attachment | null; onClose: () => void }) {
+    const open = attachment !== null;
+
+    return (
+        <DialogPrimitive.Root open={open} onOpenChange={(value) => { if (!value) onClose(); }}>
+            <DialogPrimitive.Portal>
+                <DialogPrimitive.Backdrop className="fixed inset-0 z-40 bg-[#0F172A]/70 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+                <DialogPrimitive.Popup className="fixed inset-0 z-50 grid place-items-center p-4 outline-none">
+                    {attachment && (
+                        <div className="flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-white shadow-2xl">
+                            <div className="flex items-center justify-between gap-3 border-b border-[#E2E8F0] bg-white px-4 py-3">
+                                <div className="min-w-0 flex-1">
+                                    <DialogPrimitive.Title className="truncate text-sm font-medium text-[#0F172A]">
+                                        {attachment.name ?? `File ${attachment.file_id}`}
+                                    </DialogPrimitive.Title>
+                                    <p className="text-xs text-[#94A3B8]">
+                                        {attachment.mime} {formatBytes(attachment.size) ? `· ${formatBytes(attachment.size)}` : ''}
+                                    </p>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <a
+                                        href={attachment.download_url}
+                                        download
+                                        className="inline-flex items-center gap-1.5 rounded-md border border-[#E2E8F0] bg-white px-2.5 py-1.5 text-xs font-medium text-[#64748B] transition-colors hover:border-[#CBD5E1] hover:text-[#0F172A]"
+                                    >
+                                        <HugeiconsIcon icon={Download01Icon} size={12} />
+                                        Download
+                                    </a>
+                                    <DialogPrimitive.Close
+                                        className="grid h-8 w-8 place-items-center rounded-md text-[#64748B] transition-colors hover:bg-[#F1F5F9] hover:text-[#0F172A]"
+                                        aria-label="Close preview"
+                                    >
+                                        <HugeiconsIcon icon={Cancel01Icon} size={16} />
+                                    </DialogPrimitive.Close>
+                                </div>
+                            </div>
+                            <div className="flex flex-1 items-center justify-center overflow-auto bg-[#F1F5F9]">
+                                {isImage(attachment.mime) ? (
+                                    <img
+                                        src={attachment.download_url}
+                                        alt={attachment.name ?? ''}
+                                        className="max-h-[80vh] max-w-full object-contain"
+                                    />
+                                ) : isPdf(attachment.mime) ? (
+                                    <iframe
+                                        src={attachment.download_url}
+                                        title={attachment.name ?? 'Attachment preview'}
+                                        className="h-[80vh] w-full bg-white"
+                                    />
+                                ) : (
+                                    <p className="p-12 text-sm text-[#64748B]">No preview available for this file type.</p>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </DialogPrimitive.Popup>
+            </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
     );
 }
 
@@ -366,7 +669,8 @@ function ReferralsPanel({ referrals }: { referrals: Referral[] }) {
                 <ul className="space-y-2 text-sm">
                     {referrals.map((referral) => (
                         <li key={referral.id} className="flex items-center justify-between rounded-md border border-[#E2E8F0] bg-[#F8FAFC] px-3 py-2">
-                            <span className="font-medium text-[#0F172A]">
+                            <span className="flex items-center gap-2 font-medium text-[#0F172A]">
+                                <HugeiconsIcon icon={Link01Icon} size={12} className="text-[#5B619D]" />
                                 {referral.object_type ?? 'object'} #{referral.object_id ?? '?'}
                             </span>
                             {referral.created && (
@@ -400,6 +704,33 @@ function PanelEmpty({ text }: { text: string }) {
     return <p className="text-sm text-[#64748B]">{text}</p>;
 }
 
+function StatusSummary({ ticket }: { ticket: Ticket }) {
+    return (
+        <SidebarPanel title="Summary">
+            <dl className="space-y-3 text-sm">
+                <SummaryRow icon={CheckmarkCircle02Icon} label="Status" value={ticket.status ?? '—'} />
+                <SummaryRow icon={AlertCircleIcon} label="Priority" value={ticket.priority ?? '—'} />
+                <SummaryRow icon={UserGroupIcon} label="Department" value={ticket.department ?? '—'} />
+                <SummaryRow icon={Calendar01Icon} label="Created" value={(ticket.created ? formatDateTime(ticket.created) : null) ?? '—'} />
+            </dl>
+        </SidebarPanel>
+    );
+}
+
+function SummaryRow({ icon, label, value }: { icon: typeof Mail01Icon; label: string; value: string }) {
+    return (
+        <div className="flex items-start gap-2.5">
+            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md bg-[#F1F5F9] text-[#5B619D]">
+                <HugeiconsIcon icon={icon} size={11} />
+            </span>
+            <div className="min-w-0 flex-1">
+                <dt className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#94A3B8]">{label}</dt>
+                <dd className="mt-0.5 break-words text-[#0F172A]">{value}</dd>
+            </div>
+        </div>
+    );
+}
+
 export default function TicketShow({ ticket, customFields, timeline, attachments, collaborators, referrals }: TicketShowProps) {
     return (
         <div className="space-y-6">
@@ -408,7 +739,8 @@ export default function TicketShow({ ticket, customFields, timeline, attachments
             <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
                 <Timeline items={timeline} />
 
-                <aside className="space-y-6">
+                <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
+                    <StatusSummary ticket={ticket} />
                     <CustomFieldsPanel fields={customFields} />
                     <AttachmentsPanel attachments={attachments} />
                     <CollaboratorsPanel collaborators={collaborators} />
@@ -419,14 +751,30 @@ export default function TicketShow({ ticket, customFields, timeline, attachments
     );
 }
 
+function TicketHeaderTitle() {
+    const { props } = usePage<{ ticket?: Ticket }>();
+    const number = props.ticket?.number ?? '';
+
+    return (
+        <div className="flex items-baseline gap-2.5">
+            <h1 className="font-display text-xl font-medium tracking-[-0.02em] text-[#0F172A]">
+                #{number}
+            </h1>
+            <span className="text-[#94A3B8]">·</span>
+            <span className="font-body text-[11px] font-medium uppercase tracking-[0.12em] text-[#94A3B8]">
+                Tickets
+            </span>
+        </div>
+    );
+}
+
 type TicketShowComponent = typeof TicketShow & {
     layout?: (page: ReactElement) => ReactNode;
 };
 
 (TicketShow as TicketShowComponent).layout = (page) => (
     <DashboardLayout
-        title="Ticket"
-        eyebrow="Tickets"
+        headerLeft={<TicketHeaderTitle />}
         activeNav="queues"
         contentClassName="w-full max-w-7xl mx-auto"
         headerActions={

--- a/resources/js/pages/Scp/Tickets/Show.tsx
+++ b/resources/js/pages/Scp/Tickets/Show.tsx
@@ -1,0 +1,443 @@
+import { Link } from '@inertiajs/react';
+import type { ReactElement, ReactNode } from 'react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import {
+    Calendar01Icon,
+    Clock01Icon,
+    File01Icon,
+    Mail01Icon,
+    Note01Icon,
+    UserGroupIcon,
+} from '@hugeicons/core-free-icons';
+
+import { PriorityBadge } from '@/components/scp/PriorityBadge';
+import { StatusBadge } from '@/components/scp/StatusBadge';
+import DashboardLayout from '@/layouts/DashboardLayout';
+import { formatBytes, formatDateTime, formatRelative } from '@/lib/datetime';
+import { cn } from '@/lib/utils';
+
+interface Ticket {
+    id: number;
+    number: string;
+    status: string | null;
+    status_state: string | null;
+    priority: string | null;
+    department: string | null;
+    assignee: string | null;
+    sla_id: number;
+    duedate: string | null;
+    created: string | null;
+    updated: string | null;
+    closed: string | null;
+    subject: string | null;
+    requester: string | null;
+    requester_email: string | null;
+}
+
+interface ThreadEntry {
+    kind: 'entry';
+    id: number;
+    type: string | null;
+    author: string | null;
+    body: string | null;
+    format: string | null;
+    created: string | null;
+}
+
+interface ThreadEvent {
+    kind: 'event';
+    id: number;
+    event_id: number;
+    label: string | null;
+    data: string | null;
+    created: string | null;
+}
+
+type TimelineItem = ThreadEntry | ThreadEvent;
+
+interface Attachment {
+    id: number;
+    file_id: number;
+    name: string | null;
+    mime: string | null;
+    size: number | null;
+    download_url: string;
+}
+
+interface Collaborator {
+    id: number;
+    name?: string | null;
+    email?: string | null;
+    role?: string | null;
+}
+
+interface Referral {
+    id: number;
+    object_type?: string | null;
+    object_id?: number | null;
+    created?: string | null;
+}
+
+interface TicketShowProps {
+    ticket: Ticket;
+    customFields: Record<string, string | number | boolean | null>;
+    timeline: TimelineItem[];
+    attachments: Attachment[];
+    collaborators: Collaborator[];
+    referrals: Referral[];
+}
+
+const ENTRY_KIND_META: Record<string, { label: string; tone: string; icon: typeof Mail01Icon }> = {
+    M: { label: 'Message', tone: 'border-sky-200 bg-sky-50 text-sky-700', icon: Mail01Icon },
+    R: { label: 'Response', tone: 'border-emerald-200 bg-emerald-50 text-emerald-700', icon: Mail01Icon },
+    N: { label: 'Internal note', tone: 'border-amber-200 bg-amber-50 text-amber-800', icon: Note01Icon },
+};
+
+const ENTRY_DEFAULT = {
+    label: 'Entry',
+    tone: 'border-[#E2E8F0] bg-[#F8FAFC] text-[#475569]',
+    icon: Mail01Icon,
+};
+
+function stripHtml(value: string | null | undefined): string {
+    if (!value) return '';
+    return value
+        .replace(/<style[\s\S]*?<\/style>/gi, '')
+        .replace(/<script[\s\S]*?<\/script>/gi, '')
+        .replace(/<br\s*\/?>(\s|&nbsp;)*/gi, '\n')
+        .replace(/<\/p>\s*/gi, '\n\n')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
+function entryMeta(type: string | null) {
+    if (!type) return ENTRY_DEFAULT;
+    return ENTRY_KIND_META[type.toUpperCase()] ?? ENTRY_DEFAULT;
+}
+
+function Metric({ label, value, helper }: { label: string; value: ReactNode; helper?: string }) {
+    return (
+        <div>
+            <dt className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[#94A3B8]">{label}</dt>
+            <dd className="mt-1.5 text-sm font-medium text-[#0F172A]">{value || <span className="text-[#94A3B8]">—</span>}</dd>
+            {helper && <p className="mt-0.5 text-xs text-[#94A3B8]">{helper}</p>}
+        </div>
+    );
+}
+
+function TicketHeader({ ticket }: { ticket: Ticket }) {
+    return (
+        <header className="rounded-[18px] border border-[#E2E8F0] bg-white p-6 shadow-sm shadow-[#0F172A]/[0.03] xl:p-8">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-[#94A3B8]">
+                        <span className="font-mono text-[#0F172A]">#{ticket.number}</span>
+                        {ticket.created && (
+                            <>
+                                <span className="text-[#CBD5E1]">·</span>
+                                <span title={formatDateTime(ticket.created) ?? undefined}>
+                                    Created {formatRelative(ticket.created)}
+                                </span>
+                            </>
+                        )}
+                        {ticket.requester && (
+                            <>
+                                <span className="text-[#CBD5E1]">·</span>
+                                <span>by {ticket.requester}</span>
+                            </>
+                        )}
+                    </div>
+                    <h1 className="mt-2 font-display text-2xl font-medium tracking-tight text-[#0F172A]">
+                        {ticket.subject ?? `Ticket ${ticket.number}`}
+                    </h1>
+                    {ticket.requester_email && (
+                        <a href={`mailto:${ticket.requester_email}`} className="mt-1 inline-flex items-center gap-1.5 text-xs text-[#5B619D] hover:underline">
+                            <HugeiconsIcon icon={Mail01Icon} size={12} />
+                            {ticket.requester_email}
+                        </a>
+                    )}
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                    <StatusBadge status={ticket.status} state={ticket.status_state} />
+                    <PriorityBadge priority={ticket.priority} />
+                </div>
+            </div>
+
+            <dl className="mt-6 grid grid-cols-2 gap-4 border-t border-[#F1F5F9] pt-6 sm:grid-cols-4">
+                <Metric label="Department" value={ticket.department} />
+                <Metric label="Assignee" value={ticket.assignee} />
+                <Metric
+                    label="Due date"
+                    value={ticket.duedate ? formatDateTime(ticket.duedate) : null}
+                    helper={ticket.duedate ? (formatRelative(ticket.duedate) ?? undefined) : undefined}
+                />
+                <Metric
+                    label="Updated"
+                    value={ticket.updated ? formatRelative(ticket.updated) : null}
+                    helper={ticket.updated ? (formatDateTime(ticket.updated) ?? undefined) : undefined}
+                />
+            </dl>
+        </header>
+    );
+}
+
+function TimelineEntry({ item }: { item: ThreadEntry }) {
+    const meta = entryMeta(item.type);
+    const text = stripHtml(item.body);
+
+    return (
+        <article className="relative rounded-[14px] border border-[#E2E8F0] bg-white p-5 shadow-sm shadow-[#0F172A]/[0.02]">
+            <header className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                    <span className={cn('inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]', meta.tone)}>
+                        <HugeiconsIcon icon={meta.icon} size={10} />
+                        {meta.label}
+                    </span>
+                    {item.author && <span className="text-sm font-medium text-[#0F172A]">{item.author}</span>}
+                </div>
+                {item.created && (
+                    <time
+                        dateTime={item.created}
+                        title={formatDateTime(item.created) ?? undefined}
+                        className="inline-flex items-center gap-1 text-xs text-[#94A3B8]"
+                    >
+                        <HugeiconsIcon icon={Clock01Icon} size={11} />
+                        {formatRelative(item.created)}
+                    </time>
+                )}
+            </header>
+            {text ? (
+                <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-[#0F172A]">{text}</p>
+            ) : (
+                <p className="mt-4 text-sm italic text-[#94A3B8]">No content.</p>
+            )}
+        </article>
+    );
+}
+
+function TimelineEvent({ item }: { item: ThreadEvent }) {
+    return (
+        <div className="flex items-start gap-3 rounded-md border border-dashed border-[#E2E8F0] bg-[#F8FAFC] px-4 py-3">
+            <div className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-white text-[#5B619D] ring-1 ring-[#E2E8F0]">
+                <HugeiconsIcon icon={Calendar01Icon} size={12} />
+            </div>
+            <div className="flex-1 text-xs text-[#64748B]">
+                <p className="font-medium text-[#0F172A]">{item.label ?? 'Event'}</p>
+                {item.created && (
+                    <p className="mt-0.5">
+                        <time dateTime={item.created} title={formatDateTime(item.created) ?? undefined}>
+                            {formatRelative(item.created)}
+                        </time>
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function Timeline({ items }: { items: TimelineItem[] }) {
+    return (
+        <section className="rounded-[18px] border border-[#E2E8F0] bg-white p-6 shadow-sm shadow-[#0F172A]/[0.03] xl:p-8">
+            <header className="flex items-center justify-between">
+                <h2 className="font-display text-lg font-medium text-[#0F172A]">Timeline</h2>
+                <span className="text-xs text-[#94A3B8]">{items.length} {items.length === 1 ? 'item' : 'items'}</span>
+            </header>
+            {items.length === 0 ? (
+                <p className="mt-5 text-sm text-[#64748B]">No thread entries or events were found.</p>
+            ) : (
+                <ol className="mt-6 space-y-4">
+                    {items.map((item) => (
+                        <li key={`${item.kind}-${item.id}`}>
+                            {item.kind === 'entry' ? <TimelineEntry item={item} /> : <TimelineEvent item={item} />}
+                        </li>
+                    ))}
+                </ol>
+            )}
+        </section>
+    );
+}
+
+function CustomFieldsPanel({ fields }: { fields: TicketShowProps['customFields'] }) {
+    const entries = Object.entries(fields);
+
+    return (
+        <SidebarPanel title="Custom Fields">
+            {entries.length === 0 ? (
+                <PanelEmpty text="No custom fields were captured." />
+            ) : (
+                <dl className="space-y-3 text-sm">
+                    {entries.map(([key, value]) => (
+                        <div key={key}>
+                            <dt className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#94A3B8]">{key}</dt>
+                            <dd className="mt-1 break-words text-[#0F172A]">
+                                {value === null || value === '' ? <span className="text-[#94A3B8]">—</span> : String(value)}
+                            </dd>
+                        </div>
+                    ))}
+                </dl>
+            )}
+        </SidebarPanel>
+    );
+}
+
+function AttachmentsPanel({ attachments }: { attachments: Attachment[] }) {
+    return (
+        <SidebarPanel title="Attachments" count={attachments.length}>
+            {attachments.length === 0 ? (
+                <PanelEmpty text="No attachments." />
+            ) : (
+                <ul className="space-y-2">
+                    {attachments.map((attachment) => (
+                        <li key={attachment.id}>
+                            <a
+                                href={attachment.download_url}
+                                className="flex items-start gap-3 rounded-md border border-[#E2E8F0] bg-[#F8FAFC] px-3 py-2.5 text-sm transition-colors hover:bg-white"
+                            >
+                                <span className="grid h-8 w-8 shrink-0 place-items-center rounded-md bg-white text-[#5B619D] ring-1 ring-[#E2E8F0]">
+                                    <HugeiconsIcon icon={File01Icon} size={14} />
+                                </span>
+                                <span className="min-w-0 flex-1">
+                                    <span className="block truncate font-medium text-[#0F172A]">
+                                        {attachment.name ?? `File ${attachment.file_id}`}
+                                    </span>
+                                    <span className="mt-0.5 flex items-center gap-2 text-xs text-[#94A3B8]">
+                                        {attachment.mime && <span className="truncate">{attachment.mime}</span>}
+                                        {formatBytes(attachment.size) && (
+                                            <>
+                                                <span className="text-[#CBD5E1]">·</span>
+                                                <span>{formatBytes(attachment.size)}</span>
+                                            </>
+                                        )}
+                                    </span>
+                                </span>
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </SidebarPanel>
+    );
+}
+
+function CollaboratorsPanel({ collaborators }: { collaborators: Collaborator[] }) {
+    return (
+        <SidebarPanel title="Collaborators" count={collaborators.length}>
+            {collaborators.length === 0 ? (
+                <PanelEmpty text="No collaborators." />
+            ) : (
+                <ul className="space-y-3">
+                    {collaborators.map((collaborator) => (
+                        <li key={collaborator.id} className="flex items-start gap-3">
+                            <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[#F1F5F9] text-[#5B619D]">
+                                <HugeiconsIcon icon={UserGroupIcon} size={14} />
+                            </span>
+                            <div className="min-w-0 flex-1 text-sm">
+                                <p className="truncate font-medium text-[#0F172A]">
+                                    {collaborator.name ?? collaborator.email ?? 'Unknown'}
+                                </p>
+                                {collaborator.email && collaborator.name && (
+                                    <p className="truncate text-xs text-[#94A3B8]">{collaborator.email}</p>
+                                )}
+                                {collaborator.role && (
+                                    <span className="mt-1 inline-flex items-center rounded-full bg-[#F3ECFF] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[#5B619D]">
+                                        {collaborator.role}
+                                    </span>
+                                )}
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </SidebarPanel>
+    );
+}
+
+function ReferralsPanel({ referrals }: { referrals: Referral[] }) {
+    return (
+        <SidebarPanel title="Referrals" count={referrals.length}>
+            {referrals.length === 0 ? (
+                <PanelEmpty text="No referrals." />
+            ) : (
+                <ul className="space-y-2 text-sm">
+                    {referrals.map((referral) => (
+                        <li key={referral.id} className="flex items-center justify-between rounded-md border border-[#E2E8F0] bg-[#F8FAFC] px-3 py-2">
+                            <span className="font-medium text-[#0F172A]">
+                                {referral.object_type ?? 'object'} #{referral.object_id ?? '?'}
+                            </span>
+                            {referral.created && (
+                                <time dateTime={referral.created} className="text-xs text-[#94A3B8]" title={formatDateTime(referral.created) ?? undefined}>
+                                    {formatRelative(referral.created)}
+                                </time>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </SidebarPanel>
+    );
+}
+
+function SidebarPanel({ title, count, children }: { title: string; count?: number; children: ReactNode }) {
+    return (
+        <section className="rounded-[18px] border border-[#E2E8F0] bg-white p-5 shadow-sm shadow-[#0F172A]/[0.03]">
+            <header className="mb-4 flex items-center justify-between">
+                <h3 className="font-display text-base font-medium text-[#0F172A]">{title}</h3>
+                {count !== undefined && (
+                    <span className="rounded-full bg-[#F1F5F9] px-2 py-0.5 text-[10px] font-semibold text-[#64748B]">{count}</span>
+                )}
+            </header>
+            {children}
+        </section>
+    );
+}
+
+function PanelEmpty({ text }: { text: string }) {
+    return <p className="text-sm text-[#64748B]">{text}</p>;
+}
+
+export default function TicketShow({ ticket, customFields, timeline, attachments, collaborators, referrals }: TicketShowProps) {
+    return (
+        <div className="space-y-6">
+            <TicketHeader ticket={ticket} />
+
+            <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
+                <Timeline items={timeline} />
+
+                <aside className="space-y-6">
+                    <CustomFieldsPanel fields={customFields} />
+                    <AttachmentsPanel attachments={attachments} />
+                    <CollaboratorsPanel collaborators={collaborators} />
+                    <ReferralsPanel referrals={referrals} />
+                </aside>
+            </div>
+        </div>
+    );
+}
+
+type TicketShowComponent = typeof TicketShow & {
+    layout?: (page: ReactElement) => ReactNode;
+};
+
+(TicketShow as TicketShowComponent).layout = (page) => (
+    <DashboardLayout
+        title="Ticket"
+        eyebrow="Tickets"
+        activeNav="queues"
+        contentClassName="w-full max-w-7xl mx-auto"
+        headerActions={
+            <Link
+                href="/scp/queues"
+                className="inline-flex items-center gap-2 rounded-md border border-[#E2E8F0] bg-white px-3 py-2 text-xs font-medium text-[#64748B] transition-colors hover:text-[#0F172A]"
+            >
+                Back to tickets
+            </Link>
+        }
+    >
+        {page}
+    </DashboardLayout>
+);

--- a/resources/js/pages/Scp/Tickets/Show.tsx
+++ b/resources/js/pages/Scp/Tickets/Show.tsx
@@ -191,7 +191,14 @@ function computeSlaProgress(ticket: Ticket, now: Date): SlaProgress | null {
         const total = dueMs - created.getTime();
         const elapsed = nowMs - created.getTime();
         const percent = total > 0 ? Math.max(0, Math.min(100, (elapsed / total) * 100)) : 0;
-        const tone: SlaProgress['tone'] = percent >= 75 ? 'danger' : percent >= 50 ? 'warn' : 'safe';
+        let tone: SlaProgress['tone'];
+        if (percent >= 75) {
+            tone = 'danger';
+        } else if (percent >= 50) {
+            tone = 'warn';
+        } else {
+            tone = 'safe';
+        }
 
         return {
             label: 'On track',
@@ -219,26 +226,25 @@ function Metric({ label, value, helper }: { label: string; value: ReactNode; hel
     );
 }
 
-function SlaBar({ progress }: { progress: SlaProgress }) {
-    const trackColor = progress.tone === 'overdue'
-        ? 'bg-red-500'
-        : progress.tone === 'danger'
-        ? 'bg-amber-500'
-        : progress.tone === 'warn'
-        ? 'bg-yellow-400'
-        : progress.tone === 'closed'
-        ? 'bg-zinc-400'
-        : 'bg-emerald-500';
+const SLA_TRACK_COLOR: Record<SlaProgress['tone'], string> = {
+    overdue: 'bg-red-500',
+    danger: 'bg-amber-500',
+    warn: 'bg-yellow-400',
+    closed: 'bg-zinc-400',
+    safe: 'bg-emerald-500',
+};
 
-    const labelTone = progress.tone === 'overdue'
-        ? 'text-red-600'
-        : progress.tone === 'danger'
-        ? 'text-amber-600'
-        : progress.tone === 'warn'
-        ? 'text-yellow-700'
-        : progress.tone === 'closed'
-        ? 'text-zinc-500'
-        : 'text-emerald-600';
+const SLA_LABEL_TONE: Record<SlaProgress['tone'], string> = {
+    overdue: 'text-red-600',
+    danger: 'text-amber-600',
+    warn: 'text-yellow-700',
+    closed: 'text-zinc-500',
+    safe: 'text-emerald-600',
+};
+
+function SlaBar({ progress }: { progress: SlaProgress }) {
+    const trackColor = SLA_TRACK_COLOR[progress.tone];
+    const labelTone = SLA_LABEL_TONE[progress.tone];
 
     return (
         <div className="rounded-md bg-[#F8FAFC] px-3 py-2.5">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,18 +1,23 @@
 <?php
 
-use App\Http\Controllers\Account\SecurityController;
 use App\Http\Controllers\Account\MigrationBannerController;
-use App\Http\Controllers\Account\TwoFactorWizardController;
+use App\Http\Controllers\Account\SecurityController;
 use App\Http\Controllers\Account\TwoFactorSecurityController;
+use App\Http\Controllers\Account\TwoFactorWizardController;
 use App\Http\Controllers\Auth\ConfirmPasswordController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\PasswordResetController;
 use App\Http\Controllers\Auth\TwoFactorAppController;
 use App\Http\Controllers\Auth\TwoFactorController;
+use App\Http\Controllers\Scp\AttachmentController;
+use App\Http\Controllers\Scp\DashboardController;
+use App\Http\Controllers\Scp\QueueController;
+use App\Http\Controllers\Scp\SearchController;
+use App\Http\Controllers\Scp\StaffPreferencesController;
+use App\Http\Controllers\Scp\TicketController;
 use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
 
 Route::get('/', function () {
     if (Auth::guard('staff')->check()) {
@@ -40,7 +45,7 @@ Route::prefix('scp')->name('scp.')->group(function () {
         Route::post('/password/reset', [PasswordResetController::class, 'resetPassword'])->name('password.update');
     });
 
-    Route::middleware('auth.staff')->group(function () {
+    Route::middleware(['auth.staff', 'scp.access', 'scp.log'])->group(function () {
         Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
 
         Route::get('/account/security', [SecurityController::class, 'show'])->name('account.security');
@@ -57,9 +62,15 @@ Route::prefix('scp')->name('scp.')->group(function () {
             Route::delete('/account/security/two-factor', [TwoFactorSecurityController::class, 'disable'])->name('account.security.two-factor.disable');
         });
 
-        Route::get('/', function () {
-            return Inertia::render('Dashboard');
-        })->name('dashboard');
+        Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
+        Route::get('/queues', [QueueController::class, 'index'])->name('queues.index');
+        Route::get('/queues/{queue}', [QueueController::class, 'show'])->name('queues.show');
+        Route::get('/queues/{queue}/export', [QueueController::class, 'export'])->name('queues.export');
+        Route::get('/tickets/{ticket}', [TicketController::class, 'show'])->name('tickets.show');
+        Route::get('/attachments/{file}', [AttachmentController::class, 'download'])->name('attachments.download');
+        Route::get('/search', [SearchController::class, 'index'])->name('search');
+        Route::get('/preferences', [StaffPreferencesController::class, 'show'])->name('preferences.show');
+        Route::patch('/preferences', [StaffPreferencesController::class, 'update'])->name('preferences.update');
     });
 });
 

--- a/tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php
+++ b/tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php
@@ -62,6 +62,45 @@ test('staff auth migrations migration backfills missing optional columns on an e
         ->and($schema->hasIndex('staff_auth_migrations', ['staff_id'], 'unique'))->toBeTrue();
 });
 
+test('staff preferences migration rollback does not drop pre-existing shared table', function () {
+    recreateOsticket2Table('staff_preferences', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('staff_id')->unique();
+    });
+
+    try {
+        $migration = loadMigration('2026_04_26_000100_create_staff_preferences_table.php');
+        $migration->up();
+        $migration->down();
+
+        expect(Schema::connection('osticket2')->hasTable('staff_preferences'))->toBeTrue();
+    } finally {
+        Schema::connection('osticket2')->dropIfExists('staff_preferences');
+        loadMigration('2026_04_26_000100_create_staff_preferences_table.php')->up();
+    }
+});
+
+test('staff preferences migration rollback drops only tables it created', function () {
+    Schema::connection('osticket2')->dropIfExists('staff_preferences');
+
+    try {
+        $migration = loadMigration('2026_04_26_000100_create_staff_preferences_table.php');
+        $migration->up();
+
+        expect(Schema::connection('osticket2')->hasColumn(
+            'staff_preferences',
+            'created_by_migration_2026_04_26_000100'
+        ))->toBeTrue();
+
+        $migration->down();
+
+        expect(Schema::connection('osticket2')->hasTable('staff_preferences'))->toBeFalse();
+    } finally {
+        Schema::connection('osticket2')->dropIfExists('staff_preferences');
+        loadMigration('2026_04_26_000100_create_staff_preferences_table.php')->up();
+    }
+});
+
 test('staff two factor migration fails loudly when the shared table is missing core columns', function () {
     recreateOsticket2Table('staff_two_factor', function (Blueprint $table): void {
         $table->unsignedBigInteger('staff_id');

--- a/tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php
+++ b/tests/Feature/Auth/LegacyAuthMigrationSchemaTest.php
@@ -101,6 +101,47 @@ test('staff preferences migration rollback drops only tables it created', functi
     }
 });
 
+test('scp access log migration rollback does not drop pre-existing shared table', function () {
+    recreateOsticket2Table('access_log', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('staff_id')->index();
+        $table->string('action', 128);
+        $table->timestamp('created_at')->useCurrent();
+    });
+
+    try {
+        $migration = loadMigration('2026_04_26_000200_create_scp_access_log_table.php');
+        $migration->up();
+        $migration->down();
+
+        expect(Schema::connection('osticket2')->hasTable('access_log'))->toBeTrue();
+    } finally {
+        Schema::connection('osticket2')->dropIfExists('access_log');
+        loadMigration('2026_04_26_000200_create_scp_access_log_table.php')->up();
+    }
+});
+
+test('scp access log migration rollback drops only tables it created', function () {
+    Schema::connection('osticket2')->dropIfExists('access_log');
+
+    try {
+        $migration = loadMigration('2026_04_26_000200_create_scp_access_log_table.php');
+        $migration->up();
+
+        expect(Schema::connection('osticket2')->hasColumn(
+            'access_log',
+            'created_by_migration_2026_04_26_000200'
+        ))->toBeTrue();
+
+        $migration->down();
+
+        expect(Schema::connection('osticket2')->hasTable('access_log'))->toBeFalse();
+    } finally {
+        Schema::connection('osticket2')->dropIfExists('access_log');
+        loadMigration('2026_04_26_000200_create_scp_access_log_table.php')->up();
+    }
+});
+
 test('staff two factor migration fails loudly when the shared table is missing core columns', function () {
     recreateOsticket2Table('staff_two_factor', function (Blueprint $table): void {
         $table->unsignedBigInteger('staff_id');

--- a/tests/Feature/Scp/PhaseOneReadTest.php
+++ b/tests/Feature/Scp/PhaseOneReadTest.php
@@ -1,0 +1,501 @@
+<?php
+
+use App\Models\Staff;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    $schema = Schema::connection('legacy');
+
+    foreach ([
+        '_search', 'attachment', 'file_chunk', 'file', 'thread_referral', 'thread_collaborator',
+        'thread_event', 'event', 'thread_entry', 'thread', 'queue_export', 'queue',
+        'form_field', 'ticket__cdata', 'ticket_status', 'ticket_priority', 'user_email', 'user', 'department', 'ticket',
+    ] as $table) {
+        $schema->dropIfExists($table);
+    }
+
+    $schema->create('ticket', function (Blueprint $table): void {
+        $table->unsignedInteger('ticket_id')->primary();
+        $table->string('number')->default('');
+        $table->unsignedInteger('user_id')->default(0);
+        $table->unsignedInteger('status_id')->default(1);
+        $table->unsignedInteger('dept_id')->default(0);
+        $table->unsignedInteger('staff_id')->default(0);
+        $table->unsignedInteger('team_id')->default(0);
+        $table->unsignedInteger('topic_id')->default(0);
+        $table->unsignedInteger('sla_id')->default(0);
+        $table->unsignedInteger('email_id')->default(0);
+        $table->string('source')->default('');
+        $table->string('ip_address')->default('');
+        $table->tinyInteger('isoverdue')->default(0);
+        $table->tinyInteger('isanswered')->default(0);
+        $table->dateTime('duedate')->nullable();
+        $table->dateTime('closed')->nullable();
+        $table->dateTime('lastupdate')->nullable();
+        $table->dateTime('lastmessage')->nullable();
+        $table->dateTime('lastresponse')->nullable();
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('ticket__cdata', function (Blueprint $table): void {
+        $table->unsignedInteger('ticket_id')->primary();
+        $table->string('subject')->nullable();
+        $table->string('priority')->nullable();
+    });
+
+    $schema->create('ticket_status', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->string('name');
+        $table->string('state');
+        $table->unsignedInteger('mode')->default(0);
+        $table->unsignedInteger('flags')->default(0);
+        $table->unsignedInteger('sort')->default(0);
+        $table->text('properties')->nullable();
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('ticket_priority', function (Blueprint $table): void {
+        $table->unsignedInteger('priority_id')->primary();
+        $table->string('priority');
+        $table->string('priority_desc')->default('');
+        $table->string('priority_color')->default('');
+        $table->unsignedInteger('priority_urgency')->default(0);
+        $table->tinyInteger('ispublic')->default(1);
+    });
+
+    $schema->create('department', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('tpl_id')->default(0);
+        $table->unsignedInteger('sla_id')->default(0);
+        $table->unsignedInteger('manager_id')->default(0);
+        $table->string('name')->default('');
+        $table->text('signature')->nullable();
+        $table->tinyInteger('ispublic')->default(1);
+    });
+
+    $schema->create('user', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('org_id')->default(0);
+        $table->unsignedInteger('default_email_id')->default(0);
+        $table->string('name')->default('');
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('user_email', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('user_id')->default(0);
+        $table->unsignedInteger('flags')->default(0);
+        $table->string('address')->default('');
+    });
+
+    $schema->create('thread', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('object_id');
+        $table->string('object_type', 1);
+        $table->dateTime('created')->nullable();
+    });
+
+    $schema->create('thread_entry', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('thread_id');
+        $table->unsignedInteger('staff_id')->default(0);
+        $table->string('type', 1)->default('M');
+        $table->text('body')->nullable();
+        $table->string('format')->default('html');
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('event', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->string('name');
+    });
+
+    $schema->create('thread_event', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('thread_id');
+        $table->string('thread_type', 1)->default('T');
+        $table->unsignedInteger('event_id')->default(0);
+        $table->unsignedInteger('staff_id')->default(0);
+        $table->unsignedInteger('team_id')->default(0);
+        $table->unsignedInteger('dept_id')->default(0);
+        $table->unsignedInteger('topic_id')->default(0);
+        $table->text('data')->nullable();
+        $table->string('username')->nullable();
+        $table->unsignedInteger('uid')->default(0);
+        $table->string('uid_type')->nullable();
+        $table->tinyInteger('annulled')->default(0);
+        $table->dateTime('timestamp')->nullable();
+    });
+
+    $schema->create('thread_collaborator', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('flags')->default(0);
+        $table->unsignedInteger('thread_id');
+        $table->unsignedInteger('user_id');
+        $table->string('role')->nullable();
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('thread_referral', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('thread_id');
+        $table->unsignedInteger('object_id');
+        $table->string('object_type');
+        $table->dateTime('created')->nullable();
+    });
+
+    $schema->create('file', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->string('bk', 8)->default('D');
+        $table->string('type')->nullable();
+        $table->unsignedInteger('size')->default(0);
+        $table->string('name')->nullable();
+        $table->string('key')->nullable();
+        $table->string('signature')->nullable();
+        $table->string('ft')->nullable();
+        $table->string('mime')->nullable();
+        $table->text('attrs')->nullable();
+        $table->dateTime('created')->nullable();
+    });
+
+    $schema->create('file_chunk', function (Blueprint $table): void {
+        $table->unsignedInteger('file_id');
+        $table->unsignedInteger('chunk_id');
+        $table->binary('filedata');
+        $table->primary(['file_id', 'chunk_id']);
+    });
+
+    $schema->create('attachment', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('file_id');
+        $table->string('object_type');
+        $table->unsignedInteger('object_id');
+        $table->string('name')->nullable();
+        $table->tinyInteger('inline')->default(0);
+    });
+
+    $schema->create('_search', function (Blueprint $table): void {
+        $table->string('object_type', 1);
+        $table->unsignedInteger('object_id');
+        $table->text('title')->nullable();
+        $table->text('content')->nullable();
+    });
+
+    $schema->create('queue', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('parent_id')->nullable();
+        $table->unsignedInteger('staff_id')->default(0);
+        $table->unsignedInteger('flags')->default(0);
+        $table->string('title')->default('');
+        $table->text('config')->nullable();
+        $table->unsignedInteger('sort')->default(0);
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('queue_export', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('queue_id');
+        $table->string('name')->nullable();
+        $table->text('config')->nullable();
+    });
+
+    $schema->create('form_field', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->string('name')->nullable();
+        $table->string('label')->nullable();
+    });
+
+    seedPhaseOneReadFixture();
+});
+
+afterEach(function (): void {
+    $schema = Schema::connection('legacy');
+
+    foreach (['attachment', 'file_chunk', 'file'] as $table) {
+        if ($schema->hasTable($table)) {
+            DB::connection('legacy')->table($table)->delete();
+        }
+    }
+
+    foreach ([
+        '_search', 'thread_referral', 'thread_collaborator',
+        'thread_event', 'event', 'thread_entry', 'thread', 'queue_export', 'queue',
+        'form_field', 'ticket__cdata', 'ticket_status', 'ticket_priority', 'user_email', 'user', 'department', 'ticket',
+    ] as $table) {
+        $schema->dropIfExists($table);
+    }
+});
+
+function phaseOneStaff(array $attributes = []): Staff
+{
+    DB::connection('legacy')->table('staff')->insert(array_merge([
+        'staff_id' => 80,
+        'dept_id' => 1,
+        'username' => 'phaseone',
+        'firstname' => 'Phase',
+        'lastname' => 'One',
+        'email' => 'phase-one@example.com',
+        'passwd' => bcrypt('password'),
+        'isactive' => 1,
+        'isadmin' => 0,
+        'created' => now(),
+    ], $attributes));
+
+    return Staff::on('legacy')->find($attributes['staff_id'] ?? 80);
+}
+
+function seedPhaseOneReadFixture(): void
+{
+    DB::connection('legacy')->table('ticket_status')->insert([
+        'id' => 1,
+        'name' => 'Open',
+        'state' => 'open',
+    ]);
+
+    DB::connection('legacy')->table('ticket_priority')->insert([
+        'priority_id' => 2,
+        'priority' => 'High',
+    ]);
+
+    DB::connection('legacy')->table('department')->insert([
+        'id' => 1,
+        'name' => 'Support',
+    ]);
+
+    DB::connection('legacy')->table('user')->insert([
+        ['id' => 1, 'default_email_id' => 1, 'name' => 'Grace Hopper'],
+        ['id' => 2, 'default_email_id' => 2, 'name' => 'Hidden User'],
+    ]);
+
+    DB::connection('legacy')->table('user_email')->insert([
+        ['id' => 1, 'user_id' => 1, 'address' => 'grace@example.com'],
+        ['id' => 2, 'user_id' => 2, 'address' => 'hidden@example.com'],
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 200, 'number' => '200200', 'user_id' => 1, 'status_id' => 1, 'dept_id' => 1, 'staff_id' => 80, 'sla_id' => 5, 'created' => '2026-04-20 10:00:00', 'updated' => '2026-04-20 10:30:00'],
+        ['ticket_id' => 201, 'number' => '200201', 'user_id' => 2, 'status_id' => 1, 'dept_id' => 3, 'staff_id' => 0, 'sla_id' => 0, 'created' => '2026-04-20 11:00:00', 'updated' => null],
+    ]);
+
+    DB::connection('legacy')->table('ticket__cdata')->insert([
+        ['ticket_id' => 200, 'subject' => 'Visible searchable ticket', 'priority' => '2'],
+        ['ticket_id' => 201, 'subject' => 'Hidden searchable ticket', 'priority' => '2'],
+    ]);
+
+    DB::connection('legacy')->table('thread')->insert([
+        'id' => 300,
+        'object_id' => 200,
+        'object_type' => 'T',
+        'created' => '2026-04-20 10:00:00',
+    ]);
+
+    DB::connection('legacy')->table('thread_entry')->insert([
+        'id' => 400,
+        'thread_id' => 300,
+        'staff_id' => 80,
+        'type' => 'M',
+        'body' => 'Initial message body',
+        'format' => 'html',
+        'created' => '2026-04-20 10:01:00',
+    ]);
+
+    DB::connection('legacy')->table('event')->insert(['id' => 1, 'name' => 'created']);
+    DB::connection('legacy')->table('thread_event')->insert([
+        'id' => 500,
+        'thread_id' => 300,
+        'event_id' => 1,
+        'staff_id' => 80,
+        'username' => 'phaseone',
+        'data' => '{}',
+        'timestamp' => '2026-04-20 10:02:00',
+    ]);
+
+    DB::connection('legacy')->table('thread_collaborator')->insert([
+        'id' => 600,
+        'thread_id' => 300,
+        'user_id' => 1,
+        'role' => 'cc',
+    ]);
+
+    DB::connection('legacy')->table('thread_referral')->insert([
+        'id' => 700,
+        'thread_id' => 300,
+        'object_id' => 9,
+        'object_type' => 'D',
+        'created' => '2026-04-20 10:03:00',
+    ]);
+
+    DB::connection('legacy')->table('file')->insert([
+        'id' => 800,
+        'bk' => 'D',
+        'size' => 11,
+        'name' => 'hello.txt',
+        'mime' => 'text/plain',
+    ]);
+
+    DB::connection('legacy')->table('file_chunk')->insert([
+        ['file_id' => 800, 'chunk_id' => 1, 'filedata' => 'hello '],
+        ['file_id' => 800, 'chunk_id' => 2, 'filedata' => 'world'],
+    ]);
+
+    DB::connection('legacy')->table('attachment')->insert([
+        'id' => 900,
+        'file_id' => 800,
+        'object_type' => 'H',
+        'object_id' => 400,
+        'name' => 'hello.txt',
+        'inline' => 0,
+    ]);
+
+    DB::connection('legacy')->table('_search')->insert([
+        ['object_type' => 'T', 'object_id' => 200, 'title' => 'Visible searchable ticket', 'content' => 'needle'],
+        ['object_type' => 'T', 'object_id' => 201, 'title' => 'Hidden searchable ticket', 'content' => 'needle'],
+    ]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 1000,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'Open',
+        'config' => json_encode([['status__state', 'exact', 'open']]),
+    ]);
+
+    DB::connection('legacy')->table('queue_export')->insert([
+        'id' => 1001,
+        'queue_id' => 1000,
+        'name' => 'Default',
+        'config' => json_encode(['number', 'subject', 'from', 'priority']),
+    ]);
+
+    DB::connection('legacy')->table('form_field')->insert([
+        ['id' => 1, 'name' => 'subject', 'label' => 'Subject'],
+        ['id' => 2, 'name' => 'priority', 'label' => 'Priority'],
+    ]);
+}
+
+test('ticket detail includes timeline attachments collaborators referrals and custom fields', function () {
+    $staff = phaseOneStaff();
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/tickets/200');
+
+    $response->assertOk();
+    $response->assertJsonPath('component', 'Scp/Tickets/Show');
+    $response->assertJsonPath('props.ticket.number', '200200');
+    $response->assertJsonPath('props.customFields.Subject', 'Visible searchable ticket');
+    $response->assertJsonPath('props.timeline.0.body', 'Initial message body');
+    $response->assertJsonPath('props.attachments.0.file_id', 800);
+    $response->assertJsonPath('props.collaborators.0.email', 'grace@example.com');
+    $response->assertJsonPath('props.referrals.0.object_type', 'D');
+});
+
+test('search returns only rbac-visible tickets', function () {
+    $staff = phaseOneStaff(['staff_id' => 81]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/search?q=needle');
+
+    $response->assertOk();
+    $response->assertJsonPath('props.results.0.id', 200);
+    expect($response->json('props.results'))->toHaveCount(1);
+});
+
+test('dashboard uses live visible open ticket counts', function () {
+    $this->travelTo('2026-04-28 12:00:00');
+    $staff = phaseOneStaff();
+
+    DB::connection('legacy')->table('ticket_status')->insert([
+        'id' => 2,
+        'name' => 'Closed',
+        'state' => 'closed',
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        [
+            'ticket_id' => 202,
+            'number' => '200202',
+            'user_id' => 1,
+            'status_id' => 1,
+            'dept_id' => 1,
+            'staff_id' => 0,
+            'team_id' => 0,
+            'isoverdue' => 1,
+            'source' => 'Email',
+            'created' => '2026-04-20 12:00:00',
+            'closed' => null,
+        ],
+        [
+            'ticket_id' => 203,
+            'number' => '200203',
+            'user_id' => 1,
+            'status_id' => 2,
+            'dept_id' => 1,
+            'staff_id' => 80,
+            'team_id' => 0,
+            'isoverdue' => 0,
+            'source' => 'Email',
+            'created' => '2026-03-20 12:00:00',
+            'closed' => '2026-04-05 12:00:00',
+        ],
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp');
+
+    $response->assertOk();
+    $response->assertJsonPath('component', 'Dashboard');
+    $response->assertJsonPath('props.metrics.open', 2);
+    $response->assertJsonPath('props.metrics.assignedToMe', 1);
+    $response->assertJsonPath('props.metrics.unassigned', 1);
+    $response->assertJsonPath('props.metrics.overdue', 1);
+    $response->assertJsonPath('props.metrics.trend.open.previous', 1);
+    $response->assertJsonPath('props.metrics.trend.open.percent', 100);
+    $response->assertJsonPath('props.metrics.trend.open.direction', 'up');
+    $response->assertJsonPath('props.metrics.trend.assignedToMe.direction', 'flat');
+    $response->assertJsonPath('props.metrics.trend.unassigned.direction', 'new');
+    $response->assertJsonPath('props.metrics.statusComparison.rangeStart', '2025-11-01');
+    $response->assertJsonPath('props.metrics.statusComparison.rangeEnd', '2026-04-28');
+    $response->assertJsonPath('props.metrics.statusComparison.openTotal', 2);
+    $response->assertJsonPath('props.metrics.statusComparison.solvedTotal', 1);
+    $response->assertJsonPath('props.metrics.statusComparison.months.5.month', '2026-04-01');
+    $response->assertJsonPath('props.metrics.statusComparison.months.5.open', 2);
+    $response->assertJsonPath('props.metrics.statusComparison.months.5.solved', 1);
+    $response->assertJsonPath('props.metrics.channelDistribution.total', 3);
+    $response->assertJsonPath('props.metrics.channelDistribution.channels.0.key', 'email');
+    $response->assertJsonPath('props.metrics.channelDistribution.channels.0.label', 'Email');
+    $response->assertJsonPath('props.metrics.channelDistribution.channels.0.count', 2);
+    $response->assertJsonPath('props.metrics.recentActivity.0.ticket_number', '200200');
+});
+
+test('chunked attachment download streams legacy bytes', function () {
+    $staff = phaseOneStaff(['staff_id' => 82]);
+
+    $response = $this->actingAs($staff, 'staff')->get('/scp/attachments/800');
+
+    $response->assertOk();
+    expect($response->streamedContent())->toBe('hello world');
+});
+
+test('queue csv export uses configured fields and rbac-visible rows', function () {
+    $staff = phaseOneStaff(['staff_id' => 83]);
+
+    $response = $this->actingAs($staff, 'staff')->get('/scp/queues/1000/export');
+
+    $response->assertOk();
+    $csv = $response->streamedContent();
+
+    expect($csv)->toContain('Number,Subject,From,Priority')
+        ->and($csv)->toContain('200200,"Visible searchable ticket","Grace Hopper",High')
+        ->and($csv)->not->toContain('200201');
+});

--- a/tests/Feature/Scp/PhaseOneReadTest.php
+++ b/tests/Feature/Scp/PhaseOneReadTest.php
@@ -220,6 +220,10 @@ beforeEach(function (): void {
 afterEach(function (): void {
     $schema = Schema::connection('legacy');
 
+    DB::connection('legacy')->table('staff')
+        ->whereIn('staff_id', [80, 81, 82, 83, 84, 85])
+        ->delete();
+
     foreach (['attachment', 'file_chunk', 'file'] as $table) {
         if ($schema->hasTable($table)) {
             DB::connection('legacy')->table($table)->delete();
@@ -478,8 +482,10 @@ test('dashboard uses live visible open ticket counts', function () {
     $response->assertJsonPath('props.metrics.trend.unassigned.direction', 'new');
     $response->assertJsonPath('props.metrics.statusComparison.rangeStart', '2025-11-01');
     $response->assertJsonPath('props.metrics.statusComparison.rangeEnd', '2026-04-28');
-    $response->assertJsonPath('props.metrics.statusComparison.openTotal', 2);
+    $response->assertJsonPath('props.metrics.statusComparison.openTotal', 3);
     $response->assertJsonPath('props.metrics.statusComparison.solvedTotal', 1);
+    $response->assertJsonPath('props.metrics.statusComparison.months.4.month', '2026-03-01');
+    $response->assertJsonPath('props.metrics.statusComparison.months.4.open', 1);
     $response->assertJsonPath('props.metrics.statusComparison.months.5.month', '2026-04-01');
     $response->assertJsonPath('props.metrics.statusComparison.months.5.open', 2);
     $response->assertJsonPath('props.metrics.statusComparison.months.5.solved', 1);
@@ -488,6 +494,25 @@ test('dashboard uses live visible open ticket counts', function () {
     $response->assertJsonPath('props.metrics.channelDistribution.channels.0.label', 'Email');
     $response->assertJsonPath('props.metrics.channelDistribution.channels.0.count', 2);
     $response->assertJsonPath('props.metrics.recentActivity.0.ticket_number', '200200');
+});
+
+test('dashboard degraded fallback preserves selected date range', function () {
+    $this->travelTo('2026-04-28 12:00:00');
+    $staff = phaseOneStaff();
+
+    Schema::connection('legacy')->dropIfExists('ticket');
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp?range=last_7_days');
+
+    $response->assertOk();
+    $response->assertJsonPath('props.range', 'last_7_days');
+    $response->assertJsonPath('props.metrics.open', 0);
+    $response->assertJsonPath('props.metrics.statusComparison.rangeStart', '2026-04-22');
+    $response->assertJsonPath('props.metrics.statusComparison.rangeEnd', '2026-04-28');
+    $response->assertJsonPath('props.metrics.channelDistribution.rangeStart', '2026-04-22');
+    $response->assertJsonPath('props.metrics.channelDistribution.rangeEnd', '2026-04-28');
 });
 
 test('chunked attachment download streams legacy bytes', function () {

--- a/tests/Feature/Scp/PhaseOneReadTest.php
+++ b/tests/Feature/Scp/PhaseOneReadTest.php
@@ -3,6 +3,7 @@
 use App\Models\Staff;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
 
 beforeEach(function (): void {
@@ -243,7 +244,7 @@ function phaseOneStaff(array $attributes = []): Staff
         'firstname' => 'Phase',
         'lastname' => 'One',
         'email' => 'phase-one@example.com',
-        'passwd' => bcrypt('password'),
+        'passwd' => Hash::make('password'),
         'isactive' => 1,
         'isadmin' => 0,
         'created' => now(),

--- a/tests/Feature/Scp/PhaseOneReadTest.php
+++ b/tests/Feature/Scp/PhaseOneReadTest.php
@@ -426,6 +426,48 @@ test('search treats fallback like wildcards as literal characters', function () 
     expect($response->json('props.results'))->toBe([]);
 });
 
+test('search preserves relevance order across more accessible candidates than the result limit', function () {
+    $staff = phaseOneStaff(['staff_id' => 84]);
+    $tickets = [];
+    $cdata = [];
+    $searchRows = [];
+
+    foreach (range(226, 300) as $ticketId) {
+        $tickets[] = [
+            'ticket_id' => $ticketId,
+            'number' => (string) $ticketId,
+            'user_id' => 1,
+            'status_id' => 1,
+            'dept_id' => 1,
+            'staff_id' => 0,
+            'created' => '2026-04-20 12:00:00',
+        ];
+        $cdata[] = [
+            'ticket_id' => $ticketId,
+            'subject' => "Search candidate {$ticketId}",
+            'priority' => '2',
+        ];
+        $searchRows[] = [
+            'object_type' => 'T',
+            'object_id' => $ticketId,
+            'title' => "Search candidate {$ticketId}",
+            'content' => 'rankneedle',
+        ];
+    }
+
+    DB::connection('legacy')->table('ticket')->insert($tickets);
+    DB::connection('legacy')->table('ticket__cdata')->insert($cdata);
+    DB::connection('legacy')->table('_search')->insert($searchRows);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/search?q=rankneedle');
+
+    $response->assertOk();
+    expect(collect($response->json('props.results'))->pluck('id')->all())
+        ->toBe(range(300, 276));
+});
+
 test('dashboard uses live visible open ticket counts', function () {
     $this->travelTo('2026-04-28 12:00:00');
     $staff = phaseOneStaff();

--- a/tests/Feature/Scp/PhaseOneReadTest.php
+++ b/tests/Feature/Scp/PhaseOneReadTest.php
@@ -584,3 +584,24 @@ test('queue csv export uses configured fields and rbac-visible rows', function (
         ->and($csv)->toContain('200200,"Visible searchable ticket","Grace Hopper",High')
         ->and($csv)->not->toContain('200201');
 });
+
+test('queue csv export does not expose arbitrary relationship attributes', function () {
+    $staff = phaseOneStaff(['staff_id' => 83]);
+    $passwordHash = (string) DB::connection('legacy')
+        ->table('staff')
+        ->where('staff_id', 83)
+        ->value('passwd');
+
+    DB::connection('legacy')->table('queue_export')
+        ->where('id', 1001)
+        ->update(['config' => json_encode(['number', 'staff.passwd', 'user.defaultEmail.address'])]);
+
+    $response = $this->actingAs($staff, 'staff')->get('/scp/queues/1000/export');
+
+    $response->assertOk();
+    $csv = $response->streamedContent();
+
+    expect($csv)->toContain('Number,Staff.passwd,User.defaultemail.address')
+        ->and($csv)->toContain('200200,,grace@example.com')
+        ->and($csv)->not->toContain($passwordHash);
+});

--- a/tests/Feature/Scp/PhaseOneReadTest.php
+++ b/tests/Feature/Scp/PhaseOneReadTest.php
@@ -410,6 +410,17 @@ test('search returns only rbac-visible tickets', function () {
     expect($response->json('props.results'))->toHaveCount(1);
 });
 
+test('search treats fallback like wildcards as literal characters', function () {
+    $staff = phaseOneStaff(['staff_id' => 84]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/search?q=%');
+
+    $response->assertOk();
+    expect($response->json('props.results'))->toBe([]);
+});
+
 test('dashboard uses live visible open ticket counts', function () {
     $this->travelTo('2026-04-28 12:00:00');
     $staff = phaseOneStaff();
@@ -485,6 +496,54 @@ test('chunked attachment download streams legacy bytes', function () {
 
     $response->assertOk();
     expect($response->streamedContent())->toBe('hello world');
+});
+
+test('attachment downloads are scoped to accessible ticket departments', function () {
+    $staff = phaseOneStaff(['staff_id' => 85]);
+
+    DB::connection('legacy')->table('thread')->insert([
+        'id' => 301,
+        'object_id' => 201,
+        'object_type' => 'T',
+        'created' => '2026-04-20 11:00:00',
+    ]);
+
+    DB::connection('legacy')->table('thread_entry')->insert([
+        'id' => 401,
+        'thread_id' => 301,
+        'staff_id' => 0,
+        'type' => 'M',
+        'body' => 'Hidden message body',
+        'format' => 'html',
+        'created' => '2026-04-20 11:01:00',
+    ]);
+
+    DB::connection('legacy')->table('file')->insert([
+        'id' => 801,
+        'bk' => 'D',
+        'size' => 6,
+        'name' => 'hidden.txt',
+        'mime' => 'text/plain',
+    ]);
+
+    DB::connection('legacy')->table('file_chunk')->insert([
+        'file_id' => 801,
+        'chunk_id' => 1,
+        'filedata' => 'hidden',
+    ]);
+
+    DB::connection('legacy')->table('attachment')->insert([
+        'id' => 901,
+        'file_id' => 801,
+        'object_type' => 'H',
+        'object_id' => 401,
+        'name' => 'hidden.txt',
+        'inline' => 0,
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')->get('/scp/attachments/801');
+
+    $response->assertNotFound();
 });
 
 test('queue csv export uses configured fields and rbac-visible rows', function () {

--- a/tests/Feature/Scp/QueueReadTest.php
+++ b/tests/Feature/Scp/QueueReadTest.php
@@ -3,6 +3,7 @@
 use App\Models\Staff;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
 
 beforeEach(function (): void {
@@ -109,7 +110,7 @@ function queueReadStaff(array $attributes = []): Staff
         'firstname' => 'Queue',
         'lastname' => 'Reader',
         'email' => 'queue-reader@example.com',
-        'passwd' => bcrypt('password'),
+        'passwd' => Hash::make('password'),
         'isactive' => 1,
         'isadmin' => 0,
         'created' => now(),
@@ -453,4 +454,44 @@ test('assigned to me queue filters by authenticated staff', function () {
     $response->assertJsonPath('props.unsupported', false);
     $response->assertJsonPath('props.pagination.total', 1);
     $response->assertJsonPath('props.tickets.0.id', 140);
+
+    $sortedResponse = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/14?sort=assignee&dir=asc');
+
+    $sortedResponse->assertOk();
+    $sortedResponse->assertJsonPath('props.pagination.total', 1);
+    $sortedResponse->assertJsonPath('props.tickets.0.id', 140);
+});
+
+test('assigned to my teams queue returns no tickets when staff has no teams', function () {
+    $staff = queueReadStaff(['staff_id' => 75]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 15,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'Assigned to my teams',
+        'config' => json_encode([
+            'criteria' => [
+                ['assignee', 'includes', ['T' => 'Teams']],
+            ],
+            'conditions' => [],
+        ]),
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 150, 'number' => '150150', 'dept_id' => 1, 'team_id' => 12],
+        ['ticket_id' => 151, 'number' => '150151', 'dept_id' => 1, 'staff_id' => 75],
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/15');
+
+    $response->assertOk();
+    $response->assertJsonPath('props.unsupported', false);
+    $response->assertJsonPath('props.pagination.total', 0);
 });

--- a/tests/Feature/Scp/QueueReadTest.php
+++ b/tests/Feature/Scp/QueueReadTest.php
@@ -1,0 +1,295 @@
+<?php
+
+use App\Models\Staff;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    $schema = Schema::connection('legacy');
+
+    foreach (['queue', 'ticket', 'ticket__cdata', 'ticket_status', 'ticket_priority', 'user', 'user_email'] as $table) {
+        $schema->dropIfExists($table);
+    }
+
+    $schema->create('queue', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('parent_id')->nullable();
+        $table->unsignedInteger('staff_id')->default(0);
+        $table->unsignedInteger('flags')->default(0);
+        $table->string('title')->default('');
+        $table->text('config')->nullable();
+        $table->unsignedInteger('sort')->default(0);
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('ticket', function (Blueprint $table): void {
+        $table->unsignedInteger('ticket_id')->primary();
+        $table->string('number')->default('');
+        $table->unsignedInteger('user_id')->default(0);
+        $table->unsignedInteger('status_id')->default(1);
+        $table->unsignedInteger('dept_id')->default(0);
+        $table->unsignedInteger('staff_id')->default(0);
+        $table->unsignedInteger('team_id')->default(0);
+        $table->unsignedInteger('topic_id')->default(0);
+        $table->unsignedInteger('sla_id')->default(0);
+        $table->unsignedInteger('email_id')->default(0);
+        $table->string('source')->default('');
+        $table->string('ip_address')->default('');
+        $table->tinyInteger('isoverdue')->default(0);
+        $table->tinyInteger('isanswered')->default(0);
+        $table->dateTime('duedate')->nullable();
+        $table->dateTime('closed')->nullable();
+        $table->dateTime('lastupdate')->nullable();
+        $table->dateTime('lastmessage')->nullable();
+        $table->dateTime('lastresponse')->nullable();
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('ticket__cdata', function (Blueprint $table): void {
+        $table->unsignedInteger('ticket_id')->primary();
+        $table->string('subject')->nullable();
+        $table->string('priority')->nullable();
+    });
+
+    $schema->create('ticket_status', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->string('name');
+        $table->string('state');
+        $table->unsignedInteger('mode')->default(0);
+        $table->unsignedInteger('flags')->default(0);
+        $table->unsignedInteger('sort')->default(0);
+        $table->text('properties')->nullable();
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('ticket_priority', function (Blueprint $table): void {
+        $table->unsignedInteger('priority_id')->primary();
+        $table->string('priority');
+        $table->string('priority_desc')->default('');
+        $table->string('priority_color')->default('');
+        $table->unsignedInteger('priority_urgency')->default(0);
+        $table->tinyInteger('ispublic')->default(1);
+    });
+
+    $schema->create('user', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('org_id')->default(0);
+        $table->unsignedInteger('default_email_id')->default(0);
+        $table->string('name')->default('');
+        $table->dateTime('created')->nullable();
+        $table->dateTime('updated')->nullable();
+    });
+
+    $schema->create('user_email', function (Blueprint $table): void {
+        $table->unsignedInteger('id')->primary();
+        $table->unsignedInteger('user_id')->default(0);
+        $table->unsignedInteger('flags')->default(0);
+        $table->string('address')->default('');
+    });
+});
+
+afterEach(function (): void {
+    $schema = Schema::connection('legacy');
+
+    foreach (['queue', 'ticket', 'ticket__cdata', 'ticket_status', 'ticket_priority', 'user', 'user_email'] as $table) {
+        $schema->dropIfExists($table);
+    }
+});
+
+function queueReadStaff(array $attributes = []): Staff
+{
+    DB::connection('legacy')->table('staff')->insert(array_merge([
+        'staff_id' => 70,
+        'dept_id' => 1,
+        'username' => 'queuereader',
+        'firstname' => 'Queue',
+        'lastname' => 'Reader',
+        'email' => 'queue-reader@example.com',
+        'passwd' => bcrypt('password'),
+        'isactive' => 1,
+        'isadmin' => 0,
+        'created' => now(),
+    ], $attributes));
+
+    return Staff::on('legacy')->find($attributes['staff_id'] ?? 70);
+}
+
+test('queue show renders translated criteria rows through ticket rbac', function () {
+    $staff = queueReadStaff();
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 10,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'Open urgent',
+        'config' => json_encode([
+            ['status__state', 'exact', 'open'],
+            ['cdata.priority', 'in', [2]],
+        ]),
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket_status')->insert([
+        ['id' => 1, 'name' => 'Open', 'state' => 'open'],
+        ['id' => 2, 'name' => 'Closed', 'state' => 'closed'],
+    ]);
+
+    DB::connection('legacy')->table('ticket_priority')->insert([
+        'priority_id' => 2,
+        'priority' => 'High',
+    ]);
+
+    DB::connection('legacy')->table('user')->insert([
+        'id' => 1,
+        'default_email_id' => 5,
+        'name' => 'Ada Lovelace',
+    ]);
+
+    DB::connection('legacy')->table('user_email')->insert([
+        'id' => 5,
+        'user_id' => 1,
+        'address' => 'ada@example.com',
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 100, 'number' => '100100', 'user_id' => 1, 'status_id' => 1, 'dept_id' => 1, 'created' => '2026-04-20 10:00:00'],
+        ['ticket_id' => 101, 'number' => '100101', 'user_id' => 1, 'status_id' => 2, 'dept_id' => 1, 'created' => '2026-04-20 11:00:00'],
+        ['ticket_id' => 102, 'number' => '100102', 'user_id' => 1, 'status_id' => 1, 'dept_id' => 1, 'created' => '2026-04-20 12:00:00'],
+        ['ticket_id' => 103, 'number' => '100103', 'user_id' => 1, 'status_id' => 1, 'dept_id' => 3, 'created' => '2026-04-20 13:00:00'],
+    ]);
+
+    DB::connection('legacy')->table('ticket__cdata')->insert([
+        ['ticket_id' => 100, 'subject' => 'Visible ticket', 'priority' => '2'],
+        ['ticket_id' => 101, 'subject' => 'Closed ticket', 'priority' => '2'],
+        ['ticket_id' => 102, 'subject' => 'Low ticket', 'priority' => '1'],
+        ['ticket_id' => 103, 'subject' => 'Forbidden ticket', 'priority' => '2'],
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/10');
+
+    $response->assertOk();
+    $response->assertJsonPath('component', 'Scp/Queues/Show');
+    $response->assertJsonPath('props.unsupported', false);
+    $response->assertJsonPath('props.pagination.total', 1);
+    $response->assertJsonPath('props.tickets.0.id', 100);
+    $response->assertJsonPath('props.tickets.0.subject', 'Visible ticket');
+    $response->assertJsonPath('props.tickets.0.priority', 'High');
+});
+
+test('private queues owned by another staff member are hidden', function () {
+    $staff = queueReadStaff(['staff_id' => 71]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 11,
+        'parent_id' => null,
+        'staff_id' => 999,
+        'flags' => 2,
+        'title' => 'Other personal queue',
+        'config' => null,
+        'sort' => 1,
+    ]);
+
+    $this->actingAs($staff, 'staff')->get('/scp/queues/11')->assertNotFound();
+});
+
+test('unsupported queue criteria are reported without crashing', function () {
+    $staff = queueReadStaff(['staff_id' => 72]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 12,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'Unsupported queue',
+        'config' => json_encode([
+            ['unknown__field', 'exact', 'value'],
+        ]),
+        'sort' => 1,
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/12');
+
+    $response->assertOk();
+    $response->assertJsonPath('props.unsupported', true);
+    $response->assertJsonPath('props.unsupportedReasons.0', 'Unsupported queue field [unknown__field].');
+});
+
+test('queue show supports legacy includes operator with option objects', function () {
+    $staff = queueReadStaff(['staff_id' => 73]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 13,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'CCM source',
+        'config' => json_encode([
+            'criteria' => [
+                ['source', 'includes', ['CCM' => 'CCM']],
+            ],
+            'conditions' => [],
+        ]),
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 130, 'number' => '130130', 'dept_id' => 1, 'staff_id' => 0, 'source' => 'CCM'],
+        ['ticket_id' => 131, 'number' => '130131', 'dept_id' => 1, 'staff_id' => 0, 'source' => 'MMS'],
+    ]);
+
+    DB::connection('legacy')->table('ticket__cdata')->insert([
+        ['ticket_id' => 130, 'subject' => 'CCM ticket', 'priority' => '1'],
+        ['ticket_id' => 131, 'subject' => 'MMS ticket', 'priority' => '1'],
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/13');
+
+    $response->assertOk();
+    $response->assertJsonPath('props.unsupported', false);
+    $response->assertJsonPath('props.pagination.total', 1);
+    $response->assertJsonPath('props.tickets.0.id', 130);
+});
+
+test('assigned to me queue filters by authenticated staff', function () {
+    $staff = queueReadStaff(['staff_id' => 74]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 14,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'Assigned to me',
+        'config' => json_encode([
+            'criteria' => [
+                ['assignee', 'includes', ['M' => 'Me']],
+            ],
+            'conditions' => [],
+        ]),
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 140, 'number' => '140140', 'dept_id' => 1, 'staff_id' => 74],
+        ['ticket_id' => 141, 'number' => '140141', 'dept_id' => 1, 'staff_id' => 75],
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/14');
+
+    $response->assertOk();
+    $response->assertJsonPath('props.unsupported', false);
+    $response->assertJsonPath('props.pagination.total', 1);
+    $response->assertJsonPath('props.tickets.0.id', 140);
+});

--- a/tests/Feature/Scp/QueueReadTest.php
+++ b/tests/Feature/Scp/QueueReadTest.php
@@ -261,6 +261,167 @@ test('queue show supports legacy includes operator with option objects', functio
     $response->assertJsonPath('props.tickets.0.id', 130);
 });
 
+test('queue filter chips narrow tickets by source priority state and date', function () {
+    $staff = queueReadStaff(['staff_id' => 80]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 80,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'All open',
+        'config' => json_encode([['status__state', 'exact', 'open']]),
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket_status')->insert([
+        ['id' => 1, 'name' => 'Open', 'state' => 'open'],
+        ['id' => 2, 'name' => 'Closed', 'state' => 'closed'],
+    ]);
+
+    DB::connection('legacy')->table('ticket_priority')->insert([
+        ['priority_id' => 2, 'priority' => 'High', 'priority_urgency' => 1],
+        ['priority_id' => 3, 'priority' => 'Low', 'priority_urgency' => 4],
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 800, 'number' => '800', 'dept_id' => 1, 'status_id' => 1, 'source' => 'Email', 'created' => '2026-04-26 09:00:00'],
+        ['ticket_id' => 801, 'number' => '801', 'dept_id' => 1, 'status_id' => 1, 'source' => 'Web', 'created' => '2026-04-26 10:00:00'],
+        ['ticket_id' => 802, 'number' => '802', 'dept_id' => 1, 'status_id' => 1, 'source' => 'Phone', 'created' => '2026-01-15 09:00:00'],
+        ['ticket_id' => 803, 'number' => '803', 'dept_id' => 1, 'status_id' => 1, 'source' => 'Email', 'created' => '2026-04-26 11:00:00'],
+    ]);
+
+    DB::connection('legacy')->table('ticket__cdata')->insert([
+        ['ticket_id' => 800, 'subject' => 'Email High', 'priority' => '2'],
+        ['ticket_id' => 801, 'subject' => 'Web High', 'priority' => '2'],
+        ['ticket_id' => 802, 'subject' => 'Phone Low', 'priority' => '3'],
+        ['ticket_id' => 803, 'subject' => 'Email Low', 'priority' => '3'],
+    ]);
+
+    $sourceResponse = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/80?source[]=Email');
+
+    $sourceResponse->assertOk();
+    $sourceResponse->assertJsonPath('props.pagination.total', 2);
+    $sourceResponse->assertJsonPath('props.filters.source.0', 'Email');
+
+    $priorityResponse = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/80?priority[]=2');
+
+    $priorityResponse->assertJsonPath('props.pagination.total', 2);
+    expect(collect($priorityResponse->json('props.tickets'))->pluck('id')->all())
+        ->toEqualCanonicalizing([800, 801]);
+
+    $bothResponse = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/80?source[]=Email&priority[]=2');
+
+    $bothResponse->assertJsonPath('props.pagination.total', 1);
+    $bothResponse->assertJsonPath('props.tickets.0.id', 800);
+
+    $stateResponse = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/80?state[]=closed');
+
+    // The queue itself filters to state=open via criteria, so a closed-state filter yields zero.
+    $stateResponse->assertJsonPath('props.pagination.total', 0);
+
+    $dateResponse = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/80?created_from=2026-04-01&created_to=2026-04-30');
+
+    $dateResponse->assertJsonPath('props.pagination.total', 3);
+    expect(collect($dateResponse->json('props.tickets'))->pluck('id')->all())
+        ->not->toContain(802);
+});
+
+test('queue sort orders rows server-side', function () {
+    $staff = queueReadStaff(['staff_id' => 81]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 81,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'Sortable',
+        'config' => null,
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 900, 'number' => '900', 'dept_id' => 1, 'staff_id' => 0, 'created' => '2026-04-20 09:00:00'],
+        ['ticket_id' => 901, 'number' => '901', 'dept_id' => 1, 'staff_id' => 0, 'created' => '2026-04-22 09:00:00'],
+        ['ticket_id' => 902, 'number' => '902', 'dept_id' => 1, 'staff_id' => 0, 'created' => '2026-04-21 09:00:00'],
+    ]);
+
+    DB::connection('legacy')->table('ticket__cdata')->insert([
+        ['ticket_id' => 900, 'subject' => 'A', 'priority' => '3'],
+        ['ticket_id' => 901, 'subject' => 'B', 'priority' => '1'],
+        ['ticket_id' => 902, 'subject' => 'C', 'priority' => '2'],
+    ]);
+
+    $createdAsc = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/81?sort=created&dir=asc');
+
+    expect(collect($createdAsc->json('props.tickets'))->pluck('id')->all())
+        ->toBe([900, 902, 901]);
+
+    $createdDesc = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/81?sort=created&dir=desc');
+
+    expect(collect($createdDesc->json('props.tickets'))->pluck('id')->all())
+        ->toBe([901, 902, 900]);
+
+    $priorityAsc = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/81?sort=priority&dir=asc');
+
+    expect(collect($priorityAsc->json('props.tickets'))->pluck('id')->all())
+        ->toBe([901, 902, 900]);
+
+    $numberDesc = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/81?sort=number&dir=desc');
+
+    expect(collect($numberDesc->json('props.tickets'))->pluck('id')->all())
+        ->toBe([902, 901, 900]);
+});
+
+test('queue filters do not bypass ticket rbac', function () {
+    $staff = queueReadStaff(['staff_id' => 82, 'dept_id' => 1]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 82,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'RBAC test',
+        'config' => null,
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 1000, 'number' => '1000', 'dept_id' => 1, 'staff_id' => 0, 'source' => 'Email', 'created' => '2026-04-25 09:00:00'],
+        ['ticket_id' => 1001, 'number' => '1001', 'dept_id' => 9, 'staff_id' => 0, 'source' => 'Email', 'created' => '2026-04-25 09:00:00'],
+    ]);
+
+    DB::connection('legacy')->table('ticket__cdata')->insert([
+        ['ticket_id' => 1000, 'subject' => 'mine', 'priority' => '2'],
+        ['ticket_id' => 1001, 'subject' => 'forbidden', 'priority' => '2'],
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/82?source[]=Email');
+
+    $response->assertJsonPath('props.pagination.total', 1);
+    $response->assertJsonPath('props.tickets.0.id', 1000);
+});
+
 test('assigned to me queue filters by authenticated staff', function () {
     $staff = queueReadStaff(['staff_id' => 74]);
 

--- a/tests/Feature/Scp/QueueReadTest.php
+++ b/tests/Feature/Scp/QueueReadTest.php
@@ -532,3 +532,40 @@ test('assigned to my teams queue returns no tickets when staff has no teams', fu
     $response->assertJsonPath('props.unsupported', false);
     $response->assertJsonPath('props.pagination.total', 0);
 });
+
+test('assignee exclusion with no recognized targets leaves queue unconstrained', function () {
+    $staff = queueReadStaff(['staff_id' => 76]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 16,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'Unknown assignee exclusion',
+        'config' => json_encode([
+            'criteria' => [
+                ['assignee', '!includes', ['D' => 'Department']],
+            ],
+            'conditions' => [],
+        ]),
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 160, 'number' => '160160', 'dept_id' => 1, 'staff_id' => 76],
+        ['ticket_id' => 161, 'number' => '160161', 'dept_id' => 1, 'staff_id' => 0],
+    ]);
+
+    DB::connection('legacy')->table('ticket__cdata')->insert([
+        ['ticket_id' => 160, 'subject' => 'Assigned', 'priority' => '1'],
+        ['ticket_id' => 161, 'subject' => 'Unassigned', 'priority' => '1'],
+    ]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/16');
+
+    $response->assertOk();
+    $response->assertJsonPath('props.unsupported', false);
+    $response->assertJsonPath('props.pagination.total', 2);
+});

--- a/tests/Feature/Scp/QueueReadTest.php
+++ b/tests/Feature/Scp/QueueReadTest.php
@@ -355,12 +355,14 @@ test('queue sort orders rows server-side', function () {
         ['ticket_id' => 900, 'number' => '900', 'dept_id' => 1, 'staff_id' => 0, 'created' => '2026-04-20 09:00:00'],
         ['ticket_id' => 901, 'number' => '901', 'dept_id' => 1, 'staff_id' => 0, 'created' => '2026-04-22 09:00:00'],
         ['ticket_id' => 902, 'number' => '902', 'dept_id' => 1, 'staff_id' => 0, 'created' => '2026-04-21 09:00:00'],
+        ['ticket_id' => 903, 'number' => '903', 'dept_id' => 1, 'staff_id' => 0, 'created' => '2026-04-23 09:00:00'],
     ]);
 
     DB::connection('legacy')->table('ticket__cdata')->insert([
         ['ticket_id' => 900, 'subject' => 'A', 'priority' => '3'],
         ['ticket_id' => 901, 'subject' => 'B', 'priority' => '1'],
         ['ticket_id' => 902, 'subject' => 'C', 'priority' => '2'],
+        ['ticket_id' => 903, 'subject' => 'D', 'priority' => '10'],
     ]);
 
     $createdAsc = $this->actingAs($staff, 'staff')
@@ -368,28 +370,59 @@ test('queue sort orders rows server-side', function () {
         ->get('/scp/queues/81?sort=created&dir=asc');
 
     expect(collect($createdAsc->json('props.tickets'))->pluck('id')->all())
-        ->toBe([900, 902, 901]);
+        ->toBe([900, 902, 901, 903]);
 
     $createdDesc = $this->actingAs($staff, 'staff')
         ->withHeaders(inertiaHeaders())
         ->get('/scp/queues/81?sort=created&dir=desc');
 
     expect(collect($createdDesc->json('props.tickets'))->pluck('id')->all())
-        ->toBe([901, 902, 900]);
+        ->toBe([903, 901, 902, 900]);
 
     $priorityAsc = $this->actingAs($staff, 'staff')
         ->withHeaders(inertiaHeaders())
         ->get('/scp/queues/81?sort=priority&dir=asc');
 
     expect(collect($priorityAsc->json('props.tickets'))->pluck('id')->all())
-        ->toBe([901, 902, 900]);
+        ->toBe([901, 902, 900, 903]);
 
     $numberDesc = $this->actingAs($staff, 'staff')
         ->withHeaders(inertiaHeaders())
         ->get('/scp/queues/81?sort=number&dir=desc');
 
     expect(collect($numberDesc->json('props.tickets'))->pluck('id')->all())
-        ->toBe([902, 901, 900]);
+        ->toBe([903, 902, 901, 900]);
+});
+
+test('queue read degrades to empty rows when the legacy ticket query fails', function () {
+    $staff = queueReadStaff(['staff_id' => 83]);
+
+    DB::connection('legacy')->table('queue')->insert([
+        'id' => 83,
+        'parent_id' => null,
+        'staff_id' => 0,
+        'flags' => 3,
+        'title' => 'Broken legacy query',
+        'config' => null,
+        'sort' => 1,
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        'ticket_id' => 830,
+        'number' => '830',
+        'dept_id' => 1,
+        'created' => '2026-04-25 09:00:00',
+    ]);
+
+    Schema::connection('legacy')->dropIfExists('ticket__cdata');
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/queues/83?sort=priority&dir=asc');
+
+    $response->assertOk();
+    $response->assertJsonPath('props.pagination.total', 0);
+    $response->assertJsonPath('props.tickets', []);
 });
 
 test('queue filters do not bypass ticket rbac', function () {

--- a/tests/Feature/Scp/QueueReadTest.php
+++ b/tests/Feature/Scp/QueueReadTest.php
@@ -403,7 +403,9 @@ test('queue read degrades to empty rows when the legacy ticket query fails', fun
         'staff_id' => 0,
         'flags' => 3,
         'title' => 'Broken legacy query',
-        'config' => null,
+        'config' => json_encode([
+            ['unknown__field', 'exact', 'value'],
+        ]),
         'sort' => 1,
     ]);
 
@@ -423,6 +425,8 @@ test('queue read degrades to empty rows when the legacy ticket query fails', fun
     $response->assertOk();
     $response->assertJsonPath('props.pagination.total', 0);
     $response->assertJsonPath('props.tickets', []);
+    $response->assertJsonPath('props.unsupported', true);
+    $response->assertJsonPath('props.unsupportedReasons.0', 'Unsupported queue field [unknown__field].');
 });
 
 test('queue filters do not bypass ticket rbac', function () {

--- a/tests/Feature/Scp/ScpFoundationTest.php
+++ b/tests/Feature/Scp/ScpFoundationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Models\Staff;
+use App\Models\Ticket;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function (): void {
+    $schema = Schema::connection('legacy');
+
+    if (! $schema->hasTable('ticket')) {
+        $schema->create('ticket', function (Blueprint $table): void {
+            $table->unsignedInteger('ticket_id')->primary();
+            $table->string('number')->default('');
+            $table->unsignedInteger('user_id')->default(0);
+            $table->unsignedInteger('status_id')->default(1);
+            $table->unsignedInteger('dept_id')->default(0);
+            $table->unsignedInteger('staff_id')->default(0);
+            $table->unsignedInteger('sla_id')->default(0);
+            $table->unsignedInteger('email_id')->default(0);
+            $table->string('source')->default('');
+            $table->string('ip_address')->default('');
+            $table->tinyInteger('isoverdue')->default(0);
+            $table->tinyInteger('isanswered')->default(0);
+            $table->dateTime('duedate')->nullable();
+            $table->dateTime('closed')->nullable();
+            $table->dateTime('lastupdate')->nullable();
+            $table->dateTime('lastmessage')->nullable();
+            $table->dateTime('lastresponse')->nullable();
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+    }
+
+    foreach ([
+        'number' => fn (Blueprint $table) => $table->string('number')->default(''),
+        'dept_id' => fn (Blueprint $table) => $table->unsignedInteger('dept_id')->default(0),
+        'staff_id' => fn (Blueprint $table) => $table->unsignedInteger('staff_id')->default(0),
+        'topic_id' => fn (Blueprint $table) => $table->unsignedInteger('topic_id')->default(0),
+        'status_id' => fn (Blueprint $table) => $table->unsignedInteger('status_id')->default(1),
+        'source' => fn (Blueprint $table) => $table->string('source')->default(''),
+        'isoverdue' => fn (Blueprint $table) => $table->tinyInteger('isoverdue')->default(0),
+        'created' => fn (Blueprint $table) => $table->dateTime('created')->nullable(),
+        'updated' => fn (Blueprint $table) => $table->dateTime('updated')->nullable(),
+        'closed' => fn (Blueprint $table) => $table->dateTime('closed')->nullable(),
+    ] as $column => $definition) {
+        if (! $schema->hasColumn('ticket', $column)) {
+            $schema->table('ticket', $definition);
+        }
+    }
+
+    if ($schema->hasTable('ticket__cdata')) {
+        foreach ([
+            'subject' => fn (Blueprint $table) => $table->string('subject')->nullable(),
+            'priority' => fn (Blueprint $table) => $table->string('priority')->nullable(),
+        ] as $column => $definition) {
+            if (! $schema->hasColumn('ticket__cdata', $column)) {
+                $schema->table('ticket__cdata', $definition);
+            }
+        }
+    }
+
+    DB::connection('legacy')->table('ticket')->delete();
+});
+
+afterEach(function (): void {
+    if (Schema::connection('legacy')->hasTable('ticket')) {
+        Schema::connection('legacy')->drop('ticket');
+    }
+});
+
+function scpStaff(array $attributes = []): Staff
+{
+    DB::connection('legacy')->table('staff')->insert(array_merge([
+        'staff_id' => 50,
+        'dept_id' => 1,
+        'username' => 'scpstaff',
+        'firstname' => 'SCP',
+        'lastname' => 'Staff',
+        'email' => 'scp@example.com',
+        'passwd' => bcrypt('password'),
+        'isactive' => 1,
+        'isadmin' => 0,
+        'created' => now(),
+    ], $attributes));
+
+    return Staff::on('legacy')->find($attributes['staff_id'] ?? 50);
+}
+
+test('ticket queries are scoped to authenticated staff department access', function () {
+    $staff = scpStaff(['staff_id' => 51, 'dept_id' => 1]);
+
+    DB::connection('legacy')->table('staff_dept_access')->insert([
+        'staff_id' => 51,
+        'dept_id' => 2,
+        'role_id' => 1,
+        'flags' => 0,
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 1, 'number' => 'A', 'dept_id' => 1, 'staff_id' => 0],
+        ['ticket_id' => 2, 'number' => 'B', 'dept_id' => 2, 'staff_id' => 0],
+        ['ticket_id' => 3, 'number' => 'C', 'dept_id' => 3, 'staff_id' => 0],
+    ]);
+
+    Auth::guard('staff')->login($staff);
+
+    expect(Ticket::query()->pluck('ticket_id')->all())->toBe([1, 2]);
+});
+
+test('admin ticket queries are not department scoped', function () {
+    $staff = scpStaff(['staff_id' => 52, 'dept_id' => 1, 'isadmin' => 1]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 1, 'number' => 'A', 'dept_id' => 1, 'staff_id' => 0],
+        ['ticket_id' => 2, 'number' => 'B', 'dept_id' => 3, 'staff_id' => 0],
+    ]);
+
+    Auth::guard('staff')->login($staff);
+
+    expect(Ticket::query()->pluck('ticket_id')->all())->toBe([1, 2]);
+});
+
+test('preferences page creates own preference row and logs access', function () {
+    $staff = scpStaff(['staff_id' => 53]);
+
+    $response = $this->actingAs($staff, 'staff')
+        ->withHeaders(inertiaHeaders())
+        ->get('/scp/preferences');
+
+    $response->assertOk();
+    $response->assertJsonPath('component', 'Scp/Preferences/Index');
+
+    expect(DB::connection('osticket2')->table('staff_preferences')->where('staff_id', 53)->exists())->toBeTrue()
+        ->and(DB::connection('osticket2')->table('access_log')->where('staff_id', 53)->where('action', 'scp.preferences.show')->exists())->toBeTrue();
+});
+
+test('inactive authenticated staff is denied scp access', function () {
+    $staff = scpStaff(['staff_id' => 54, 'isactive' => 0]);
+
+    $response = $this->actingAs($staff, 'staff')->get('/scp');
+
+    $response->assertForbidden();
+});

--- a/tests/Feature/Scp/ScpFoundationTest.php
+++ b/tests/Feature/Scp/ScpFoundationTest.php
@@ -5,6 +5,7 @@ use App\Models\Ticket;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
 
 beforeEach(function (): void {
@@ -80,7 +81,7 @@ function scpStaff(array $attributes = []): Staff
         'firstname' => 'SCP',
         'lastname' => 'Staff',
         'email' => 'scp@example.com',
-        'passwd' => bcrypt('password'),
+        'passwd' => Hash::make('password'),
         'isactive' => 1,
         'isadmin' => 0,
         'created' => now(),

--- a/tests/Feature/Scp/ScpFoundationTest.php
+++ b/tests/Feature/Scp/ScpFoundationTest.php
@@ -124,6 +124,41 @@ test('admin ticket queries are not department scoped', function () {
     expect(Ticket::query()->pluck('ticket_id')->all())->toBe([1, 2]);
 });
 
+test('ticket queries fail closed without authenticated staff', function () {
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 1, 'number' => 'A', 'dept_id' => 1, 'staff_id' => 0],
+        ['ticket_id' => 2, 'number' => 'B', 'dept_id' => 2, 'staff_id' => 0],
+    ]);
+
+    Auth::guard('staff')->logout();
+
+    expect(Ticket::query()->pluck('ticket_id')->all())->toBe([]);
+});
+
+test('staff assigned tickets relation is not scoped to the authenticated viewer', function () {
+    $viewer = scpStaff([
+        'staff_id' => 55,
+        'dept_id' => 1,
+        'username' => 'viewer',
+        'email' => 'viewer@example.com',
+    ]);
+    $owner = scpStaff([
+        'staff_id' => 56,
+        'dept_id' => 3,
+        'username' => 'owner',
+        'email' => 'owner@example.com',
+    ]);
+
+    DB::connection('legacy')->table('ticket')->insert([
+        ['ticket_id' => 1, 'number' => 'A', 'dept_id' => 3, 'staff_id' => 56],
+        ['ticket_id' => 2, 'number' => 'B', 'dept_id' => 1, 'staff_id' => 55],
+    ]);
+
+    Auth::guard('staff')->login($viewer);
+
+    expect($owner->assignedTickets()->pluck('ticket_id')->all())->toBe([1]);
+});
+
 test('preferences page creates own preference row and logs access', function () {
     $staff = scpStaff(['staff_id' => 53]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -126,9 +126,33 @@ abstract class TestCase extends BaseTestCase
                 });
             }
 
+            $this->ensureLegacyTable($osticket2, 'staff_preferences', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->unique();
+                $table->string('theme', 16)->default('system');
+                $table->string('language', 16)->nullable();
+                $table->string('timezone', 64)->nullable();
+                $table->json('notifications')->nullable();
+                $table->timestamps();
+            });
+
+            $this->ensureLegacyTable($osticket2, 'access_log', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->index();
+                $table->string('action', 128);
+                $table->string('subject_type', 64)->nullable();
+                $table->unsignedBigInteger('subject_id')->nullable();
+                $table->json('metadata')->nullable();
+                $table->string('ip_address', 45)->nullable();
+                $table->text('user_agent')->nullable();
+                $table->timestamp('created_at')->useCurrent();
+            });
+
+            foreach (['access_log', 'staff_preferences', 'staff_auth_migrations', 'staff_two_factor'] as $table) {
+                $osticket2Connection->table($table)->delete();
+            }
+
             foreach ([
-                'staff_auth_migrations',
-                'staff_two_factor',
                 'role_has_permissions',
                 'model_has_roles',
                 'model_has_permissions',
@@ -138,12 +162,6 @@ abstract class TestCase extends BaseTestCase
                 'session',
                 'staff',
             ] as $table) {
-                if (in_array($table, ['staff_two_factor', 'staff_auth_migrations'], true)) {
-                    $osticket2Connection->table($table)->delete();
-
-                    continue;
-                }
-
                 $legacyConnection->table($table)->delete();
             }
         }

--- a/tests/Unit/Mail/OutboundMailGuardTest.php
+++ b/tests/Unit/Mail/OutboundMailGuardTest.php
@@ -12,9 +12,8 @@ test('outbound mail guard bypasses non-production environments', function () {
         ->to('customer@example.com')
         ->subject('Customer Reply');
 
-    app(OutboundMailGuard::class)->handle(new MessageSending($email));
-
-    expect(true)->toBeTrue();
+    expect(fn () => app(OutboundMailGuard::class)->handle(new MessageSending($email)))
+        ->not->toThrow(RuntimeException::class);
 });
 
 test('outbound mail guard allows password reset in production', function () {
@@ -24,11 +23,9 @@ test('outbound mail guard allows password reset in production', function () {
         ->to('staff@example.com')
         ->subject('Reset Your Password');
 
-    app(OutboundMailGuard::class)->handle(new MessageSending($email, [
+    expect(fn () => app(OutboundMailGuard::class)->handle(new MessageSending($email, [
         '__laravel_mailable' => PasswordResetLinkMail::class,
-    ]));
-
-    expect(true)->toBeTrue();
+    ])))->not->toThrow(RuntimeException::class);
 });
 
 test('outbound mail guard does not bypass arbitrary mail by subject', function () {

--- a/tests/Unit/Mail/OutboundMailGuardTest.php
+++ b/tests/Unit/Mail/OutboundMailGuardTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Mail\OutboundMailGuard;
+use Illuminate\Mail\Events\MessageSending;
+use Symfony\Component\Mime\Email;
+
+test('outbound mail guard bypasses non-production environments', function () {
+    app()->detectEnvironment(fn (): string => 'testing');
+
+    $email = (new Email)
+        ->to('customer@example.com')
+        ->subject('Customer Reply');
+
+    app(OutboundMailGuard::class)->handle(new MessageSending($email));
+
+    expect(true)->toBeTrue();
+});
+
+test('outbound mail guard allows password reset in production', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+
+    $email = (new Email)
+        ->to('staff@example.com')
+        ->subject('Reset Your Password');
+
+    app(OutboundMailGuard::class)->handle(new MessageSending($email));
+
+    expect(true)->toBeTrue();
+});
+
+test('outbound mail guard blocks customer mail in production', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+
+    $email = (new Email)
+        ->to('customer@example.com')
+        ->subject('Ticket Updated');
+
+    app(OutboundMailGuard::class)->handle(new MessageSending($email));
+})->throws(RuntimeException::class, 'Outbound mail is disabled');

--- a/tests/Unit/Mail/OutboundMailGuardTest.php
+++ b/tests/Unit/Mail/OutboundMailGuardTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Mail\OutboundMailGuard;
+use App\Mail\PasswordResetLinkMail;
 use Illuminate\Mail\Events\MessageSending;
 use Symfony\Component\Mime\Email;
 
@@ -23,10 +24,22 @@ test('outbound mail guard allows password reset in production', function () {
         ->to('staff@example.com')
         ->subject('Reset Your Password');
 
-    app(OutboundMailGuard::class)->handle(new MessageSending($email));
+    app(OutboundMailGuard::class)->handle(new MessageSending($email, [
+        '__laravel_mailable' => PasswordResetLinkMail::class,
+    ]));
 
     expect(true)->toBeTrue();
 });
+
+test('outbound mail guard does not bypass arbitrary mail by subject', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+
+    $email = (new Email)
+        ->to('customer@example.com')
+        ->subject('Reset Your Password');
+
+    app(OutboundMailGuard::class)->handle(new MessageSending($email));
+})->throws(RuntimeException::class, 'Outbound mail is disabled for this phase of the SCP migration.');
 
 test('outbound mail guard blocks customer mail in production', function () {
     app()->detectEnvironment(fn (): string => 'production');
@@ -36,4 +49,4 @@ test('outbound mail guard blocks customer mail in production', function () {
         ->subject('Ticket Updated');
 
     app(OutboundMailGuard::class)->handle(new MessageSending($email));
-})->throws(RuntimeException::class, 'Outbound mail is disabled');
+})->throws(RuntimeException::class, 'Outbound mail is disabled for this phase of the SCP migration.');

--- a/tests/Unit/Services/LegacyFilesystemReaderTest.php
+++ b/tests/Unit/Services/LegacyFilesystemReaderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Models\File;
+use App\Services\FileStorage\LegacyFilesystemReader;
+
+test('legacy filesystem reader only serves files inside configured root', function () {
+    $root = storage_path('framework/testing/legacy-files');
+    $outside = storage_path('framework/testing/outside-legacy.txt');
+
+    if (! is_dir($root)) {
+        mkdir($root, 0777, true);
+    }
+
+    file_put_contents($root.'/allowed.txt', 'allowed');
+    file_put_contents($outside, 'outside');
+
+    config(['services.osticket.filesystem_root' => $root]);
+
+    $reader = app(LegacyFilesystemReader::class);
+
+    expect($reader->exists(new File([
+        'id' => 1,
+        'bk' => '6',
+        'name' => 'allowed.txt',
+        'attrs' => json_encode(['path' => 'allowed.txt']),
+    ])))->toBeTrue()
+        ->and($reader->exists(new File([
+            'id' => 2,
+            'bk' => '6',
+            'name' => 'outside-legacy.txt',
+            'attrs' => $outside,
+        ])))->toBeFalse();
+});
+
+test('filesystem plugin reader derives path from file key', function () {
+    $root = storage_path('framework/testing/plugin-files');
+    $key = 'A0Ql4rlKDF2IdFknMpjhZlJetG81f_SQ';
+
+    if (! is_dir($root.'/A')) {
+        mkdir($root.'/A', 0777, true);
+    }
+
+    file_put_contents($root.'/A/'.$key, 'plugin');
+
+    config(['services.osticket.filesystem_root' => $root]);
+
+    $reader = app(LegacyFilesystemReader::class);
+
+    expect($reader->exists(new File([
+        'id' => 4,
+        'bk' => 'F',
+        'name' => 'Release_Note.docx',
+        'key' => $key,
+        'attrs' => null,
+    ])))->toBeTrue();
+});
+
+test('legacy filesystem reader fails closed without configured root', function () {
+    config(['services.osticket.filesystem_root' => null]);
+
+    $reader = app(LegacyFilesystemReader::class);
+
+    expect($reader->exists(new File([
+        'id' => 3,
+        'bk' => '6',
+        'attrs' => __FILE__,
+    ])))->toBeFalse();
+});

--- a/tests/Unit/Services/LegacyFilesystemReaderTest.php
+++ b/tests/Unit/Services/LegacyFilesystemReaderTest.php
@@ -99,3 +99,15 @@ test('legacy filesystem reader fails closed without configured root', function (
         'attrs' => __FILE__,
     ])))->toBeFalse();
 });
+
+test('legacy filesystem reader rejects filesystem root as configured root', function () {
+    config(['services.osticket.filesystem_root' => DIRECTORY_SEPARATOR]);
+
+    $reader = app(LegacyFilesystemReader::class);
+
+    expect($reader->exists(new File([
+        'id' => 6,
+        'bk' => '6',
+        'attrs' => __FILE__,
+    ])))->toBeFalse();
+});

--- a/tests/Unit/Services/LegacyFilesystemReaderTest.php
+++ b/tests/Unit/Services/LegacyFilesystemReaderTest.php
@@ -2,6 +2,13 @@
 
 use App\Models\File;
 use App\Services\FileStorage\LegacyFilesystemReader;
+use Illuminate\Support\Facades\File as Filesystem;
+
+afterEach(function (): void {
+    Filesystem::deleteDirectory(storage_path('framework/testing/legacy-files'));
+    Filesystem::deleteDirectory(storage_path('framework/testing/plugin-files'));
+    Filesystem::delete(storage_path('framework/testing/outside-legacy.txt'));
+});
 
 test('legacy filesystem reader only serves files inside configured root', function () {
     $root = storage_path('framework/testing/legacy-files');

--- a/tests/Unit/Services/LegacyFilesystemReaderTest.php
+++ b/tests/Unit/Services/LegacyFilesystemReaderTest.php
@@ -62,6 +62,32 @@ test('filesystem plugin reader derives path from file key', function () {
     ])))->toBeTrue();
 });
 
+test('legacy filesystem reader tries later decoded path candidates', function () {
+    $root = storage_path('framework/testing/legacy-files');
+    $outside = storage_path('framework/testing/outside-legacy.txt');
+
+    if (! is_dir($root)) {
+        mkdir($root, 0777, true);
+    }
+
+    file_put_contents($root.'/allowed.txt', 'allowed');
+    file_put_contents($outside, 'outside');
+
+    config(['services.osticket.filesystem_root' => $root]);
+
+    $reader = app(LegacyFilesystemReader::class);
+
+    expect($reader->exists(new File([
+        'id' => 5,
+        'bk' => '6',
+        'name' => 'allowed.txt',
+        'attrs' => json_encode([
+            'path' => $outside,
+            'file' => 'allowed.txt',
+        ]),
+    ])))->toBeTrue();
+});
+
 test('legacy filesystem reader fails closed without configured root', function () {
     config(['services.osticket.filesystem_root' => null]);
 


### PR DESCRIPTION
## Summary
Implements the live SCP dashboard with ticket counts, trend cards, open-vs-solved charts, source distribution, recent activity, responsive layout updates, and English/Vietnamese dashboard copy. Adds the supporting SCP queue, search, ticket detail, attachment, and staff preference routes/pages/services that the dashboard quick actions and activity links depend on. Adds staff-visible ticket scoping, SCP access logging, file-storage readers, queue export/search/read services, and a parity-check command for migration validation. Adds a production outbound mail guard with configuration and unit coverage to prevent unintended customer mail during the migration phase.

## Verification
- php artisan test tests/Feature/Scp
- php artisan test tests/Unit/Mail/OutboundMailGuardTest.php
- npm run build
- php artisan route:list --path=scp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live SCP dashboard, full queue UX (selector, table, filters, CSV export), search, detailed ticket view, attachment downloads (streamed), staff preferences, parity-check command, access logging, auth middleware, new UI components and utilities, i18n strings and layout updates

* **Chores**
  * DB migrations for staff preferences and access logs; config/env for filesystem and mail; outbound email guard to restrict production deliveries

* **Tests**
  * Extensive unit and feature suites covering SCP flows, file readers, exports and migrations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->