### PR TITLE
Phase 2b internal SCP actions

### DIFF
--- a/app/Console/Commands/EnsureLegacyPermissionTables.php
+++ b/app/Console/Commands/EnsureLegacyPermissionTables.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Database\Seeders\PermissionCatalogSeeder;
+use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\PermissionRegistrar;
+
+final class EnsureLegacyPermissionTables extends Command
+{
+    protected $signature = 'legacy:ensure-permission-tables {--seed : Seed the application permission catalog}';
+
+    protected $description = 'Create missing Spatie permission tables on the configured legacy permission connection.';
+
+    public function handle(): int
+    {
+        $this->prepareSqliteDatabase();
+
+        $schema = Schema::connection(config('permission.connection', 'legacy'));
+        $tables = config('permission.table_names', []);
+        $columns = config('permission.column_names', []);
+
+        $this->ensureTableConfig($tables);
+
+        $pivotRole = $columns['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columns['permission_pivot_key'] ?? 'permission_id';
+        $modelMorphKey = $columns['model_morph_key'] ?? 'model_id';
+
+        $this->ensurePermissions($schema, $tables['permissions']);
+        $this->ensureRoles($schema, $tables['roles']);
+        $this->ensureModelHasPermissions($schema, $tables['model_has_permissions'], $pivotPermission, $modelMorphKey);
+        $this->ensureModelHasRoles($schema, $tables['model_has_roles'], $pivotRole, $modelMorphKey);
+        $this->ensureRoleHasPermissions($schema, $tables['role_has_permissions'], $pivotPermission, $pivotRole);
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        if ($this->option('seed')) {
+            $this->call('db:seed', ['--class' => PermissionCatalogSeeder::class, '--force' => true]);
+        }
+
+        $this->info('Legacy permission tables are ready.');
+
+        return self::SUCCESS;
+    }
+
+    private function prepareSqliteDatabase(): void
+    {
+        $connection = (string) config('permission.connection', 'legacy');
+
+        $this->prepareSqliteConnection(config('database.default'));
+        $this->prepareSqliteConnection($connection);
+    }
+
+    private function prepareSqliteConnection(?string $connection): void
+    {
+        if (! is_string($connection) || $connection === '') {
+            return;
+        }
+
+        if (config("database.connections.{$connection}.driver") !== 'sqlite') {
+            return;
+        }
+
+        $database = config("database.connections.{$connection}.database");
+
+        if (! is_string($database) || $database === '' || $database === ':memory:' || file_exists($database)) {
+            return;
+        }
+
+        $directory = dirname($database);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+
+        touch($database);
+    }
+
+    /**
+     * @param  array<string, string>  $tables
+     */
+    private function ensureTableConfig(array $tables): void
+    {
+        $required = ['permissions', 'roles', 'model_has_permissions', 'model_has_roles', 'role_has_permissions'];
+        $missing = array_values(array_filter($required, fn (string $key): bool => empty($tables[$key])));
+
+        if ($missing !== []) {
+            throw new \RuntimeException('Missing permission table config keys: '.implode(', ', $missing));
+        }
+    }
+
+    private function ensurePermissions(Builder $schema, string $tableName): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, ['id', 'name', 'guard_name']);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+    }
+
+    private function ensureRoles(Builder $schema, string $tableName): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, ['id', 'name', 'guard_name']);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+    }
+
+    private function ensureModelHasPermissions(Builder $schema, string $tableName, string $pivotPermission, string $modelMorphKey): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, [$pivotPermission, $modelMorphKey, 'model_type']);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table) use ($pivotPermission, $modelMorphKey): void {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->string('model_type');
+            $table->unsignedBigInteger($modelMorphKey);
+            $table->index([$modelMorphKey, 'model_type'], 'model_has_permissions_model_id_model_type_index');
+            $table->primary([$pivotPermission, $modelMorphKey, 'model_type'], 'model_has_permissions_permission_model_type_primary');
+        });
+    }
+
+    private function ensureModelHasRoles(Builder $schema, string $tableName, string $pivotRole, string $modelMorphKey): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, [$pivotRole, $modelMorphKey, 'model_type']);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table) use ($pivotRole, $modelMorphKey): void {
+            $table->unsignedBigInteger($pivotRole);
+            $table->string('model_type');
+            $table->unsignedBigInteger($modelMorphKey);
+            $table->index([$modelMorphKey, 'model_type'], 'model_has_roles_model_id_model_type_index');
+            $table->primary([$pivotRole, $modelMorphKey, 'model_type'], 'model_has_roles_role_model_type_primary');
+        });
+    }
+
+    private function ensureRoleHasPermissions(Builder $schema, string $tableName, string $pivotPermission, string $pivotRole): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, [$pivotPermission, $pivotRole]);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table) use ($pivotPermission, $pivotRole): void {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+    }
+
+    /**
+     * @param  list<string>  $requiredColumns
+     */
+    private function guardRequiredColumns(Builder $schema, string $tableName, array $requiredColumns): void
+    {
+        $existingColumns = $schema->getColumnListing($tableName);
+        $missingColumns = array_values(array_diff($requiredColumns, $existingColumns));
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Existing %s table is missing required column(s): %s.',
+            $schema->getConnection()->getTablePrefix().$tableName,
+            implode(', ', $missingColumns),
+        ));
+    }
+}

--- a/app/Console/Commands/EnsureOsticket2SupportTables.php
+++ b/app/Console/Commands/EnsureOsticket2SupportTables.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+
+final class EnsureOsticket2SupportTables extends Command
+{
+    protected $signature = 'osticket2:ensure-support-tables';
+
+    protected $description = 'Create or backfill app support tables on the configured osticket2 connection.';
+
+    public function handle(): int
+    {
+        $this->prepareSqliteDatabase();
+
+        $schema = Schema::connection('osticket2');
+
+        $this->ensureStaffTwoFactor($schema);
+        $this->ensureStaffAuthMigrations($schema);
+        $this->ensureStaffPreferences($schema);
+        $this->ensureAccessLog($schema);
+        $this->ensureAdminAuditLog($schema);
+        $this->ensureMigrationProgress($schema);
+
+        $this->info('osticket2 support tables are ready.');
+
+        return self::SUCCESS;
+    }
+
+    private function prepareSqliteDatabase(): void
+    {
+        if (config('database.connections.osticket2.driver') !== 'sqlite') {
+            return;
+        }
+
+        $database = config('database.connections.osticket2.database');
+
+        if (! is_string($database) || $database === '' || $database === ':memory:' || file_exists($database)) {
+            return;
+        }
+
+        $directory = dirname($database);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+
+        touch($database);
+    }
+
+    private function ensureStaffTwoFactor(Builder $schema): void
+    {
+        if (! $schema->hasTable('staff_two_factor')) {
+            $schema->create('staff_two_factor', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->unique();
+                $table->text('two_factor_secret')->nullable();
+                $table->text('two_factor_recovery_codes')->nullable();
+                $table->timestamp('two_factor_confirmed_at')->nullable();
+                $table->timestamps();
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'staff_two_factor', ['id', 'staff_id']);
+        $this->addMissingColumns($schema, 'staff_two_factor', [
+            'two_factor_secret' => fn (Blueprint $table) => $table->text('two_factor_secret')->nullable(),
+            'two_factor_recovery_codes' => fn (Blueprint $table) => $table->text('two_factor_recovery_codes')->nullable(),
+            'two_factor_confirmed_at' => fn (Blueprint $table) => $table->timestamp('two_factor_confirmed_at')->nullable(),
+            'created_at' => fn (Blueprint $table) => $table->timestamp('created_at')->nullable(),
+            'updated_at' => fn (Blueprint $table) => $table->timestamp('updated_at')->nullable(),
+        ]);
+    }
+
+    private function ensureStaffAuthMigrations(Builder $schema): void
+    {
+        if (! $schema->hasTable('staff_auth_migrations')) {
+            $schema->create('staff_auth_migrations', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->unique();
+                $table->timestamp('migrated_at')->nullable();
+                $table->timestamp('must_upgrade_after')->nullable();
+                $table->string('upgrade_method', 32)->nullable();
+                $table->timestamp('dismissed_migration_banner_at')->nullable();
+                $table->timestamps();
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'staff_auth_migrations', ['id', 'staff_id']);
+        $this->addMissingColumns($schema, 'staff_auth_migrations', [
+            'migrated_at' => fn (Blueprint $table) => $table->timestamp('migrated_at')->nullable(),
+            'must_upgrade_after' => fn (Blueprint $table) => $table->timestamp('must_upgrade_after')->nullable(),
+            'upgrade_method' => fn (Blueprint $table) => $table->string('upgrade_method', 32)->nullable(),
+            'dismissed_migration_banner_at' => fn (Blueprint $table) => $table->timestamp('dismissed_migration_banner_at')->nullable(),
+            'created_at' => fn (Blueprint $table) => $table->timestamp('created_at')->nullable(),
+            'updated_at' => fn (Blueprint $table) => $table->timestamp('updated_at')->nullable(),
+        ]);
+    }
+
+    private function ensureStaffPreferences(Builder $schema): void
+    {
+        if (! $schema->hasTable('staff_preferences')) {
+            $schema->create('staff_preferences', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->unique();
+                $table->string('theme', 16)->default('system');
+                $table->string('language', 16)->nullable();
+                $table->string('timezone', 64)->nullable();
+                $table->json('notifications')->nullable();
+                $table->string('last_active_panel', 16)->default('scp');
+                $table->string('default_scp_tab', 64)->nullable();
+                $table->string('default_admin_tab', 64)->nullable();
+                $table->boolean('created_by_migration_2026_04_26_000100')->default(true);
+                $table->boolean('created_by_migration_2026_05_02_000100')->default(true);
+                $table->timestamps();
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'staff_preferences', ['id', 'staff_id']);
+        $this->addMissingColumns($schema, 'staff_preferences', [
+            'theme' => fn (Blueprint $table) => $table->string('theme', 16)->default('system'),
+            'language' => fn (Blueprint $table) => $table->string('language', 16)->nullable(),
+            'timezone' => fn (Blueprint $table) => $table->string('timezone', 64)->nullable(),
+            'notifications' => fn (Blueprint $table) => $table->json('notifications')->nullable(),
+            'last_active_panel' => fn (Blueprint $table) => $table->string('last_active_panel', 16)->default('scp'),
+            'default_scp_tab' => fn (Blueprint $table) => $table->string('default_scp_tab', 64)->nullable(),
+            'default_admin_tab' => fn (Blueprint $table) => $table->string('default_admin_tab', 64)->nullable(),
+            'created_at' => fn (Blueprint $table) => $table->timestamp('created_at')->nullable(),
+            'updated_at' => fn (Blueprint $table) => $table->timestamp('updated_at')->nullable(),
+        ]);
+    }
+
+    private function ensureAccessLog(Builder $schema): void
+    {
+        if (! $schema->hasTable('access_log')) {
+            $schema->create('access_log', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->index();
+                $table->string('action', 128);
+                $table->string('subject_type', 64)->nullable();
+                $table->unsignedBigInteger('subject_id')->nullable();
+                $table->json('metadata')->nullable();
+                $table->string('ip_address', 45)->nullable();
+                $table->text('user_agent')->nullable();
+                $table->boolean('created_by_migration_2026_04_26_000200')->default(true);
+                $table->timestamp('created_at')->useCurrent();
+
+                $table->index(['subject_type', 'subject_id']);
+                $table->index('created_at');
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'access_log', ['id', 'staff_id', 'action', 'created_at']);
+        $this->addMissingColumns($schema, 'access_log', [
+            'subject_type' => fn (Blueprint $table) => $table->string('subject_type', 64)->nullable(),
+            'subject_id' => fn (Blueprint $table) => $table->unsignedBigInteger('subject_id')->nullable(),
+            'metadata' => fn (Blueprint $table) => $table->json('metadata')->nullable(),
+            'ip_address' => fn (Blueprint $table) => $table->string('ip_address', 45)->nullable(),
+            'user_agent' => fn (Blueprint $table) => $table->text('user_agent')->nullable(),
+        ]);
+    }
+
+    private function ensureAdminAuditLog(Builder $schema): void
+    {
+        if (! $schema->hasTable('admin_audit_log')) {
+            $schema->create('admin_audit_log', function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('actor_id');
+                $table->string('action', 64);
+                $table->string('subject_type', 64);
+                $table->unsignedBigInteger('subject_id');
+                $table->json('before')->nullable();
+                $table->json('after')->nullable();
+                $table->json('metadata')->nullable();
+                $table->string('ip_address', 45)->nullable();
+                $table->string('user_agent', 255)->nullable();
+                $table->timestamp('created_at')->useCurrent();
+
+                $table->index(['subject_type', 'subject_id', 'created_at'], 'admin_audit_log_subject_created_idx');
+                $table->index(['actor_id', 'created_at'], 'admin_audit_log_actor_created_idx');
+                $table->index(['action', 'created_at'], 'admin_audit_log_action_created_idx');
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'admin_audit_log', ['id', 'actor_id', 'action', 'subject_type', 'subject_id', 'created_at']);
+    }
+
+    private function ensureMigrationProgress(Builder $schema): void
+    {
+        if ($schema->hasTable('_migration_progress')) {
+            $this->guardRequiredColumns($schema, '_migration_progress', ['table_name', 'status']);
+
+            return;
+        }
+
+        $schema->create('_migration_progress', function (Blueprint $table): void {
+            $table->string('table_name', 120)->primary();
+            $table->string('last_id', 255)->nullable();
+            $table->string('status', 32)->default('pending');
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * @param  array<string, callable(Blueprint): mixed>  $columns
+     */
+    private function addMissingColumns(Builder $schema, string $tableName, array $columns): void
+    {
+        $existingColumns = $schema->getColumnListing($tableName);
+        $missingColumns = array_diff(array_keys($columns), $existingColumns);
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        $schema->table($tableName, function (Blueprint $table) use ($columns, $missingColumns): void {
+            foreach ($missingColumns as $column) {
+                $columns[$column]($table);
+            }
+        });
+    }
+
+    /**
+     * @param  list<string>  $requiredColumns
+     */
+    private function guardRequiredColumns(Builder $schema, string $tableName, array $requiredColumns): void
+    {
+        $existingColumns = $schema->getColumnListing($tableName);
+        $missingColumns = array_values(array_diff($requiredColumns, $existingColumns));
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Existing %s table is missing required column(s): %s.',
+            $schema->getConnection()->getTablePrefix().$tableName,
+            implode(', ', $missingColumns),
+        ));
+    }
+}

--- a/app/Console/Commands/ScpPhase2bParityCheck.php
+++ b/app/Console/Commands/ScpPhase2bParityCheck.php
@@ -46,19 +46,21 @@ final class ScpPhase2bParityCheck extends Command
 
         foreach ($ticketIds as $ticketId) {
             // Find ticket on legacy connection
-            $ticket = Ticket::on('legacy')->find($ticketId);
+            $ticket = Ticket::on('legacy')->withoutGlobalScopes()->find($ticketId);
 
-            if (!$ticket) {
+            if (! $ticket) {
                 $this->error("Ticket {$ticketId} not found on legacy connection");
                 $errorCount++;
+
                 continue;
             }
 
             // Get thread for this ticket
             $thread = $ticket->thread()->first();
 
-            if (!$thread) {
+            if (! $thread) {
                 $this->warn("Ticket {$ticketId} has no thread");
+
                 continue;
             }
 

--- a/app/Console/Commands/ScpPhase2bParityCheck.php
+++ b/app/Console/Commands/ScpPhase2bParityCheck.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Scp\ScpActionLog;
+use App\Models\Ticket;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class ScpPhase2bParityCheck extends Command
+{
+    protected $signature = 'scp:phase-2b-parity-check
+        {--ticket= : Specific ticket ID}
+        {--since= : ISO date filter}
+        {--sample=50 : Random sample size}';
+
+    protected $description = 'Verify legacy still renders tickets touched by phase 2b without errors.';
+
+    public function handle(): int
+    {
+        // Parse --since option, default to 1 day ago
+        $since = $this->option('since')
+            ? Carbon::parse($this->option('since'))
+            : Carbon::now()->subDay();
+
+        // Determine ticket IDs to check
+        $ticketIds = [];
+        if ($this->option('ticket')) {
+            $ticketIds = [(int) $this->option('ticket')];
+        } else {
+            $ticketIds = ScpActionLog::query()
+                ->whereNotNull('ticket_id')
+                ->where('outcome', 'success')
+                ->where('created_at', '>=', $since)
+                ->distinct()
+                ->limit((int) $this->option('sample'))
+                ->pluck('ticket_id')
+                ->toArray();
+        }
+
+        $errorCount = 0;
+        $ticketCount = count($ticketIds);
+
+        foreach ($ticketIds as $ticketId) {
+            // Find ticket on legacy connection
+            $ticket = Ticket::on('legacy')->find($ticketId);
+
+            if (!$ticket) {
+                $this->error("Ticket {$ticketId} not found on legacy connection");
+                $errorCount++;
+                continue;
+            }
+
+            // Get thread for this ticket
+            $thread = $ticket->thread()->first();
+
+            if (!$thread) {
+                $this->warn("Ticket {$ticketId} has no thread");
+                continue;
+            }
+
+            // Query thread_event rows for this thread
+            $events = DB::connection('legacy')
+                ->table('thread_event')
+                ->where('thread_id', $thread->id)
+                ->get();
+
+            foreach ($events as $event) {
+                // Verify JSON validity if data is not null/empty
+                if ($event->data !== null && $event->data !== '') {
+                    $decoded = json_decode($event->data, true);
+                    if ($decoded === null && $event->data !== 'null') {
+                        $this->error("Ticket {$ticketId}, thread {$thread->id}, event {$event->id}: invalid JSON in data column");
+                        $errorCount++;
+                    }
+                }
+            }
+        }
+
+        $this->info("Parity check complete. {$ticketCount} tickets, {$errorCount} errors.");
+
+        return $errorCount === 0 ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/app/Exceptions/ForbiddenStatusTransition.php
+++ b/app/Exceptions/ForbiddenStatusTransition.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Illuminate\Http\JsonResponse;
+use RuntimeException;
+
+final class ForbiddenStatusTransition extends RuntimeException
+{
+    public function __construct(
+        public readonly string $fromState,
+        public readonly string $toState,
+    ) {
+        parent::__construct("Transition from {$fromState} to {$toState} is forbidden.");
+    }
+
+    public function render(): JsonResponse
+    {
+        return response()->json(
+            data: [
+                'message' => 'Status transition not allowed.',
+                'errors' => [
+                    'status_id' => ["Transition from {$this->fromState} to {$this->toState} is forbidden."],
+                ],
+            ],
+            status: 422,
+        );
+    }
+}

--- a/app/Exceptions/TicketLockedException.php
+++ b/app/Exceptions/TicketLockedException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Illuminate\Http\JsonResponse;
+use RuntimeException;
+
+final class TicketLockedException extends RuntimeException
+{
+    public function __construct(
+        public readonly int $ticketId,
+        public readonly int $heldByStaffId,
+        public readonly string $expiresAt,
+    ) {
+        parent::__construct(
+            message: "Ticket {$ticketId} is locked by staff {$heldByStaffId} until {$expiresAt}"
+        );
+    }
+
+    public function render(): JsonResponse
+    {
+        return response()->json(
+            data: [
+                'message' => 'Ticket is locked by another staff member.',
+                'held_by_staff_id' => $this->heldByStaffId,
+                'expires_at' => $this->expiresAt,
+            ],
+            status: 423,
+        );
+    }
+}

--- a/app/Exceptions/TicketModifiedConcurrentlyException.php
+++ b/app/Exceptions/TicketModifiedConcurrentlyException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Illuminate\Http\JsonResponse;
+use RuntimeException;
+
+final class TicketModifiedConcurrentlyException extends RuntimeException
+{
+    public function __construct(
+        public readonly int $ticketId,
+        public readonly string $currentUpdated,
+    ) {
+        parent::__construct(
+            message: "Ticket {$ticketId} was modified concurrently (now {$currentUpdated})"
+        );
+    }
+
+    public function render(): JsonResponse
+    {
+        return response()->json(
+            data: [
+                'message' => 'Ticket was modified since you opened it. Please reload.',
+                'current_updated' => $this->currentUpdated,
+            ],
+            status: 409,
+        );
+    }
+}

--- a/app/Http/Controllers/Scp/Queues/QueueColumnsController.php
+++ b/app/Http/Controllers/Scp/Queues/QueueColumnsController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scp\Queues;
+
+use App\Http\Controllers\Controller;
+use App\Models\Queue;
+use App\Services\Scp\Queues\QueueColumnsService;
+use App\Services\Scp\Tickets\ActionLogger;
+use Illuminate\Http\Request;
+
+final class QueueColumnsController extends Controller
+{
+    public function __construct(
+        private readonly QueueColumnsService $columns,
+        private readonly ActionLogger $logger,
+    ) {}
+
+    public function update(Request $request, Queue $queue): \Illuminate\Http\RedirectResponse
+    {
+        $data = $request->validate([
+            'columns' => 'required|array|min:1',
+            'columns.*.column_id' => 'required|integer',
+            'columns.*.sort' => 'nullable|integer',
+            'columns.*.width' => 'nullable|integer|min:50|max:1000',
+            'columns.*.heading' => 'nullable|string|max:80',
+        ]);
+
+        $staff = $request->user('staff');
+
+        $this->columns->update($staff, $queue, $data['columns']);
+
+        $this->logger->record(
+            staff: $staff,
+            action: 'queue.columns_changed',
+            outcome: 'success',
+            httpStatus: 302,
+            queueId: $queue->id,
+            request: $request,
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Scp/Queues/QueueConfigController.php
+++ b/app/Http/Controllers/Scp/Queues/QueueConfigController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scp\Queues;
+
+use App\Http\Controllers\Controller;
+use App\Models\Queue;
+use App\Services\Scp\Queues\QueueConfigService;
+use App\Services\Scp\Tickets\ActionLogger;
+use Illuminate\Http\Request;
+
+final class QueueConfigController extends Controller
+{
+    public function __construct(
+        private readonly QueueConfigService $configs,
+        private readonly ActionLogger $logger,
+    ) {}
+
+    public function update(Request $request, Queue $queue): \Illuminate\Http\RedirectResponse
+    {
+        $data = $request->validate([
+            'sort_id' => 'nullable|integer',
+            'filter' => 'nullable|string|max:255',
+            'criteria_inheritance' => 'nullable|boolean',
+            'columns_inheritance' => 'nullable|boolean',
+            'sort_inheritance' => 'nullable|boolean',
+        ]);
+
+        $staff = $request->user('staff');
+
+        $this->configs->update($staff, $queue, $data);
+
+        $this->logger->record(
+            staff: $staff,
+            action: 'queue.config_changed',
+            outcome: 'success',
+            httpStatus: 302,
+            queueId: $queue->id,
+            request: $request,
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Scp/Tickets/AssignmentController.php
+++ b/app/Http/Controllers/Scp/Tickets/AssignmentController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scp\Tickets;
+
+use App\Http\Controllers\Controller;
+use App\Models\Ticket;
+use App\Services\Scp\Tickets\ActionLogger;
+use App\Services\Scp\Tickets\AssignmentService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+final class AssignmentController extends Controller
+{
+    public function __construct(
+        private readonly AssignmentService $assignments,
+        private readonly ActionLogger $audit,
+    ) {}
+
+    public function store(Request $request, Ticket $ticket): RedirectResponse
+    {
+        $staff = $request->user('staff');
+        $this->authorize('assign', $ticket);
+
+        $validated = $request->validate([
+            'assignee_type' => 'required|in:staff,team',
+            'assignee_id' => 'required|integer|min:1',
+            'comments' => 'nullable|string|max:65535',
+            'expected_updated' => 'required|string',
+        ]);
+
+        $thread = $ticket->thread()->firstOrFail();
+
+        $this->assignments->assign(
+            $ticket,
+            $thread,
+            $staff,
+            $validated['assignee_type'],
+            $validated['assignee_id'],
+            $validated['comments'] ?? null,
+            $validated['expected_updated'],
+        );
+
+        $this->audit->record(
+            staff: $staff,
+            action: 'ticket.assigned',
+            outcome: 'success',
+            httpStatus: 302,
+            ticketId: $ticket->ticket_id,
+            request: $request,
+        );
+
+        return back();
+    }
+
+    public function destroy(Request $request, Ticket $ticket): RedirectResponse
+    {
+        $staff = $request->user('staff');
+        $this->authorize('assign', $ticket);
+
+        $validated = $request->validate([
+            'comments' => 'nullable|string|max:65535',
+            'expected_updated' => 'required|string',
+        ]);
+
+        $thread = $ticket->thread()->firstOrFail();
+
+        $this->assignments->release(
+            $ticket,
+            $thread,
+            $staff,
+            $validated['comments'] ?? null,
+            $validated['expected_updated'],
+        );
+
+        $this->audit->record(
+            staff: $staff,
+            action: 'ticket.unassigned',
+            outcome: 'success',
+            httpStatus: 302,
+            ticketId: $ticket->ticket_id,
+            request: $request,
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Scp/Tickets/DraftController.php
+++ b/app/Http/Controllers/Scp/Tickets/DraftController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scp\Tickets;
+
+use App\Http\Controllers\Controller;
+use App\Models\Ticket;
+use App\Services\Scp\Tickets\DraftService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class DraftController extends Controller
+{
+    public function __construct(
+        private readonly DraftService $drafts,
+    ) {}
+
+    public function show(Request $request, Ticket $ticket): JsonResponse
+    {
+        $staff = $request->user('staff');
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+
+        $draft = $this->drafts->find($staff, $namespace);
+
+        if ($draft === null) {
+            return response()->json([
+                'body' => '',
+                'updated' => null,
+            ]);
+        }
+
+        return response()->json([
+            'body' => $draft->body,
+            'updated' => $draft->updated,
+        ]);
+    }
+
+    public function store(Request $request, Ticket $ticket): JsonResponse
+    {
+        $staff = $request->user('staff');
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+
+        $validated = $request->validate([
+            'body' => 'required|string',
+        ]);
+
+        $draft = $this->drafts->upsert($staff, $namespace, $validated['body']);
+
+        return response()->json([
+            'body' => $draft->body,
+            'updated' => $draft->updated,
+        ], 201);
+    }
+
+    public function update(Request $request, Ticket $ticket): JsonResponse
+    {
+        $staff = $request->user('staff');
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+
+        $validated = $request->validate([
+            'body' => 'required|string',
+        ]);
+
+        $draft = $this->drafts->upsert($staff, $namespace, $validated['body']);
+
+        return response()->json([
+            'body' => $draft->body,
+            'updated' => $draft->updated,
+        ]);
+    }
+
+    public function destroy(Request $request, Ticket $ticket): JsonResponse
+    {
+        $staff = $request->user('staff');
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+
+        $this->drafts->discard($staff, $namespace);
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Http/Controllers/Scp/Tickets/LockController.php
+++ b/app/Http/Controllers/Scp/Tickets/LockController.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scp\Tickets;
+
+use App\Exceptions\TicketLockedException;
+use App\Http\Controllers\Controller;
+use App\Models\Ticket;
+use App\Services\Scp\Tickets\ActionLogger;
+use App\Services\Scp\Tickets\LockService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class LockController extends Controller
+{
+    public function __construct(
+        private readonly LockService $locks,
+        private readonly ActionLogger $audit,
+    ) {}
+
+    public function acquire(Request $request, Ticket $ticket): JsonResponse
+    {
+        $staff = $request->user('staff');
+
+        try {
+            $lock = $this->locks->acquire($staff, $ticket);
+
+            $this->audit->record(
+                staff: $staff,
+                action: 'lock.acquired',
+                outcome: 'success',
+                httpStatus: 200,
+                ticketId: $ticket->ticket_id,
+                lockId: (string) $lock->lock_id,
+                request: $request,
+            );
+
+            return response()->json([
+                'lock_id' => (string) $lock->lock_id,
+                'held_by_staff_id' => (int) $lock->staff_id,
+                'expires_at' => $lock->expire,
+            ]);
+        } catch (TicketLockedException $e) {
+            $this->audit->recordFailure(
+                staff: $staff,
+                action: 'lock.acquired',
+                httpStatus: 423,
+                ticketId: $ticket->ticket_id,
+                errorClass: TicketLockedException::class,
+                request: $request,
+            );
+
+            throw $e;
+        }
+    }
+
+    public function renew(Request $request, Ticket $ticket): JsonResponse
+    {
+        $staff = $request->user('staff');
+
+        try {
+            $lock = $this->locks->renew($staff, $ticket);
+
+            $this->audit->record(
+                staff: $staff,
+                action: 'lock.renewed',
+                outcome: 'success',
+                httpStatus: 200,
+                ticketId: $ticket->ticket_id,
+                lockId: (string) $lock->lock_id,
+                request: $request,
+            );
+
+            return response()->json([
+                'lock_id' => (string) $lock->lock_id,
+                'held_by_staff_id' => (int) $lock->staff_id,
+                'expires_at' => $lock->expire,
+            ]);
+        } catch (TicketLockedException $e) {
+            $this->audit->recordFailure(
+                staff: $staff,
+                action: 'lock.renewed',
+                httpStatus: 423,
+                ticketId: $ticket->ticket_id,
+                errorClass: TicketLockedException::class,
+                request: $request,
+            );
+
+            throw $e;
+        }
+    }
+
+    public function release(Request $request, Ticket $ticket): JsonResponse
+    {
+        $staff = $request->user('staff');
+
+        $this->locks->release($staff, $ticket);
+
+        $this->audit->record(
+            staff: $staff,
+            action: 'lock.released',
+            outcome: 'success',
+            httpStatus: 204,
+            ticketId: $ticket->ticket_id,
+            request: $request,
+        );
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Http/Controllers/Scp/Tickets/NoteController.php
+++ b/app/Http/Controllers/Scp/Tickets/NoteController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scp\Tickets;
+
+use App\Http\Controllers\Controller;
+use App\Models\Ticket;
+use App\Services\Scp\Tickets\ActionLogger;
+use App\Services\Scp\Tickets\DraftService;
+use App\Services\Scp\Tickets\NotePostingService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+final class NoteController extends Controller
+{
+    public function __construct(
+        private readonly NotePostingService $notes,
+        private readonly DraftService $drafts,
+        private readonly ActionLogger $audit,
+    ) {}
+
+    public function store(Request $request, Ticket $ticket): RedirectResponse
+    {
+        $staff = $request->user('staff');
+        $this->authorize('postNote', $ticket);
+        $validated = $request->validate([
+            'body' => 'required|string|max:65535',
+            'format' => 'required|in:html,text',
+            'expected_updated' => 'required|string',
+        ]);
+        $thread = $ticket->thread()->firstOrFail();
+        $this->notes->post($ticket, $thread, $staff, $validated['body'], $validated['format'], $validated['expected_updated']);
+        $this->drafts->discard($staff, "ticket.note.{$ticket->ticket_id}");
+        $this->audit->record(
+            staff: $staff,
+            action: 'note.posted',
+            outcome: 'success',
+            httpStatus: 302,
+            ticketId: $ticket->ticket_id,
+            request: $request,
+        );
+        return back()->with('success', 'Note posted.');
+    }
+}

--- a/app/Http/Controllers/Scp/Tickets/StatusController.php
+++ b/app/Http/Controllers/Scp/Tickets/StatusController.php
@@ -8,9 +8,10 @@ use App\Exceptions\ForbiddenStatusTransition;
 use App\Exceptions\TicketModifiedConcurrentlyException;
 use App\Http\Controllers\Controller;
 use App\Models\Ticket;
-use App\Models\Thread;
 use App\Services\Scp\Tickets\ActionLogger;
 use App\Services\Scp\Tickets\StatusTransitionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 final class StatusController extends Controller
@@ -20,7 +21,7 @@ final class StatusController extends Controller
         private readonly ActionLogger $logger,
     ) {}
 
-    public function store(Request $request, Ticket $ticket): \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+    public function store(Request $request, Ticket $ticket): RedirectResponse|JsonResponse
     {
         $this->authorize('setStatus', $ticket);
 
@@ -31,10 +32,7 @@ final class StatusController extends Controller
         ]);
 
         $staff = $request->user('staff');
-        $thread = Thread::on('legacy')
-            ->where('object_id', $ticket->ticket_id)
-            ->where('object_type', 'A')
-            ->firstOrFail();
+        $thread = $ticket->thread()->firstOrFail();
 
         try {
             $this->transitions->transition(

--- a/app/Http/Controllers/Scp/Tickets/StatusController.php
+++ b/app/Http/Controllers/Scp/Tickets/StatusController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scp\Tickets;
+
+use App\Exceptions\ForbiddenStatusTransition;
+use App\Exceptions\TicketModifiedConcurrentlyException;
+use App\Http\Controllers\Controller;
+use App\Models\Ticket;
+use App\Models\Thread;
+use App\Services\Scp\Tickets\ActionLogger;
+use App\Services\Scp\Tickets\StatusTransitionService;
+use Illuminate\Http\Request;
+
+final class StatusController extends Controller
+{
+    public function __construct(
+        private readonly StatusTransitionService $transitions,
+        private readonly ActionLogger $logger,
+    ) {}
+
+    public function store(Request $request, Ticket $ticket): \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+    {
+        $this->authorize('setStatus', $ticket);
+
+        $data = $request->validate([
+            'status_id' => 'required|integer|exists:legacy.ticket_status,id',
+            'comments' => 'nullable|string|max:65535',
+            'expected_updated' => 'required|string',
+        ]);
+
+        $staff = $request->user('staff');
+        $thread = Thread::on('legacy')
+            ->where('object_id', $ticket->ticket_id)
+            ->where('object_type', 'A')
+            ->firstOrFail();
+
+        try {
+            $this->transitions->transition(
+                ticket: $ticket,
+                thread: $thread,
+                caller: $staff,
+                targetStatusId: $data['status_id'],
+                comments: $data['comments'] ?? null,
+                expectedUpdated: $data['expected_updated'],
+            );
+
+            $this->logger->record(
+                staff: $staff,
+                action: 'status.changed',
+                outcome: 'success',
+                httpStatus: 302,
+                ticketId: $ticket->ticket_id,
+                request: $request,
+            );
+
+            return back();
+        } catch (ForbiddenStatusTransition) {
+            $this->logger->recordFailure(
+                staff: $staff,
+                action: 'status.changed',
+                httpStatus: 422,
+                ticketId: $ticket->ticket_id,
+                errorClass: ForbiddenStatusTransition::class,
+                request: $request,
+            );
+
+            return response()->json([
+                'message' => 'Forbidden status transition',
+            ], 422);
+        } catch (TicketModifiedConcurrentlyException) {
+            $this->logger->recordFailure(
+                staff: $staff,
+                action: 'status.changed',
+                httpStatus: 409,
+                ticketId: $ticket->ticket_id,
+                errorClass: TicketModifiedConcurrentlyException::class,
+                request: $request,
+            );
+
+            return response()->json([
+                'message' => 'Ticket was modified',
+            ], 409);
+        }
+    }
+}

--- a/app/Http/Middleware/EnforceTicketLock.php
+++ b/app/Http/Middleware/EnforceTicketLock.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Ticket;
+use App\Services\Scp\Tickets\LockService;
+use Closure;
+use Illuminate\Http\Request;
+
+final class EnforceTicketLock
+{
+    public function __construct(
+        private readonly LockService $locks,
+    ) {}
+
+    public function handle(Request $request, Closure $next)
+    {
+        $ticket = $request->route('ticket');
+
+        if (! $ticket instanceof Ticket) {
+            $ticket = Ticket::findOrFail($ticket);
+        }
+
+        $staff = $request->user('staff');
+
+        $this->locks->assertHeldBy($staff, $ticket);
+
+        return $next($request);
+    }
+}

--- a/app/Models/LegacyConfig.php
+++ b/app/Models/LegacyConfig.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+class LegacyConfig extends LegacyModel
+{
+    protected $table = 'config';
+    protected $primaryKey = 'id';
+    public $timestamps = false;
+}

--- a/app/Models/Queue.php
+++ b/app/Models/Queue.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use Database\Factories\QueueFactory;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 /**
  * Queue model for the legacy osTicket ost_queue table.
@@ -22,6 +24,9 @@ use Illuminate\Database\Eloquent\Collection;
  */
 class Queue extends LegacyModel
 {
+    /** @use HasFactory<QueueFactory> */
+    use HasFactory;
+
     protected $table = 'queue';
 
     protected $primaryKey = 'id';

--- a/app/Models/Scp/ScpActionLog.php
+++ b/app/Models/Scp/ScpActionLog.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Scp;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ScpActionLog extends Model
+{
+    protected $table = 'scp_action_log';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'staff_id',
+        'ticket_id',
+        'thread_id',
+        'queue_id',
+        'action',
+        'outcome',
+        'http_status',
+        'before_state',
+        'after_state',
+        'lock_id',
+        'request_id',
+        'ip_address',
+        'user_agent',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'before_state' => 'array',
+        'after_state' => 'array',
+        'created_at' => 'datetime',
+    ];
+}

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use Database\Factories\ThreadFactory;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -20,6 +22,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class Thread extends LegacyModel
 {
+    use HasFactory;
+
     /**
      * The table associated with the model.
      *
@@ -33,6 +37,11 @@ class Thread extends LegacyModel
      * @var string
      */
     protected $primaryKey = 'id';
+
+    protected static function newFactory(): ThreadFactory
+    {
+        return ThreadFactory::new();
+    }
 
     /**
      * Get the entries for the thread, ordered chronologically.

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Eloquent\Scopes\TicketAccessibleScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
@@ -37,6 +38,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  */
 class Ticket extends LegacyModel
 {
+    use HasFactory;
+
     /**
      * The table associated with the model.
      *

--- a/app/Models/TicketStatus.php
+++ b/app/Models/TicketStatus.php
@@ -1,47 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-
-/**
- * TicketStatus model for the legacy osTicket ost_ticket_status table.
- *
- * @property int $id
- * @property string $name
- * @property string $state
- * @property int $mode
- * @property int $flags
- * @property int $sort
- * @property string $properties
- * @property string $created
- * @property string $updated
- * @property-read Collection<int, Ticket> $tickets
- */
-class TicketStatus extends LegacyModel
+final class TicketStatus extends LegacyModel
 {
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
     protected $table = 'ticket_status';
 
-    /**
-     * The primary key associated with the table.
-     *
-     * @var string
-     */
     protected $primaryKey = 'id';
 
-    /**
-     * Get all tickets with this status.
-     *
-     * @return HasMany<Ticket, $this>
-     */
-    public function tickets()
-    {
-        return $this->hasMany(Ticket::class, 'status_id', 'id');
-    }
+    public $timestamps = false;
 }

--- a/app/Policies/TicketActionPolicy.php
+++ b/app/Policies/TicketActionPolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Services\DepartmentPermissionService;
+
+final class TicketActionPolicy
+{
+    public function __construct(
+        private readonly DepartmentPermissionService $deptService,
+    ) {}
+
+    public function postNote(Staff $staff, Ticket $ticket): bool
+    {
+        return $staff->can('tickets.post-note') && $this->deptService->hasAccessToDepartment($staff, $ticket->dept_id);
+    }
+
+    public function assign(Staff $staff, Ticket $ticket): bool
+    {
+        return $staff->can('tickets.assign') && $this->deptService->hasAccessToDepartment($staff, $ticket->dept_id);
+    }
+
+    public function setStatus(Staff $staff, Ticket $ticket): bool
+    {
+        return $staff->can('tickets.set-status') && $this->deptService->hasAccessToDepartment($staff, $ticket->dept_id);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,6 +26,7 @@ use App\Policies\RolePolicy;
 use App\Policies\SlaPolicy;
 use App\Policies\StaffPolicy;
 use App\Policies\TeamPolicy;
+use App\Policies\TicketActionPolicy;
 use App\Services\Admin\DepartmentRoleResolver;
 use App\Services\LegacyHasher;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -86,6 +87,7 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(EmailTemplate::class, EmailConfigPolicy::class);
         Gate::policy(EmailTemplateGroup::class, EmailConfigPolicy::class);
         Gate::policy(Staff::class, StaffPolicy::class);
+        Gate::policy(Ticket::class, TicketActionPolicy::class);
 
         Event::listen(MessageSending::class, OutboundMailGuard::class);
     }

--- a/app/Services/Scp/Queues/QueueColumnsService.php
+++ b/app/Services/Scp/Queues/QueueColumnsService.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Queues;
+
+use App\Models\Queue;
+use App\Models\Staff;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+final class QueueColumnsService
+{
+    public function update(Staff $staff, Queue $queue, array $columns): void
+    {
+        foreach ($columns as $column) {
+            $columnId = $column['column_id'];
+
+            $exists = DB::connection('legacy')->table('queue_column')
+                ->where('queue_id', $queue->id)
+                ->where('id', $columnId)
+                ->exists();
+
+            if (!$exists) {
+                throw new InvalidArgumentException(
+                    "Column {$columnId} does not belong to queue {$queue->id}"
+                );
+            }
+
+            DB::connection('legacy')->table('queue_columns')->updateOrInsert(
+                [
+                    'queue_id' => $queue->id,
+                    'column_id' => $columnId,
+                    'staff_id' => $staff->staff_id,
+                ],
+                [
+                    'sort' => $column['sort'] ?? 0,
+                    'width' => $column['width'] ?? 0,
+                    'heading' => $column['heading'] ?? '',
+                ]
+            );
+        }
+    }
+}

--- a/app/Services/Scp/Queues/QueueConfigService.php
+++ b/app/Services/Scp/Queues/QueueConfigService.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Queues;
+
+use App\Models\Queue;
+use App\Models\Staff;
+use Illuminate\Support\Facades\DB;
+
+final class QueueConfigService
+{
+    public function update(Staff $staff, Queue $queue, array $config): void
+    {
+        DB::connection('legacy')->table('queue_config')->updateOrInsert(
+            [
+                'queue_id' => $queue->id,
+                'staff_id' => $staff->staff_id,
+            ],
+            [
+                'setting' => json_encode($config),
+            ]
+        );
+    }
+}

--- a/app/Services/Scp/Tickets/ActionLogger.php
+++ b/app/Services/Scp/Tickets/ActionLogger.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use App\Models\Scp\ScpActionLog;
+use App\Models\Staff;
+use Illuminate\Http\Request;
+
+final class ActionLogger
+{
+    /**
+     * Record an action with full context.
+     *
+     * @param Staff $staff
+     * @param string $action
+     * @param string $outcome
+     * @param int $httpStatus
+     * @param int|null $ticketId
+     * @param int|null $threadId
+     * @param int|null $queueId
+     * @param array|null $beforeState
+     * @param array|null $afterState
+     * @param string|null $lockId
+     * @param Request|null $request
+     * @return ScpActionLog
+     */
+    public function record(
+        Staff $staff,
+        string $action,
+        string $outcome,
+        int $httpStatus,
+        ?int $ticketId = null,
+        ?int $threadId = null,
+        ?int $queueId = null,
+        ?array $beforeState = null,
+        ?array $afterState = null,
+        ?string $lockId = null,
+        ?Request $request = null,
+    ): ScpActionLog {
+        $data = [
+            'staff_id' => $staff->staff_id,
+            'action' => $action,
+            'outcome' => $outcome,
+            'http_status' => $httpStatus,
+            'ticket_id' => $ticketId,
+            'thread_id' => $threadId,
+            'queue_id' => $queueId,
+            'before_state' => $beforeState,
+            'after_state' => $afterState,
+            'lock_id' => $lockId,
+        ];
+
+        if ($request !== null) {
+            $data['request_id'] = $request->headers->get('X-Request-Id');
+            $data['ip_address'] = $request->ip();
+            $data['user_agent'] = $request->userAgent();
+        }
+
+        return ScpActionLog::create($data);
+    }
+
+    /**
+     * Record a failed action with error class.
+     *
+     * @param Staff $staff
+     * @param string $action
+     * @param int $httpStatus
+     * @param int|null $ticketId
+     * @param string $errorClass
+     * @param Request|null $request
+     * @return ScpActionLog
+     */
+    public function recordFailure(
+        Staff $staff,
+        string $action,
+        int $httpStatus,
+        ?int $ticketId = null,
+        string $errorClass = '',
+        ?Request $request = null,
+    ): ScpActionLog {
+        return $this->record(
+            staff: $staff,
+            action: $action,
+            outcome: 'failed',
+            httpStatus: $httpStatus,
+            ticketId: $ticketId,
+            beforeState: ['error_class' => $errorClass],
+            request: $request,
+        );
+    }
+}

--- a/app/Services/Scp/Tickets/AssignmentService.php
+++ b/app/Services/Scp/Tickets/AssignmentService.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use App\Exceptions\TicketModifiedConcurrentlyException;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+final class AssignmentService
+{
+    public function __construct(
+        private readonly ThreadEventWriter $threadEvents,
+        private readonly NotePostingService $notePostingService,
+        private readonly TicketCacheUpdater $ticketCacheUpdater,
+    ) {}
+
+    public function assign(
+        Ticket $ticket,
+        Thread $thread,
+        Staff $caller,
+        string $type,
+        int $assigneeId,
+        ?string $comments,
+        string $expectedUpdated,
+    ): void {
+        if (! in_array($type, ['staff', 'team'], true)) {
+            throw new InvalidArgumentException("Unsupported assignment type [{$type}].");
+        }
+
+        DB::connection('legacy')->transaction(function () use ($ticket, $thread, $caller, $type, $assigneeId, $comments, $expectedUpdated): void {
+            $current = $this->lockCurrentTicket($ticket);
+            $before = $this->snapshot($current);
+
+            $this->assertExpectedUpdated($current, $expectedUpdated);
+
+            if ($type === 'staff') {
+                $current->forceFill([
+                    'staff_id' => $assigneeId,
+                    'team_id' => 0,
+                ])->save();
+            } else {
+                $current->forceFill([
+                    'staff_id' => 0,
+                    'team_id' => $assigneeId,
+                ])->save();
+            }
+
+            if ($comments !== null && $comments !== '') {
+                $this->notePostingService->post($current, $thread, $caller, $comments, 'text', $expectedUpdated);
+            }
+
+            $this->threadEvents->record(
+                thread: $thread,
+                eventName: 'assigned',
+                entryId: null,
+                staff: $caller,
+                data: [
+                    'staff' => $type === 'staff' ? ['id' => $assigneeId] : null,
+                    'team' => $type === 'team' ? ['id' => $assigneeId] : null,
+                    'before' => $before,
+                ],
+            );
+
+            $this->ticketCacheUpdater->touch($current, $thread);
+        });
+    }
+
+    public function release(
+        Ticket $ticket,
+        Thread $thread,
+        Staff $caller,
+        ?string $comments,
+        string $expectedUpdated,
+    ): void {
+        DB::connection('legacy')->transaction(function () use ($ticket, $thread, $caller, $comments, $expectedUpdated): void {
+            $current = $this->lockCurrentTicket($ticket);
+            $before = $this->snapshot($current);
+
+            $this->assertExpectedUpdated($current, $expectedUpdated);
+
+            $current->forceFill([
+                'staff_id' => 0,
+                'team_id' => 0,
+            ])->save();
+
+            if ($comments !== null && $comments !== '') {
+                $this->notePostingService->post($current, $thread, $caller, $comments, 'text', $expectedUpdated);
+            }
+
+            $this->threadEvents->record(
+                thread: $thread,
+                eventName: 'released',
+                entryId: null,
+                staff: $caller,
+                data: [
+                    'staff' => null,
+                    'team' => null,
+                    'before' => $before,
+                ],
+            );
+
+            $this->ticketCacheUpdater->touch($current, $thread);
+        });
+    }
+
+    private function assertExpectedUpdated(Ticket $ticket, string $expectedUpdated): void
+    {
+        if ((string) $ticket->updated !== $expectedUpdated) {
+            throw new TicketModifiedConcurrentlyException($ticket->ticket_id, (string) $ticket->updated);
+        }
+    }
+
+    /**
+     * @return array{staff_id:int,team_id:int}
+     */
+    private function snapshot(Ticket $ticket): array
+    {
+        return [
+            'staff_id' => (int) $ticket->staff_id,
+            'team_id' => (int) ($ticket->team_id ?? 0),
+        ];
+    }
+
+    private function lockCurrentTicket(Ticket $ticket): Ticket
+    {
+        $query = Ticket::on('legacy')
+            ->withoutGlobalScopes()
+            ->whereKey($ticket->ticket_id);
+
+        if (DB::connection('legacy')->getDriverName() !== 'sqlite') {
+            $query->lockForUpdate();
+        }
+
+        return $query->firstOrFail();
+    }
+}

--- a/app/Services/Scp/Tickets/DraftService.php
+++ b/app/Services/Scp/Tickets/DraftService.php
@@ -27,11 +27,18 @@ final class DraftService
                 'staff_id' => $staff->staff_id,
                 'namespace' => $namespace,
             ],
-            [
-                'body' => $body,
-                'created' => $now,
-                'updated' => $now,
-            ]
+            function (bool $exists) use ($body, $now): array {
+                $values = [
+                    'body' => $body,
+                    'updated' => $now,
+                ];
+
+                if (! $exists) {
+                    $values['created'] = $now;
+                }
+
+                return $values;
+            },
         );
 
         return $this->find($staff, $namespace);

--- a/app/Services/Scp/Tickets/DraftService.php
+++ b/app/Services/Scp/Tickets/DraftService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use App\Models\Draft;
+use App\Models\Staff;
+use Illuminate\Support\Facades\DB;
+
+final class DraftService
+{
+    public function find(Staff $staff, string $namespace): ?Draft
+    {
+        return Draft::on('legacy')
+            ->where('staff_id', $staff->staff_id)
+            ->where('namespace', $namespace)
+            ->first();
+    }
+
+    public function upsert(Staff $staff, string $namespace, string $body): Draft
+    {
+        $now = now()->toDateTimeString();
+
+        DB::connection('legacy')->table('draft')->updateOrInsert(
+            [
+                'staff_id' => $staff->staff_id,
+                'namespace' => $namespace,
+            ],
+            [
+                'body' => $body,
+                'created' => $now,
+                'updated' => $now,
+            ]
+        );
+
+        return $this->find($staff, $namespace);
+    }
+
+    public function discard(Staff $staff, string $namespace): void
+    {
+        DB::connection('legacy')->table('draft')
+            ->where('staff_id', $staff->staff_id)
+            ->where('namespace', $namespace)
+            ->delete();
+    }
+}

--- a/app/Services/Scp/Tickets/LegacyConfigReader.php
+++ b/app/Services/Scp/Tickets/LegacyConfigReader.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services\Scp\Tickets;
+
+use App\Models\LegacyConfig;
+
+class LegacyConfigReader
+{
+    private const TICKET_LOCK_MODES = [
+        '0' => 'disabled',
+        '1' => 'on_view',
+        '2' => 'on_activity',
+    ];
+
+    private array $cache = [];
+
+    public function ticketLockMode(): string
+    {
+        $value = $this->get('core', 'ticket_lock', '0');
+        return self::TICKET_LOCK_MODES[$value] ?? 'disabled';
+    }
+
+    public function lockTime(): int
+    {
+        $minutes = (int) $this->get('core', 'lock_time', '3');
+        return max(60, $minutes * 60);
+    }
+
+    private function get(string $namespace, string $key, string $default): string
+    {
+        $cacheKey = "$namespace:$key";
+
+        if (! array_key_exists($cacheKey, $this->cache)) {
+            $row = LegacyConfig::on('legacy')
+                ->where('namespace', $namespace)
+                ->where('key', $key)
+                ->value('value');
+            $this->cache[$cacheKey] = $row !== null ? (string) $row : $default;
+        }
+
+        return $this->cache[$cacheKey];
+    }
+}

--- a/app/Services/Scp/Tickets/LockService.php
+++ b/app/Services/Scp/Tickets/LockService.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use App\Exceptions\TicketLockedException;
+use App\Models\Lock;
+use App\Models\Staff;
+use App\Models\Ticket;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class LockService
+{
+    public function __construct(
+        private readonly LegacyConfigReader $config,
+        private readonly ActionLogger $audit,
+    ) {}
+
+    public function acquire(Staff $staff, Ticket $ticket): Lock
+    {
+        $stolenAudit = null;
+
+        $lock = DB::connection('legacy')->transaction(function () use ($staff, $ticket, &$stolenAudit): Lock {
+            $lock = $this->lockQuery($ticket, forUpdate: true)->first();
+            $expiresAt = $this->expiresAt();
+
+            if ($lock === null) {
+                return Lock::on('legacy')->create([
+                    'object_type' => 'T',
+                    'object_id' => $ticket->ticket_id,
+                    'staff_id' => $staff->staff_id,
+                    'expire' => $expiresAt,
+                ]);
+            }
+
+            if ((int) $lock->staff_id === (int) $staff->staff_id) {
+                $lock->forceFill(['expire' => $expiresAt])->save();
+
+                return $lock->refresh();
+            }
+
+            if (! $this->isExpired($lock)) {
+                $this->throwLocked($ticket, $lock);
+            }
+
+            $beforeState = [
+                'staff_id' => (int) $lock->staff_id,
+                'expire' => Carbon::parse($lock->expire)->toDateTimeString(),
+            ];
+
+            $lock->forceFill([
+                'staff_id' => $staff->staff_id,
+                'expire' => $expiresAt,
+            ])->save();
+
+            $lock->refresh();
+
+            $stolenAudit = [
+                'before_state' => $beforeState,
+                'after_state' => [
+                    'staff_id' => (int) $lock->staff_id,
+                    'expire' => Carbon::parse($lock->expire)->toDateTimeString(),
+                ],
+                'lock_id' => (string) $lock->lock_id,
+            ];
+
+            return $lock;
+        });
+
+        if ($stolenAudit !== null) {
+            $this->audit->record(
+                staff: $staff,
+                action: 'lock.stolen',
+                outcome: 'success',
+                httpStatus: 200,
+                ticketId: $ticket->ticket_id,
+                beforeState: $stolenAudit['before_state'],
+                afterState: $stolenAudit['after_state'],
+                lockId: $stolenAudit['lock_id'],
+            );
+        }
+
+        return $lock;
+    }
+
+    public function renew(Staff $staff, Ticket $ticket): Lock
+    {
+        return DB::connection('legacy')->transaction(function () use ($staff, $ticket): Lock {
+            $lock = $this->lockQuery($ticket, forUpdate: true)->first();
+
+            if ($lock === null || $this->isExpired($lock)) {
+                throw new TicketLockedException($ticket->ticket_id, 0, '');
+            }
+
+            if ((int) $lock->staff_id !== (int) $staff->staff_id) {
+                $this->throwLocked($ticket, $lock);
+            }
+
+            $lock->forceFill(['expire' => $this->expiresAt()])->save();
+
+            return $lock->refresh();
+        });
+    }
+
+    public function release(Staff $staff, Ticket $ticket): void
+    {
+        $this->lockQuery($ticket)
+            ->where('staff_id', $staff->staff_id)
+            ->delete();
+    }
+
+    public function assertHeldBy(Staff $staff, Ticket $ticket): void
+    {
+        if ($this->config->ticketLockMode() === 'disabled') {
+            return;
+        }
+
+        $lock = $this->lockQuery($ticket)->first();
+
+        if ($lock === null || $this->isExpired($lock)) {
+            throw new TicketLockedException($ticket->ticket_id, 0, '');
+        }
+
+        if ((int) $lock->staff_id !== (int) $staff->staff_id) {
+            $this->throwLocked($ticket, $lock);
+        }
+    }
+
+    private function lockQuery(Ticket $ticket, bool $forUpdate = false)
+    {
+        $query = Lock::on('legacy')
+            ->where('object_type', 'T')
+            ->where('object_id', $ticket->ticket_id);
+
+        if ($forUpdate && DB::connection('legacy')->getDriverName() !== 'sqlite') {
+            $query->lockForUpdate();
+        }
+
+        return $query;
+    }
+
+    private function expiresAt(): string
+    {
+        return Carbon::now()->addSeconds($this->config->lockTime())->toDateTimeString();
+    }
+
+    private function isExpired(Lock $lock): bool
+    {
+        return Carbon::parse($lock->expire)->lessThanOrEqualTo(Carbon::now());
+    }
+
+    private function throwLocked(Ticket $ticket, Lock $lock): never
+    {
+        throw new TicketLockedException(
+            $ticket->ticket_id,
+            (int) $lock->staff_id,
+            Carbon::parse($lock->expire)->toDateTimeString(),
+        );
+    }
+}

--- a/app/Services/Scp/Tickets/NotePostingService.php
+++ b/app/Services/Scp/Tickets/NotePostingService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use App\Exceptions\TicketModifiedConcurrentlyException;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use App\Models\ThreadEntry;
+use Illuminate\Support\Facades\DB;
+
+final class NotePostingService
+{
+    public function __construct(
+        private readonly ThreadEventWriter $threadEvents,
+        private readonly SearchIndexer $searchIndexer,
+        private readonly TicketCacheUpdater $ticketCacheUpdater,
+    ) {}
+
+    public function post(
+        Ticket $ticket,
+        Thread $thread,
+        Staff $staff,
+        string $body,
+        string $format,
+        string $expectedUpdated,
+    ): ThreadEntry {
+        return DB::connection('legacy')->transaction(function () use ($ticket, $thread, $staff, $body, $format, $expectedUpdated): ThreadEntry {
+            $current = $this->lockCurrentTicket($ticket);
+
+            if ((string) $current->updated !== $expectedUpdated) {
+                throw new TicketModifiedConcurrentlyException($current->ticket_id, (string) $current->updated);
+            }
+
+            $entry = ThreadEntry::on('legacy')->create([
+                'thread_id' => $thread->id,
+                'staff_id' => $staff->staff_id,
+                'type' => 'N',
+                'format' => $format,
+                'body' => $body,
+                'title' => '',
+                'poster' => $staff->displayName(),
+                'created' => now(),
+                'updated' => now(),
+            ]);
+
+            $this->threadEvents->record($thread, 'created', $entry->id, $staff, ['entry_id' => $entry->id]);
+            $this->searchIndexer->index('THE', $entry->id, '', $entry->body ?? '');
+            $this->ticketCacheUpdater->touch($current, $thread);
+
+            return $entry;
+        });
+    }
+
+    private function lockCurrentTicket(Ticket $ticket): Ticket
+    {
+        $query = Ticket::on('legacy')
+            ->withoutGlobalScopes()
+            ->whereKey($ticket->ticket_id);
+
+        if (DB::connection('legacy')->getDriverName() !== 'sqlite') {
+            $query->lockForUpdate();
+        }
+
+        return $query->findOrFail($ticket->ticket_id);
+    }
+}

--- a/app/Services/Scp/Tickets/SearchIndexer.php
+++ b/app/Services/Scp/Tickets/SearchIndexer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use Illuminate\Support\Facades\DB;
+
+final class SearchIndexer
+{
+    public function index(string $objectType, int $objectId, string $title, string $content): void
+    {
+        $processedContent = $this->plain($content);
+
+        DB::connection('legacy')->table('_search')->updateOrInsert(
+            [
+                'object_type' => $objectType,
+                'object_id' => $objectId,
+            ],
+            [
+                'title' => $title,
+                'content' => $processedContent,
+            ]
+        );
+    }
+
+    private function plain(string $content): string
+    {
+        $stripped = strip_tags($content);
+        $decoded = html_entity_decode($stripped, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $normalized = preg_replace('/\s+/u', ' ', $decoded) ?? '';
+
+        return trim($normalized);
+    }
+}

--- a/app/Services/Scp/Tickets/StatusTransitionService.php
+++ b/app/Services/Scp/Tickets/StatusTransitionService.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use App\Exceptions\ForbiddenStatusTransition;
+use App\Exceptions\TicketModifiedConcurrentlyException;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use App\Models\TicketStatus;
+use Illuminate\Support\Facades\DB;
+
+final class StatusTransitionService
+{
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_STATES = ['open', 'onhold'];
+
+    public function __construct(
+        private readonly ThreadEventWriter $threadEvents,
+        private readonly NotePostingService $notes,
+        private readonly TicketCacheUpdater $ticketCacheUpdater,
+    ) {}
+
+    public function transition(
+        Ticket $ticket,
+        Thread $thread,
+        Staff $caller,
+        int $targetStatusId,
+        ?string $comments,
+        string $expectedUpdated,
+    ): void {
+        DB::connection('legacy')->transaction(function () use ($ticket, $thread, $caller, $targetStatusId, $comments, $expectedUpdated): void {
+            $currentTicket = $this->lockCurrentTicket($ticket);
+
+            if ((string) $currentTicket->updated !== $expectedUpdated) {
+                throw new TicketModifiedConcurrentlyException($currentTicket->ticket_id, (string) $currentTicket->updated);
+            }
+
+            /** @var TicketStatus $from */
+            $from = TicketStatus::on('legacy')->findOrFail($currentTicket->status_id);
+            /** @var TicketStatus $to */
+            $to = TicketStatus::on('legacy')->findOrFail($targetStatusId);
+
+            if (! $this->transitionAllowed((string) $from->state, (string) $to->state)) {
+                throw new ForbiddenStatusTransition((string) $from->state, (string) $to->state);
+            }
+
+            $currentTicket->forceFill([
+                'status_id' => $to->getKey(),
+            ])->save();
+
+            if ($comments !== null && trim($comments) !== '') {
+                $this->notes->post(
+                    ticket: $currentTicket,
+                    thread: $thread,
+                    staff: $caller,
+                    body: $comments,
+                    format: 'text',
+                    expectedUpdated: $expectedUpdated,
+                );
+            }
+
+            $this->threadEvents->record(
+                thread: $thread,
+                eventName: 'status',
+                entryId: null,
+                staff: $caller,
+                data: [
+                    'from' => $this->statusData($from),
+                    'to' => $this->statusData($to),
+                ],
+            );
+
+            $this->ticketCacheUpdater->touch($currentTicket, $thread);
+        });
+    }
+
+    private function transitionAllowed(string $fromState, string $toState): bool
+    {
+        return in_array($fromState, self::ALLOWED_STATES, true)
+            && in_array($toState, self::ALLOWED_STATES, true);
+    }
+
+    /**
+     * @return array{id:int,name:string,state:string}
+     */
+    private function statusData(TicketStatus $status): array
+    {
+        return [
+            'id' => (int) $status->getKey(),
+            'name' => (string) $status->name,
+            'state' => (string) $status->state,
+        ];
+    }
+
+    private function lockCurrentTicket(Ticket $ticket): Ticket
+    {
+        $query = Ticket::on('legacy')
+            ->withoutGlobalScopes()
+            ->whereKey($ticket->ticket_id);
+
+        if (DB::connection('legacy')->getDriverName() !== 'sqlite') {
+            $query->lockForUpdate();
+        }
+
+        return $query->findOrFail($ticket->ticket_id);
+    }
+}

--- a/app/Services/Scp/Tickets/ThreadEventWriter.php
+++ b/app/Services/Scp/Tickets/ThreadEventWriter.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use App\Models\Event;
+use App\Models\Staff;
+use App\Models\Thread;
+use App\Models\ThreadEvent;
+use InvalidArgumentException;
+
+final class ThreadEventWriter
+{
+    private array $eventCache = [];
+
+    public function record(
+        Thread $thread,
+        string $eventName,
+        ?int $entryId, // Reserved for future use (e.g., linking to thread entry)
+        Staff $staff,
+        array $data = []
+    ): ThreadEvent {
+        $eventId = $this->resolveEventId($eventName);
+
+        return ThreadEvent::on('legacy')->create([
+            'thread_id' => $thread->id,
+            'thread_type' => 'A',
+            'event_id' => $eventId,
+            'staff_id' => $staff->staff_id,
+            'team_id' => 0,
+            'dept_id' => 0,
+            'topic_id' => 0,
+            'data' => json_encode($data),
+            'username' => $staff->displayName(),
+            'uid' => $staff->staff_id,
+            'uid_type' => 'S',
+            'annulled' => 0,
+            'timestamp' => now(),
+        ]);
+    }
+
+    private function resolveEventId(string $eventName): int
+    {
+        if (isset($this->eventCache[$eventName])) {
+            return $this->eventCache[$eventName];
+        }
+
+        $event = Event::on('legacy')
+            ->where('name', $eventName)
+            ->first();
+
+        if (! $event) {
+            throw new InvalidArgumentException("Unknown event name: {$eventName}");
+        }
+
+        $this->eventCache[$eventName] = $event->id;
+
+        return $event->id;
+    }
+}

--- a/app/Services/Scp/Tickets/ThreadEventWriter.php
+++ b/app/Services/Scp/Tickets/ThreadEventWriter.php
@@ -25,7 +25,7 @@ final class ThreadEventWriter
 
         return ThreadEvent::on('legacy')->create([
             'thread_id' => $thread->id,
-            'thread_type' => 'A',
+            'thread_type' => $thread->object_type,
             'event_id' => $eventId,
             'staff_id' => $staff->staff_id,
             'team_id' => 0,

--- a/app/Services/Scp/Tickets/TicketCacheUpdater.php
+++ b/app/Services/Scp/Tickets/TicketCacheUpdater.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Tickets;
+
+use App\Models\Ticket;
+use App\Models\Thread;
+use Carbon\Carbon;
+
+final class TicketCacheUpdater
+{
+    public function touch(Ticket $ticket, ?Thread $thread = null): void
+    {
+        $now = Carbon::now();
+
+        $ticket->forceFill([
+            'lastupdate' => $now,
+            'updated' => $now,
+        ])->save();
+
+        if ($thread !== null) {
+            $thread->forceFill([
+                'lastresponse' => $now,
+            ])->save();
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\AuthenticateStaff;
+use App\Http\Middleware\EnforceTicketLock;
 use App\Http\Middleware\EnsureAdminAccess;
 use App\Http\Middleware\EnsureScpStaff;
 use App\Http\Middleware\HandleInertiaRequests;
@@ -38,6 +39,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'dept.access' => RequireDepartmentAccess::class,
             'scp.access' => EnsureScpStaff::class,
             'scp.log' => LogScpAccess::class,
+            'scp.ticket-lock' => EnforceTicketLock::class,
         ]);
     })
     ->withExceptions(function (): void {

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,8 @@
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
             "@php artisan key:generate",
             "@php artisan migrate --force",
+            "@php artisan legacy:ensure-permission-tables --seed --ansi",
+            "@php artisan osticket2:ensure-support-tables --ansi",
             "npm install --ignore-scripts",
             "npm run build"
         ],

--- a/config/database.php
+++ b/config/database.php
@@ -7,9 +7,10 @@ $legacy = env('LEGACY_DB_DRIVER', 'mysql') === 'sqlite'
     ? [
         'driver' => 'sqlite',
         'url' => env('DB_URL'),
-        'database' => env('DB_DATABASE', ':memory:'),
+        'database' => env('LEGACY_DB_DATABASE', env('DB_DATABASE', ':memory:')),
         'prefix' => 'ost_',
         'foreign_key_constraints' => false,
+        'transaction_mode' => 'DEFERRED',
     ]
     : [
         'driver' => 'mysql',

--- a/database/factories/QueueFactory.php
+++ b/database/factories/QueueFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Queue;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+final class QueueFactory extends Factory
+{
+    protected $model = Queue::class;
+
+    public function definition(): array
+    {
+        return [
+            'parent_id' => 0,
+            'staff_id' => 0,
+            'flags' => '',
+            'title' => $this->faker->words(3, true),
+            'config' => '{}',
+            'created' => now(),
+            'updated' => now(),
+        ];
+    }
+}

--- a/database/factories/StaffFactory.php
+++ b/database/factories/StaffFactory.php
@@ -31,4 +31,11 @@ class StaffFactory extends Factory
             'lastlogin' => null,
         ];
     }
+
+    public function admin(): self
+    {
+        return $this->state([
+            'isadmin' => 1,
+        ]);
+    }
 }

--- a/database/factories/ThreadFactory.php
+++ b/database/factories/ThreadFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Thread;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+final class ThreadFactory extends Factory
+{
+    protected $model = Thread::class;
+
+    public function definition(): array
+    {
+        return [
+            'object_id' => $this->faker->numberBetween(1, 1000),
+            'object_type' => 'A',
+            'created' => now(),
+        ];
+    }
+}

--- a/database/factories/ThreadFactory.php
+++ b/database/factories/ThreadFactory.php
@@ -13,7 +13,7 @@ final class ThreadFactory extends Factory
     {
         return [
             'object_id' => $this->faker->numberBetween(1, 1000),
-            'object_type' => 'A',
+            'object_type' => 'T',
             'created' => now(),
         ];
     }

--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Ticket;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Ticket>
+ */
+class TicketFactory extends Factory
+{
+    protected $model = Ticket::class;
+
+    public function definition(): array
+    {
+        return [
+            'number' => fake()->unique()->numerify('######'),
+            'user_id' => 1,
+            'status_id' => 1,
+            'dept_id' => 1,
+            'staff_id' => 0,
+            'sla_id' => 0,
+            'email_id' => 0,
+            'source' => 'web',
+            'ip_address' => fake()->ipv4(),
+            'isoverdue' => 0,
+            'isanswered' => 0,
+            'duedate' => null,
+            'closed' => null,
+            'lastupdate' => now(),
+            'lastmessage' => now(),
+            'lastresponse' => now(),
+            'created' => now(),
+            'updated' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_05_03_000100_create_scp_action_log_table.php
+++ b/database/migrations/2026_05_03_000100_create_scp_action_log_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('scp_action_log', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedInteger('staff_id');
+            $table->unsignedInteger('ticket_id')->nullable();
+            $table->unsignedInteger('thread_id')->nullable();
+            $table->unsignedInteger('queue_id')->nullable();
+            $table->string('action', 64);
+            $table->string('outcome', 16);
+            $table->unsignedSmallInteger('http_status');
+            $table->json('before_state')->nullable();
+            $table->json('after_state')->nullable();
+            $table->unsignedInteger('lock_id')->nullable();
+            $table->string('request_id', 64)->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->string('user_agent', 255)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['staff_id', 'created_at']);
+            $table->index(['ticket_id', 'created_at']);
+            $table->index(['action', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('scp_action_log');
+    }
+};

--- a/docs/runbooks/phase-2b-canary.md
+++ b/docs/runbooks/phase-2b-canary.md
@@ -1,0 +1,24 @@
+# Phase 2b Canary Brief
+
+## Audience
+Selected 3-5 staff who agree to pilot Phase 2b for one week.
+
+## What works
+- Internal note posting
+- Staff/team assignment
+- On-hold transition (only between open ↔ onhold)
+- Note draft autosave
+- Per-staff queue column customization
+- Ticket lock acquire/renew/release (matches legacy admin's ticket_lock setting)
+
+## Known gaps (until Phase 3)
+- Notifications for actions you take in the new SCP do NOT fire, assignees, collaborators receive nothing.
+- Plugin hooks tied to note, assignment, status events do NOT fire for actions taken here.
+- If you need notifications, switch back to legacy (Panel switcher, Legacy SCP) for that action.
+
+## Reporting issues
+- Any UI quirk, screenshot + ticket # + step, #osticket-2-canary
+- Any data discrepancy (legacy and new SCP show different things), priority; tag @on-call
+
+## Rollback
+The canary panel-switcher includes "?legacy=1" links if anything looks wrong. Use them, that ticket survives the transition unharmed.

--- a/docs/runbooks/phase-2b-rollback.md
+++ b/docs/runbooks/phase-2b-rollback.md
@@ -1,0 +1,24 @@
+# Phase 2b Rollback Runbook
+
+## Triggering events
+- Customer-visible incident traced to a Phase 2b write
+- Two or more parity-check failures in 24h
+- Canary group reports schema-shape regressions in legacy's UI for tickets touched by new SCP
+
+## Rollback steps (in order)
+
+1. **Disable Phase 2b routes.** Set `PHASE_2B_ENABLED=false` in production env; redeploy.
+2. **Confirm rollback**, `curl /scp/tickets/1/notes -X POST` should now return 404.
+3. **Audit damage**, query `scp_action_log` for actions in the incident window; export to CSV.
+4. **Verify legacy state**, for each affected ticket, open in legacy SCP and confirm activity feed renders.
+5. **Notify canary group** that the new write surfaces are temporarily disabled.
+
+## Recovery
+- Patch the underlying issue.
+- Re-enable Phase 2b routes only after parity-check passes 24h on staging.
+- Re-onboard canary group with revised brief.
+
+## What we don't roll back
+- `scp_action_log` rows, keep for postmortem.
+- The `scp_action_log` table itself, additive, doesn't touch legacy.
+- `lock` table, legacy still uses it; harmless to leave.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -36,5 +36,6 @@
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
         <env name="LEGACY_DB_DRIVER" value="sqlite"/>
+        <env name="LEGACY_DB_DATABASE" value="/tmp/osticket_test.sqlite"/>
     </php>
 </phpunit>

--- a/resources/js/components/tickets/AssignmentDialog.tsx
+++ b/resources/js/components/tickets/AssignmentDialog.tsx
@@ -77,8 +77,9 @@ export function AssignmentDialog({
         router.post(
             `/scp/tickets/${ticketId}/assignment`,
             {
-                staff_id: parseInt(selectedStaffId, 10),
-                note: comment,
+                assignee_type: 'staff',
+                assignee_id: parseInt(selectedStaffId, 10),
+                comments: comment,
                 expected_updated: expectedUpdated,
             },
             {
@@ -94,8 +95,9 @@ export function AssignmentDialog({
         router.post(
             `/scp/tickets/${ticketId}/assignment`,
             {
-                team_id: parseInt(selectedTeamId, 10),
-                note: comment,
+                assignee_type: 'team',
+                assignee_id: parseInt(selectedTeamId, 10),
+                comments: comment,
                 expected_updated: expectedUpdated,
             },
             {

--- a/resources/js/components/tickets/AssignmentDialog.tsx
+++ b/resources/js/components/tickets/AssignmentDialog.tsx
@@ -1,0 +1,260 @@
+import { useState } from 'react';
+import { router } from '@inertiajs/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { UserGroupIcon, Cancel01Icon } from '@hugeicons/core-free-icons';
+
+import { cn } from '@/lib/utils';
+import {
+    Dialog,
+    DialogTrigger,
+    DialogPortal,
+    DialogOverlay,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogClose,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+
+export interface StaffOption {
+    id: number;
+    name: string;
+}
+
+export interface TeamOption {
+    id: number;
+    name: string;
+}
+
+export interface AssignmentDialogProps {
+    ticketId: number;
+    expectedUpdated?: string;
+    currentAssignee?: string | null;
+    staffOptions: StaffOption[];
+    teamOptions: TeamOption[];
+    onSuccess?: () => void;
+}
+
+export function AssignmentDialog({
+    ticketId,
+    expectedUpdated,
+    currentAssignee,
+    staffOptions,
+    teamOptions,
+    onSuccess,
+}: AssignmentDialogProps) {
+    const [open, setOpen] = useState(false);
+    const [activeTab, setActiveTab] = useState<'staff' | 'team'>('staff');
+
+    const [selectedStaffId, setSelectedStaffId] = useState<string>('');
+    const [selectedTeamId, setSelectedTeamId] = useState<string>('');
+    const [comment, setComment] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleSuccess = () => {
+        setOpen(false);
+        resetForm();
+        onSuccess?.();
+    };
+
+    const handleFinish = () => {
+        setIsSubmitting(false);
+    };
+
+    const resetForm = () => {
+        setSelectedStaffId('');
+        setSelectedTeamId('');
+        setComment('');
+    };
+
+    const assignToStaff = () => {
+        if (!selectedStaffId) return;
+        setIsSubmitting(true);
+        router.post(
+            `/scp/tickets/${ticketId}/assignment`,
+            {
+                staff_id: parseInt(selectedStaffId, 10),
+                note: comment,
+                expected_updated: expectedUpdated,
+            },
+            {
+                onSuccess: handleSuccess,
+                onFinish: handleFinish,
+            }
+        );
+    };
+
+    const assignToTeam = () => {
+        if (!selectedTeamId) return;
+        setIsSubmitting(true);
+        router.post(
+            `/scp/tickets/${ticketId}/assignment`,
+            {
+                team_id: parseInt(selectedTeamId, 10),
+                note: comment,
+                expected_updated: expectedUpdated,
+            },
+            {
+                onSuccess: handleSuccess,
+                onFinish: handleFinish,
+            }
+        );
+    };
+
+    const unassign = () => {
+        setIsSubmitting(true);
+        router.delete(`/scp/tickets/${ticketId}/assignment`, {
+            data: { expected_updated: expectedUpdated },
+            onSuccess: handleSuccess,
+            onFinish: handleFinish,
+        });
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(val) => {
+            setOpen(val);
+            if (!val) resetForm();
+        }}>
+            <DialogTrigger
+                render={
+                    <button
+                        type="button"
+                        className="inline-flex items-center gap-1.5 rounded-full border border-[#E2E0D8] bg-white px-2.5 py-1 text-xs font-medium text-[#18181B] transition-colors hover:border-[#18181B] hover:bg-[#FAFAF8]"
+                    >
+                        {!currentAssignee && <HugeiconsIcon icon={UserGroupIcon} size={12} className="text-[#A1A1AA]" />}
+                        {currentAssignee ? currentAssignee : 'Assign'}
+                    </button>
+                }
+            />
+            <DialogPortal>
+                <DialogOverlay className="bg-[#18181B]/70" />
+                <DialogContent className="max-w-md rounded-2xl border-white/10 bg-white p-0 shadow-2xl overflow-hidden">
+                    <div className="flex items-center justify-between border-b border-[#E2E0D8] px-5 py-4">
+                        <DialogTitle className="font-display text-lg font-medium text-[#18181B]">
+                            Assign Ticket
+                        </DialogTitle>
+                        <DialogClose className="grid h-8 w-8 place-items-center rounded-md text-[#71717A] transition-colors hover:bg-[#F4F2EB] hover:text-[#18181B]">
+                            <HugeiconsIcon icon={Cancel01Icon} size={18} />
+                            <span className="sr-only">Close</span>
+                        </DialogClose>
+                    </div>
+
+                    <Tabs value={activeTab} onValueChange={(val: any) => setActiveTab(val)} className="flex flex-col">
+                        <div className="px-5 pt-4">
+                            <TabsList className="grid w-full grid-cols-2 rounded-lg bg-[#F4F2EB] p-1">
+                                <TabsTrigger value="staff" className="rounded-md px-3 py-1.5 text-xs font-medium transition-all data-selected:bg-white data-selected:text-[#18181B] data-selected:shadow-sm text-[#71717A]">
+                                    Staff
+                                </TabsTrigger>
+                                <TabsTrigger value="team" className="rounded-md px-3 py-1.5 text-xs font-medium transition-all data-selected:bg-white data-selected:text-[#18181B] data-selected:shadow-sm text-[#71717A]">
+                                    Team
+                                </TabsTrigger>
+                            </TabsList>
+                        </div>
+
+                        <div className="p-5">
+                            <TabsContent value="staff" className="space-y-4">
+                                <div className="space-y-1.5">
+                                    <Label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#A1A1AA]">Staff Member</Label>
+                                    <Select value={selectedStaffId} onValueChange={(val) => val && setSelectedStaffId(val)}>
+                                        <SelectTrigger className="w-full rounded-md border border-[#E2E0D8] bg-white h-9">
+                                            <SelectValue placeholder="Select staff member" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {staffOptions.map(staff => (
+                                                <SelectItem key={staff.id} value={staff.id.toString()}>
+                                                    {staff.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-1.5">
+                                    <Label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#A1A1AA]">Optional Comment</Label>
+                                    <Textarea
+                                        placeholder="Add an internal note..."
+                                        className="min-h-[80px] resize-none rounded-md border border-[#E2E0D8] bg-white text-sm"
+                                        value={comment}
+                                        onChange={(e) => setComment(e.target.value)}
+                                    />
+                                </div>
+                                <div className="flex items-center justify-between pt-2">
+                                    {currentAssignee ? (
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            onClick={unassign}
+                                            disabled={isSubmitting}
+                                            className="uppercase tracking-[1.2px] rounded-[3px] text-xs h-8 text-red-600 hover:bg-red-50 hover:text-red-700 border-red-200"
+                                        >
+                                            Unassign
+                                        </Button>
+                                    ) : <div />}
+                                    <Button
+                                        type="button"
+                                        onClick={assignToStaff}
+                                        disabled={!selectedStaffId || isSubmitting}
+                                        className="uppercase tracking-[1.2px] rounded-[3px] text-xs h-8 bg-[#18181B] text-white hover:bg-[#27272A]"
+                                    >
+                                        Assign
+                                    </Button>
+                                </div>
+                            </TabsContent>
+
+                            <TabsContent value="team" className="space-y-4">
+                                <div className="space-y-1.5">
+                                    <Label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#A1A1AA]">Team</Label>
+                                    <Select value={selectedTeamId} onValueChange={(val) => val && setSelectedTeamId(val)}>
+                                        <SelectTrigger className="w-full rounded-md border border-[#E2E0D8] bg-white h-9">
+                                            <SelectValue placeholder="Select team" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {teamOptions.map(team => (
+                                                <SelectItem key={team.id} value={team.id.toString()}>
+                                                    {team.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-1.5">
+                                    <Label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#A1A1AA]">Optional Comment</Label>
+                                    <Textarea
+                                        placeholder="Add an internal note..."
+                                        className="min-h-[80px] resize-none rounded-md border border-[#E2E0D8] bg-white text-sm"
+                                        value={comment}
+                                        onChange={(e) => setComment(e.target.value)}
+                                    />
+                                </div>
+                                <div className="flex items-center justify-between pt-2">
+                                    {currentAssignee ? (
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            onClick={unassign}
+                                            disabled={isSubmitting}
+                                            className="uppercase tracking-[1.2px] rounded-[3px] text-xs h-8 text-red-600 hover:bg-red-50 hover:text-red-700 border-red-200"
+                                        >
+                                            Unassign
+                                        </Button>
+                                    ) : <div />}
+                                    <Button
+                                        type="button"
+                                        onClick={assignToTeam}
+                                        disabled={!selectedTeamId || isSubmitting}
+                                        className="uppercase tracking-[1.2px] rounded-[3px] text-xs h-8 bg-[#18181B] text-white hover:bg-[#27272A]"
+                                    >
+                                        Assign
+                                    </Button>
+                                </div>
+                            </TabsContent>
+                        </div>
+                    </Tabs>
+                </DialogContent>
+            </DialogPortal>
+        </Dialog>
+    );
+}

--- a/resources/js/components/tickets/NoteComposer.tsx
+++ b/resources/js/components/tickets/NoteComposer.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { router } from '@inertiajs/react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { Note01Icon } from '@hugeicons/core-free-icons';
+
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Field, FieldError } from '@/components/ui/field';
+
+interface NoteComposerProps {
+    ticketId: number;
+    expectedUpdated: string;
+    onSuccess?: () => void;
+}
+
+export function NoteComposer({ ticketId, expectedUpdated, onSuccess }: NoteComposerProps) {
+    const [noteBody, setNoteBody] = useState('');
+    const [selectedFormat, setSelectedFormat] = useState('html');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+
+    const handleSubmit = () => {
+        setIsSubmitting(true);
+        router.post(`/scp/tickets/${ticketId}/notes`, {
+            body: noteBody,
+            format: selectedFormat,
+            expected_updated: expectedUpdated,
+        }, {
+            preserveScroll: true,
+            onSuccess: () => {
+                setNoteBody('');
+                setErrors({});
+                onSuccess?.();
+            },
+            onError: (newErrors) => {
+                setErrors(newErrors);
+            },
+            onFinish: () => {
+                setIsSubmitting(false);
+            },
+        });
+    };
+
+    return (
+        <div className="rounded-[18px] border border-[#E2E0D8] bg-white p-6 shadow-sm shadow-[#18181B]/[0.03]">
+            <div className="mb-4 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                    <HugeiconsIcon icon={Note01Icon} size={16} className="text-[#A1A1AA]" />
+                    <h3 className="font-display text-base font-medium text-[#18181B]">Post Internal Note</h3>
+                </div>
+
+                <Select value={selectedFormat} onValueChange={(val) => val && setSelectedFormat(val)}>
+                    <SelectTrigger className="h-8 w-[120px] bg-white text-xs">
+                        <SelectValue placeholder="Format" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="html">HTML</SelectItem>
+                        <SelectItem value="text">Plain Text</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+
+            <div className="space-y-4">
+                <Field>
+                    <Textarea
+                        placeholder="Write an internal note..."
+                        value={noteBody}
+                        onChange={(e) => setNoteBody(e.target.value)}
+                        className="min-h-[120px] resize-y bg-white"
+                    />
+                    {errors.body && <FieldError>{errors.body}</FieldError>}
+                </Field>
+
+                <div className="flex justify-end">
+                    <Button
+                        onClick={handleSubmit}
+                        disabled={isSubmitting || !noteBody.trim()}
+                        className="h-8 rounded-[3px] uppercase tracking-[1.2px]"
+                    >
+                        {isSubmitting ? 'Posting...' : 'Post Note'}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/tickets/NoteComposer.tsx
+++ b/resources/js/components/tickets/NoteComposer.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
 import { router } from '@inertiajs/react';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { Note01Icon } from '@hugeicons/core-free-icons';
-
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Field, FieldError } from '@/components/ui/field';
+import {
+    TextBoldIcon,
+    SmileIcon,
+    Attachment01Icon,
+    Mic01Icon as Microphone01Icon,
+    ArrowDown01Icon,
+    RefreshIcon
+} from '@hugeicons/core-free-icons';
+import { ChannelPill, FromPill, IconBtn } from './TicketDetailComponents';
 
 interface NoteComposerProps {
     ticketId: number;
@@ -16,25 +19,23 @@ interface NoteComposerProps {
 
 export function NoteComposer({ ticketId, expectedUpdated, onSuccess }: NoteComposerProps) {
     const [noteBody, setNoteBody] = useState('');
-    const [selectedFormat, setSelectedFormat] = useState('html');
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [errors, setErrors] = useState<Record<string, string>>({});
+    // Hardcoded user initials/name for now as per design template,
+    // ideally should come from auth props
+    const authorInitials = 'FIK';
 
     const handleSubmit = () => {
+        if (!noteBody.trim()) return;
         setIsSubmitting(true);
         router.post(`/scp/tickets/${ticketId}/notes`, {
             body: noteBody,
-            format: selectedFormat,
+            format: 'text', // defaulting to text based on the simple input in design
             expected_updated: expectedUpdated,
         }, {
             preserveScroll: true,
             onSuccess: () => {
                 setNoteBody('');
-                setErrors({});
                 onSuccess?.();
-            },
-            onError: (newErrors) => {
-                setErrors(newErrors);
             },
             onFinish: () => {
                 setIsSubmitting(false);
@@ -43,43 +44,67 @@ export function NoteComposer({ ticketId, expectedUpdated, onSuccess }: NoteCompo
     };
 
     return (
-        <div className="rounded-[18px] border border-[#E2E0D8] bg-white p-6 shadow-sm shadow-[#18181B]/[0.03]">
-            <div className="mb-4 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                    <HugeiconsIcon icon={Note01Icon} size={16} className="text-[#A1A1AA]" />
-                    <h3 className="font-display text-base font-medium text-[#18181B]">Post Internal Note</h3>
+        <div className="shrink-0 border-t border-[#E2E0D8] bg-white px-8 py-4">
+            <div className="rounded-lg border border-[#E2E0D8] bg-white p-4 shadow-[0_-2px_8px_rgba(0,0,0,0.03)]">
+                {/* Via / From row */}
+                <div className="mb-2.5 flex items-center gap-2.5">
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-[#FB923C] via-[#EC4899] to-[#6366F1] text-[10px] font-semibold text-white">
+                        {authorInitials}
+                    </div>
+                    <span className="text-xs text-[#71717A]">Via</span>
+                    <ChannelPill channel="Portal" />
+                    <span className="text-xs text-[#71717A]">From</span>
+                    <FromPill from="Internal Note" />
+                    <div className="ml-auto flex items-center">
+                        <IconBtn icon={RefreshIcon} size={28} className="border-none shadow-none" />
+                    </div>
                 </div>
 
-                <Select value={selectedFormat} onValueChange={(val) => val && setSelectedFormat(val)}>
-                    <SelectTrigger className="h-8 w-[120px] bg-white text-xs">
-                        <SelectValue placeholder="Format" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="html">HTML</SelectItem>
-                        <SelectItem value="text">Plain Text</SelectItem>
-                    </SelectContent>
-                </Select>
-            </div>
+                {/* Text input */}
+                <input
+                    value={noteBody}
+                    onChange={e => setNoteBody(e.target.value)}
+                    onKeyDown={e => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                            e.preventDefault();
+                            handleSubmit();
+                        }
+                    }}
+                    placeholder="Comment or Type '/' For commands (Internal Note)"
+                    className="w-full bg-transparent py-2 font-sans text-sm text-[#18181B] outline-none placeholder:text-[#A1A1AA]"
+                />
 
-            <div className="space-y-4">
-                <Field>
-                    <Textarea
-                        placeholder="Write an internal note..."
-                        value={noteBody}
-                        onChange={(e) => setNoteBody(e.target.value)}
-                        className="min-h-[120px] resize-y bg-white"
-                    />
-                    {errors.body && <FieldError>{errors.body}</FieldError>}
-                </Field>
-
-                <div className="flex justify-end">
-                    <Button
-                        onClick={handleSubmit}
-                        disabled={isSubmitting || !noteBody.trim()}
-                        className="h-8 rounded-[3px] uppercase tracking-[1.2px]"
-                    >
-                        {isSubmitting ? 'Posting...' : 'Post Note'}
-                    </Button>
+                {/* Toolbar */}
+                <div className="mt-2 flex items-center justify-between border-t border-[#E2E0D8] pt-2">
+                    <div className="flex items-center gap-0.5">
+                        {[TextBoldIcon, SmileIcon, Attachment01Icon, Microphone01Icon].map((ic, i) => (
+                            <button
+                                key={i}
+                                type="button"
+                                className="flex h-[30px] w-[30px] items-center justify-center rounded transition-colors text-[#A1A1AA] hover:bg-[#F4F2EB] hover:text-[#18181B]"
+                            >
+                                <HugeiconsIcon icon={ic} size={16} />
+                            </button>
+                        ))}
+                        <div className="mx-1.5 h-4 w-px bg-[#E2E0D8]" />
+                        <button type="button" className="flex items-center gap-1 px-2.5 py-1 font-sans text-xs font-medium text-[#A1A1AA] hover:text-[#18181B]">
+                            Macros
+                            <HugeiconsIcon icon={ArrowDown01Icon} size={12} />
+                        </button>
+                    </div>
+                    <div className="flex items-center gap-2.5">
+                        <button type="button" className="font-sans text-[13px] font-medium text-[#A1A1AA] hover:text-[#18181B]">
+                            End Chat
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleSubmit}
+                            disabled={isSubmitting || !noteBody.trim()}
+                            className="rounded-sm bg-[#71717A] px-6 py-2 font-sans text-[13px] font-medium text-white transition-colors hover:bg-[#52525B] disabled:opacity-50"
+                        >
+                            {isSubmitting ? 'Sending...' : 'Send'}
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/js/components/tickets/StatusPicker.tsx
+++ b/resources/js/components/tickets/StatusPicker.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { router } from '@inertiajs/react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { StatusBadge } from '@/components/scp/StatusBadge';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowDown01Icon } from '@hugeicons/core-free-icons';
+
+export interface StatusOption {
+    id: number;
+    name: string;
+    state: string;
+}
+
+export interface StatusPickerProps {
+    ticketId: number;
+    expectedUpdated?: string | null;
+    currentStatus: string | null;
+    currentStatusState: string | null;
+    availableStatuses: StatusOption[];
+    onSuccess?: () => void;
+}
+
+export function StatusPicker({
+    ticketId,
+    expectedUpdated,
+    currentStatus,
+    currentStatusState,
+    availableStatuses,
+    onSuccess,
+}: StatusPickerProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selectedStatusId, setSelectedStatusId] = useState<number | null>(null);
+    const [comment, setComment] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+
+    const validTransitions = availableStatuses.filter((s) => {
+        if (s.name === currentStatus) return false;
+        return s.state.toLowerCase() === 'open' || s.state.toLowerCase() === 'onhold';
+    });
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!selectedStatusId) return;
+
+        setIsSubmitting(true);
+        setErrors({});
+
+        router.post(`/scp/tickets/${ticketId}/status`, {
+            status_id: selectedStatusId,
+            comments: comment,
+            expected_updated: expectedUpdated || null,
+        }, {
+            onSuccess: () => {
+                onSuccess?.();
+                setIsOpen(false);
+                setComment('');
+                setSelectedStatusId(null);
+            },
+            onError: (errs) => {
+                setErrors(errs);
+            },
+            onFinish: () => {
+                setIsSubmitting(false);
+            },
+        });
+    };
+
+    return (
+        <Popover open={isOpen} onOpenChange={setIsOpen}>
+            <PopoverTrigger
+                className="group flex items-center gap-1.5 rounded-full ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#6366F1] focus-visible:ring-offset-2"
+            >
+                <StatusBadge status={currentStatus} state={currentStatusState} />
+                <span className="flex h-[22px] items-center gap-1 rounded-full border border-[#E2E0D8] bg-white px-2.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[#71717A] opacity-0 transition-all group-hover:opacity-100 group-focus-visible:opacity-100">
+                    Change
+                    <HugeiconsIcon icon={ArrowDown01Icon} size={10} className="text-[#A1A1AA]" />
+                </span>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-[320px] rounded-[18px] border-[#E2E0D8] bg-white p-5 shadow-sm shadow-[#18181B]/[0.03]">
+                <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+                    <div className="space-y-3">
+                        <label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#A1A1AA]">
+                            New Status
+                        </label>
+                        <Select
+                            value={selectedStatusId?.toString() ?? ''}
+                            onValueChange={(val) => setSelectedStatusId(Number(val))}
+                        >
+                            <SelectTrigger className="w-full h-10 rounded-md border-[#E2E0D8] bg-[#FAFAF8] px-3">
+                                <SelectValue placeholder="Select a status" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {validTransitions.length === 0 && (
+                                    <div className="py-2 px-3 text-xs text-[#71717A]">
+                                        No valid status transitions available.
+                                    </div>
+                                )}
+                                {validTransitions.map((status) => (
+                                    <SelectItem key={status.id} value={status.id.toString()}>
+                                        <div className="flex items-center gap-2">
+                                            <StatusBadge status={status.name} state={status.state} />
+                                        </div>
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        {errors.status_id && <p className="text-[11px] font-medium text-red-500">{errors.status_id}</p>}
+                    </div>
+
+                    {selectedStatusId && (
+                        <div className="space-y-3 fade-in animate-in">
+                            <label className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#A1A1AA]">
+                                Optional Comment
+                            </label>
+                            <Textarea
+                                value={comment}
+                                onChange={(e) => setComment(e.target.value)}
+                                placeholder="Add a note about this status change..."
+                                className="min-h-[80px] text-sm bg-[#FAFAF8] border-[#E2E0D8]"
+                            />
+                            {errors.comments && <p className="text-[11px] font-medium text-red-500">{errors.comments}</p>}
+                        </div>
+                    )}
+
+                    {errors.message && (
+                        <div className="rounded-md border border-red-200 bg-red-50 p-3">
+                            <p className="text-xs font-medium text-red-700">{errors.message}</p>
+                        </div>
+                    )}
+
+                    <div className="flex items-center justify-end gap-3 pt-2">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={() => setIsOpen(false)}
+                            disabled={isSubmitting}
+                            className="text-[#71717A] hover:text-[#18181B] hover:bg-[#F4F2EB]"
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="submit"
+                            disabled={!selectedStatusId || isSubmitting}
+                            className="bg-[#18181B] text-white hover:bg-[#27272A]"
+                        >
+                            Change Status
+                        </Button>
+                    </div>
+                </form>
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/resources/js/components/tickets/TicketDetailComponents.tsx
+++ b/resources/js/components/tickets/TicketDetailComponents.tsx
@@ -1,0 +1,196 @@
+import { useState, type ReactNode } from 'react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { cn } from '@/lib/utils';
+import {
+    ArrowDown01Icon,
+    Mail01Icon,
+    Message01Icon,
+    SmartPhone01Icon,
+    ComputerIcon,
+    Cancel01Icon
+} from '@hugeicons/core-free-icons';
+
+export function PriorityDot({ priority, size = 'default' }: { priority: string; size?: 'sm' | 'default' }) {
+    const colors: Record<string, string> = { High: 'bg-red-600', Medium: 'bg-yellow-500', Low: 'bg-green-600', Urgent: 'bg-red-600' };
+    const textColors: Record<string, string> = { High: 'text-red-600', Medium: 'text-yellow-600', Low: 'text-green-600', Urgent: 'text-red-600' };
+
+    const bgClass = colors[priority] || 'bg-[#A1A1AA]';
+    const textClass = textColors[priority] || 'text-[#A1A1AA]';
+
+    return (
+        <div className="flex items-center gap-1.5">
+            <div className={cn('h-1.5 w-1.5 shrink-0 rounded-full', bgClass)} />
+            <span className={cn('font-medium', size === 'sm' ? 'text-xs' : 'text-[13px]', textClass)}>
+                {priority}
+            </span>
+        </div>
+    );
+}
+
+export function TypeBadge({ type }: { type: string }) {
+    const styles: Record<string, string> = {
+        Incident: 'bg-red-50 text-red-600 border-red-200',
+        Problem: 'bg-orange-50 text-orange-600 border-orange-200',
+        Question: 'bg-green-50 text-green-600 border-green-200',
+        Suggestion: 'bg-indigo-50 text-indigo-600 border-indigo-200',
+    };
+    const dotColors: Record<string, string> = {
+        Incident: 'bg-red-600',
+        Problem: 'bg-orange-600',
+        Question: 'bg-green-600',
+        Suggestion: 'bg-indigo-600',
+    };
+
+    const styleClass = styles[type] || styles.Incident;
+    const dotClass = dotColors[type] || dotColors.Incident;
+
+    return (
+        <span className={cn('inline-flex items-center gap-1 rounded-[3px] border px-2.5 py-0.5 text-[11px] font-medium font-sans', styleClass)}>
+            <div className={cn('h-1.5 w-1.5 rounded-full', dotClass)} />
+            {type}
+        </span>
+    );
+}
+
+export function ClientCell({ name }: { name: string }) {
+    const initials = name.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase();
+
+    return (
+        <div className="flex items-center gap-2">
+            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#EC4899] text-[10px] font-semibold tracking-[0.02em] text-white">
+                {initials}
+            </div>
+            <span className="text-[13px]">{name}</span>
+        </div>
+    );
+}
+
+export function PrioritySegmented({ value, onChange }: { value: string; onChange: (val: string) => void }) {
+    const opts = [
+        { label: 'Low', color: 'bg-green-600' },
+        { label: 'Medium', color: 'bg-yellow-500' },
+        { label: 'High', color: 'bg-red-600' },
+    ];
+    return (
+        <div className="flex overflow-hidden rounded-sm border border-[#E2E0D8]">
+            {opts.map((o, i) => {
+                const isActive = value === o.label;
+                return (
+                    <button
+                        key={o.label}
+                        type="button"
+                        onClick={() => onChange(o.label)}
+                        className={cn(
+                            'flex flex-1 items-center justify-center gap-1.5 py-1.5 text-xs font-medium transition-all font-sans',
+                            isActive ? 'bg-[#F4F2EB] text-[#18181B] outline outline-2 outline-[#18181B] -outline-offset-2 rounded-[3px] z-10' : 'bg-white text-[#71717A] hover:bg-[#FAFAF8]',
+                            i < 2 && !isActive ? 'border-r border-[#E2E0D8]' : ''
+                        )}
+                    >
+                        <div className={cn('h-1.5 w-1.5 rounded-full', o.color)} />
+                        {o.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+export function TagChip({ label, onRemove }: { label: string; onRemove?: () => void }) {
+    return (
+        <span className="inline-flex items-center gap-1 rounded-[3px] bg-[#F4F2EB] px-2 py-0.5 text-xs font-medium text-[#18181B]">
+            {label}
+            {onRemove && (
+                <button type="button" onClick={onRemove} className="flex p-0 text-[#A1A1AA] hover:text-[#18181B]">
+                    <HugeiconsIcon icon={Cancel01Icon} size={14} />
+                </button>
+            )}
+        </span>
+    );
+}
+
+export function SplitButton({ label, onClick }: { label: string; onClick?: () => void }) {
+    const [hov, setHov] = useState(false);
+    return (
+        <div className="flex overflow-hidden rounded-sm shadow-[0_2px_6px_rgba(249,115,22,0.2)]">
+            <button
+                type="button"
+                onClick={onClick}
+                onMouseEnter={() => setHov(true)}
+                onMouseLeave={() => setHov(false)}
+                className={cn(
+                    'whitespace-nowrap px-4 py-2 font-sans text-[13px] font-medium text-white transition-colors',
+                    hov ? 'bg-orange-600' : 'bg-[#F97316]'
+                )}
+            >
+                {label}
+            </button>
+            <div className="w-[1px] bg-white/30" />
+            <button
+                type="button"
+                onMouseEnter={() => setHov(true)}
+                onMouseLeave={() => setHov(false)}
+                className={cn(
+                    'flex items-center px-2.5 text-white transition-colors',
+                    hov ? 'bg-orange-600' : 'bg-[#F97316]'
+                )}
+            >
+                <HugeiconsIcon icon={ArrowDown01Icon} size={14} />
+            </button>
+        </div>
+    );
+}
+
+export function IconBtn({
+    icon,
+    onClick,
+    size = 34,
+    tooltip,
+    className
+}: {
+    icon: any;
+    onClick?: () => void;
+    size?: number;
+    tooltip?: string;
+    className?: string;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            title={tooltip}
+            style={{ width: size, height: size }}
+            className={cn(
+                'flex shrink-0 items-center justify-center rounded-sm border border-[#E2E0D8] bg-white text-[#A1A1AA] transition-colors hover:bg-[#F4F2EB] hover:text-[#18181B]',
+                className
+            )}
+        >
+            <HugeiconsIcon icon={icon} size={size <= 30 ? 14 : 16} />
+        </button>
+    );
+}
+
+export function ChannelPill({ channel }: { channel: string }) {
+    const icons: Record<string, any> = {
+        Email: Mail01Icon,
+        Whatsapp: Message01Icon,
+        Phone: SmartPhone01Icon,
+        Portal: ComputerIcon
+    };
+    const Icon = icons[channel] || Mail01Icon;
+    return (
+        <span className="inline-flex items-center gap-1 rounded-full border border-[#E2E0D8] bg-[#F4F2EB] px-2.5 py-0.5 text-xs font-medium text-[#18181B]">
+            <HugeiconsIcon icon={Icon} size={13} className={channel === 'Whatsapp' ? 'text-[#25D366]' : 'text-[#A1A1AA]'} />
+            {channel}
+            <HugeiconsIcon icon={ArrowDown01Icon} size={12} className="ml-0.5 text-[#71717A]" />
+        </span>
+    );
+}
+
+export function FromPill({ from }: { from: string }) {
+    return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-[#71717A] px-2.5 py-0.5 text-xs font-medium text-white">
+            {from}
+            <HugeiconsIcon icon={ArrowDown01Icon} size={12} className="ml-0.5 text-white/60" />
+        </span>
+    );
+}

--- a/resources/js/hooks/useTicketLock.ts
+++ b/resources/js/hooks/useTicketLock.ts
@@ -1,0 +1,168 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { router } from '@inertiajs/react';
+
+export type LockStatus = 'free' | 'held-by-me' | 'held-by-other';
+
+export interface LockState {
+  status: LockStatus;
+  heldByStaffId: number | null;
+  expiresAt: string | null;
+}
+
+interface Options {
+  ticketId: number;
+  mode: 'disabled' | 'on_view' | 'on_activity';
+  initial?: LockState;
+}
+
+export function useTicketLock({ ticketId, mode, initial }: Options) {
+  const [state, setState] = useState<LockState>(initial || {
+    status: 'free',
+    heldByStaffId: null,
+    expiresAt: null,
+  });
+
+  const statusRef = useRef(state.status);
+  useEffect(() => {
+    statusRef.current = state.status;
+  }, [state.status]);
+
+  const getHeaders = () => {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    const csrfToken = document.head.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+    if (csrfToken) {
+      headers['X-CSRF-TOKEN'] = csrfToken;
+    }
+
+    if (!csrfToken) {
+      const match = document.cookie.match(new RegExp('(^|;\\s*)XSRF-TOKEN=([^;]*)'));
+      if (match) {
+        headers['X-XSRF-TOKEN'] = decodeURIComponent(match[2]);
+      }
+    }
+
+    return headers;
+  };
+
+  const acquire = useCallback(async () => {
+    try {
+      const response = await fetch(`/scp/tickets/${ticketId}/lock`, {
+        method: 'POST',
+        headers: getHeaders(),
+        credentials: 'same-origin',
+      });
+
+      if (response.status === 423) {
+        const data = await response.json();
+        setState({
+          status: 'held-by-other',
+          heldByStaffId: data.held_by_staff_id,
+          expiresAt: data.expires_at,
+        });
+        return false;
+      }
+
+      if (response.ok) {
+        const data = await response.json();
+        setState({
+          status: 'held-by-me',
+          heldByStaffId: data.held_by_staff_id,
+          expiresAt: data.expires_at,
+        });
+        return true;
+      }
+    } catch (error) {
+      console.error('Failed to acquire lock:', error);
+    }
+    return false;
+  }, [ticketId]);
+
+  const renew = useCallback(async () => {
+    try {
+      const response = await fetch(`/scp/tickets/${ticketId}/lock/renew`, {
+        method: 'POST',
+        headers: getHeaders(),
+        credentials: 'same-origin',
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setState(prev => ({
+          ...prev,
+          expiresAt: data.expires_at,
+        }));
+        return true;
+      }
+    } catch (error) {
+      console.error('Failed to renew lock:', error);
+    }
+    return false;
+  }, [ticketId]);
+
+  const release = useCallback(async () => {
+    try {
+      const response = await fetch(`/scp/tickets/${ticketId}/lock`, {
+        method: 'DELETE',
+        headers: getHeaders(),
+        credentials: 'same-origin',
+        keepalive: true,
+      });
+
+      if (response.ok || response.status === 204) {
+        setState({
+          status: 'free',
+          heldByStaffId: null,
+          expiresAt: null,
+        });
+        return true;
+      }
+    } catch (error) {
+      console.error('Failed to release lock:', error);
+    }
+    return false;
+  }, [ticketId]);
+
+  useEffect(() => {
+    if (mode === 'on_view') {
+      acquire();
+    }
+  }, [mode, acquire]);
+
+  useEffect(() => {
+    let intervalId: ReturnType<typeof setInterval>;
+
+    if (state.status === 'held-by-me') {
+      intervalId = setInterval(() => {
+        renew();
+      }, 30000);
+    }
+
+    return () => {
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [state.status, renew]);
+
+  useEffect(() => {
+    const handleRelease = () => {
+      if (statusRef.current === 'held-by-me') {
+        release();
+      }
+    };
+
+    const unsubscribeInertia = router.on('navigate', handleRelease);
+    window.addEventListener('pagehide', handleRelease);
+
+    return () => {
+      window.removeEventListener('pagehide', handleRelease);
+      unsubscribeInertia();
+      handleRelease();
+    };
+  }, [release]);
+
+  return { state, acquire, renew, release };
+}

--- a/resources/js/pages/Scp/Queues/Show.tsx
+++ b/resources/js/pages/Scp/Queues/Show.tsx
@@ -1,10 +1,13 @@
 import type { ReactElement, ReactNode } from 'react';
+import { useState } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
     Add01Icon,
     Download01Icon,
     Search01Icon,
+    Settings02Icon,
 } from '@hugeicons/core-free-icons';
+import { router } from '@inertiajs/react';
 
 import { QueueSelector } from '@/components/scp/QueueSelector';
 import {
@@ -26,11 +29,21 @@ import {
     InputGroupInput,
 } from '@/components/ui/input-group';
 import { Kbd } from '@/components/ui/kbd';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { appShellLayout, SetPageHeader } from '@/layouts/AppShell';
 
 interface Queue {
     id: number;
     title: string;
+}
+
+interface QueueColumn {
+    column_id: number;
+    sort?: number;
+    width?: number;
+    heading?: string;
+    [key: string]: number | string | undefined;
 }
 
 interface QueueShowProps {
@@ -43,6 +56,7 @@ interface QueueShowProps {
     filters: QueueFilters;
     filterOptions: QueueFilterOptions;
     sort: QueueSortState;
+    columns?: QueueColumn[];
 }
 
 interface QueueShowLayoutProps extends QueueShowProps {
@@ -59,7 +73,31 @@ export default function QueueShow({
     filters,
     filterOptions,
     sort,
+    columns = [],
 }: QueueShowProps) {
+    const [showCustomizeDrawer, setShowCustomizeDrawer] = useState(false);
+    const [columnEdits, setColumnEdits] = useState<QueueColumn[]>(columns);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const handleSaveColumns = () => {
+        setIsSaving(true);
+        router.patch(
+            `/scp/queues/${queue.id}/columns`,
+            { columns: columnEdits },
+            {
+                onFinish: () => {
+                    setIsSaving(false);
+                    setShowCustomizeDrawer(false);
+                },
+            }
+        );
+    };
+
+    const updateColumn = (index: number, field: string, value: unknown) => {
+        const updated = [...columnEdits];
+        updated[index] = { ...updated[index], [field]: value as number | string | undefined };
+        setColumnEdits(updated);
+    };
     return (
         <>
             <SetPageHeader>
@@ -69,6 +107,13 @@ export default function QueueShow({
                         <p className="mt-1 font-body text-sm text-[#A1A1AA]">Tickets</p>
                     </div>
                     <div className="flex shrink-0 items-center gap-2 sm:gap-3">
+                        <button
+                            onClick={() => setShowCustomizeDrawer(true)}
+                            className={buttonVariants({ variant: 'outline', size: 'sm' })}
+                        >
+                            <HugeiconsIcon icon={Settings02Icon} size={14} />
+                            Customize
+                        </button>
                         <a
                             href={`/scp/queues/${queue.id}/export`}
                             className={buttonVariants({ variant: 'outline', size: 'sm' })}
@@ -83,6 +128,92 @@ export default function QueueShow({
                     </div>
                 </div>
             </SetPageHeader>
+
+            {/* Customize Drawer */}
+            {showCustomizeDrawer && (
+                <div className="fixed inset-0 z-50 flex">
+                    {/* Backdrop */}
+                    <div
+                        className="flex-1 bg-black/50"
+                        onClick={() => setShowCustomizeDrawer(false)}
+                    />
+                    {/* Drawer Panel */}
+                    <div className="w-96 flex flex-col bg-white shadow-lg">
+                        <div className="border-b border-[#E5E5E5] px-6 py-4">
+                            <h2 className="text-lg font-semibold">Customize Columns</h2>
+                        </div>
+                        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+                            {columnEdits.map((column, index) => (
+                                <div key={column.column_id} className="space-y-3 pb-4 border-b border-[#E5E5E5]">
+                                    <div>
+                                        <Label className="text-xs font-medium text-[#71717A]">Column ID</Label>
+                                        <div className="mt-1 text-sm text-[#3F3F46]">{column.column_id}</div>
+                                    </div>
+                                    <div>
+                                        <Label htmlFor={`sort-${index}`} className="text-xs font-medium text-[#71717A]">
+                                            Sort Order
+                                        </Label>
+                                        <Input
+                                            id={`sort-${index}`}
+                                            type="number"
+                                            value={column.sort ?? ''}
+                                            onChange={(e) => updateColumn(index, 'sort', e.target.value ? parseInt(e.target.value) : undefined)}
+                                            className="mt-1"
+                                            placeholder="Sort order"
+                                        />
+                                    </div>
+                                    <div>
+                                        <Label htmlFor={`width-${index}`} className="text-xs font-medium text-[#71717A]">
+                                            Width (50-1000)
+                                        </Label>
+                                        <Input
+                                            id={`width-${index}`}
+                                            type="number"
+                                            min="50"
+                                            max="1000"
+                                            value={column.width ?? ''}
+                                            onChange={(e) => updateColumn(index, 'width', e.target.value ? parseInt(e.target.value) : undefined)}
+                                            className="mt-1"
+                                            placeholder="Width"
+                                        />
+                                    </div>
+                                    <div>
+                                        <Label htmlFor={`heading-${index}`} className="text-xs font-medium text-[#71717A]">
+                                            Heading
+                                        </Label>
+                                        <Input
+                                            id={`heading-${index}`}
+                                            type="text"
+                                            maxLength={80}
+                                            value={column.heading ?? ''}
+                                            onChange={(e) => updateColumn(index, 'heading', e.target.value || undefined)}
+                                            className="mt-1"
+                                            placeholder="Column heading"
+                                        />
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="border-t border-[#E5E5E5] flex gap-2 px-6 py-4">
+                            <Button
+                                onClick={() => setShowCustomizeDrawer(false)}
+                                variant="outline"
+                                className="flex-1"
+                                disabled={isSaving}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                onClick={handleSaveColumns}
+                                className="flex-1"
+                                disabled={isSaving}
+                            >
+                                {isSaving ? 'Saving...' : 'Save'}
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
 
             <div className="space-y-4">
             {unsupported && (

--- a/resources/js/pages/Scp/Tickets/Show.tsx
+++ b/resources/js/pages/Scp/Tickets/Show.tsx
@@ -20,8 +20,11 @@ import {
     UserGroupIcon,
 } from '@hugeicons/core-free-icons';
 
+import { StatusPicker, type StatusOption } from '@/components/tickets/StatusPicker';
 import { PriorityBadge } from '@/components/scp/PriorityBadge';
 import { StatusBadge } from '@/components/scp/StatusBadge';
+import { AssignmentDialog } from '@/components/tickets/AssignmentDialog';
+import { NoteComposer } from '@/components/tickets/NoteComposer';
 import { appShellLayout, SetPageHeader } from '@/layouts/AppShell';
 import { formatBytes, formatDateTime, formatRelative } from '@/lib/datetime';
 import { sanitizeHtml } from '@/lib/sanitizeHtml';
@@ -96,6 +99,14 @@ interface TicketShowProps {
     attachments: Attachment[];
     collaborators: Collaborator[];
     referrals: Referral[];
+    permissions?: {
+        canSetStatus?: boolean;
+        canAssign?: boolean;
+        canPostNote?: boolean;
+    };
+    availableStatuses?: StatusOption[];
+    staffOptions?: { id: number; name: string }[];
+    teamOptions?: { id: number; name: string }[];
 }
 
 const ENTRY_KIND_META: Record<string, { label: string; tone: string; icon: typeof Mail01Icon }> = {
@@ -259,7 +270,7 @@ function SlaBar({ progress }: { progress: SlaProgress }) {
     );
 }
 
-function TicketHeader({ ticket }: { ticket: Ticket }) {
+function TicketHeader({ ticket, permissions, staffOptions, teamOptions, availableStatuses }: { ticket: Ticket; permissions?: TicketShowProps['permissions']; staffOptions?: TicketShowProps['staffOptions']; teamOptions?: TicketShowProps['teamOptions']; availableStatuses?: TicketShowProps['availableStatuses'] }) {
     const { copied, copy } = useCopy();
     const [now, setNow] = useState<Date>(() => new Date());
 
@@ -316,14 +327,36 @@ function TicketHeader({ ticket }: { ticket: Ticket }) {
                     )}
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                    <StatusBadge status={ticket.status} state={ticket.status_state} />
+                    {permissions?.canSetStatus && availableStatuses ? (
+                        <StatusPicker
+                            ticketId={ticket.id}
+                            currentStatus={ticket.status}
+                            currentStatusState={ticket.status_state}
+                            availableStatuses={availableStatuses}
+                            expectedUpdated={ticket.updated}
+                        />
+                    ) : (
+                        <StatusBadge status={ticket.status} state={ticket.status_state} />
+                    )}
                     <PriorityBadge priority={ticket.priority} />
+                    {permissions?.canAssign ? (
+                        <AssignmentDialog
+                            ticketId={ticket.id}
+                            expectedUpdated={ticket.updated ?? undefined}
+                            currentAssignee={ticket.assignee}
+                            staffOptions={staffOptions ?? []}
+                            teamOptions={teamOptions ?? []}
+                        />
+                    ) : ticket.assignee ? (
+                        <span className="inline-flex items-center gap-1.5 rounded-full border border-[#E2E0D8] bg-[#FAFAF8] px-2.5 py-1 text-xs font-medium text-[#71717A]">
+                            {ticket.assignee}
+                        </span>
+                    ) : null}
                 </div>
             </div>
 
-            <dl className="mt-6 grid grid-cols-2 gap-4 border-t border-[#F4F2EB] pt-6 sm:grid-cols-4">
+            <dl className="mt-6 grid grid-cols-2 gap-4 border-t border-[#F4F2EB] pt-6 sm:grid-cols-3">
                 <Metric label="Department" value={ticket.department} />
-                <Metric label="Assignee" value={ticket.assignee} />
                 <Metric
                     label="Due date"
                     value={ticket.duedate ? formatDateTime(ticket.duedate) : null}
@@ -737,7 +770,7 @@ function SummaryRow({ icon, label, value }: { icon: typeof Mail01Icon; label: st
     );
 }
 
-export default function TicketShow({ ticket, customFields, timeline, attachments, collaborators, referrals }: TicketShowProps) {
+export default function TicketShow({ ticket, customFields, timeline, attachments, collaborators, referrals, permissions, staffOptions, teamOptions, availableStatuses }: TicketShowProps) {
     return (
         <>
             <SetPageHeader>
@@ -758,10 +791,21 @@ export default function TicketShow({ ticket, customFields, timeline, attachments
             </SetPageHeader>
 
             <div className="space-y-6">
-                <TicketHeader ticket={ticket} />
+                <TicketHeader
+                    ticket={ticket}
+                    permissions={permissions}
+                    staffOptions={staffOptions}
+                    teamOptions={teamOptions}
+                    availableStatuses={availableStatuses}
+                />
 
             <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
-                <Timeline items={timeline} />
+                <div className="space-y-6">
+                    {permissions?.canPostNote && (
+                        <NoteComposer ticketId={ticket.id} expectedUpdated={ticket.updated ?? ''} />
+                    )}
+                    <Timeline items={timeline} />
+                </div>
 
                 <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
                     <StatusSummary ticket={ticket} />

--- a/resources/js/pages/Scp/Tickets/Show.tsx
+++ b/resources/js/pages/Scp/Tickets/Show.tsx
@@ -1,34 +1,41 @@
-import { Link, usePage } from '@inertiajs/react';
+import { Link } from '@inertiajs/react';
 import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
-    AlertCircleIcon,
-    ArrowDown01Icon,
-    Calendar01Icon,
+    ArrowLeft01Icon,
+    ArrowLeft02Icon,
+    ArrowRight02Icon,
+    MoreHorizontalIcon,
+    Ticket01Icon,
     Cancel01Icon,
-    CheckmarkCircle02Icon,
-    Clock01Icon,
-    Copy01Icon,
     Download01Icon,
-    File01Icon,
     Image01Icon,
-    Link01Icon,
-    Link02Icon,
-    Mail01Icon,
-    Note01Icon,
+    ComputerIcon,
+    RefreshIcon,
+    FilterIcon,
+    Copy01Icon,
+    Bookmark01Icon,
+    Delete01Icon,
+    UserIcon,
     UserGroupIcon,
+    Chat01Icon,
+    SmartPhone01Icon,
+    Mail01Icon,
 } from '@hugeicons/core-free-icons';
 
-import { StatusPicker, type StatusOption } from '@/components/tickets/StatusPicker';
-import { PriorityBadge } from '@/components/scp/PriorityBadge';
-import { StatusBadge } from '@/components/scp/StatusBadge';
-import { AssignmentDialog } from '@/components/tickets/AssignmentDialog';
+import { type StatusOption } from '@/components/tickets/StatusPicker';
 import { NoteComposer } from '@/components/tickets/NoteComposer';
 import { appShellLayout, SetPageHeader } from '@/layouts/AppShell';
 import { formatBytes, formatDateTime, formatRelative } from '@/lib/datetime';
 import { sanitizeHtml } from '@/lib/sanitizeHtml';
 import { cn } from '@/lib/utils';
+import {
+    PrioritySegmented,
+    TagChip,
+    SplitButton,
+    IconBtn
+} from '@/components/tickets/TicketDetailComponents';
 
 interface Ticket {
     id: number;
@@ -109,58 +116,12 @@ interface TicketShowProps {
     teamOptions?: { id: number; name: string }[];
 }
 
-const ENTRY_KIND_META: Record<string, { label: string; tone: string; icon: typeof Mail01Icon }> = {
-    M: { label: 'Message', tone: 'border-sky-200 bg-sky-50 text-sky-700', icon: Mail01Icon },
-    R: { label: 'Response', tone: 'border-emerald-200 bg-emerald-50 text-emerald-700', icon: Mail01Icon },
-    N: { label: 'Internal note', tone: 'border-amber-200 bg-amber-50 text-amber-800', icon: Note01Icon },
-};
-
-const ENTRY_DEFAULT = {
-    label: 'Entry',
-    tone: 'border-[#E2E0D8] bg-[#FAFAF8] text-[#71717A]',
-    icon: Mail01Icon,
-};
-
-function entryMeta(type: string | null) {
-    if (!type) return ENTRY_DEFAULT;
-    return ENTRY_KIND_META[type.toUpperCase()] ?? ENTRY_DEFAULT;
-}
-
-function entryAnchor(id: number): string {
-    return `entry-${id}`;
-}
-
-function eventAnchor(id: number): string {
-    return `event-${id}`;
-}
-
 function isImage(mime: string | null | undefined): boolean {
     return typeof mime === 'string' && mime.toLowerCase().startsWith('image/');
 }
 
 function isPdf(mime: string | null | undefined): boolean {
     return typeof mime === 'string' && mime.toLowerCase() === 'application/pdf';
-}
-
-function useCopy(timeoutMs = 1500) {
-    const [copied, setCopied] = useState<string | null>(null);
-
-    useEffect(() => {
-        if (copied === null) return;
-        const handle = window.setTimeout(() => setCopied(null), timeoutMs);
-        return () => window.clearTimeout(handle);
-    }, [copied, timeoutMs]);
-
-    async function copy(value: string, key: string): Promise<void> {
-        try {
-            await navigator.clipboard.writeText(value);
-            setCopied(key);
-        } catch {
-            /* clipboard unavailable */
-        }
-    }
-
-    return { copied, copy };
 }
 
 interface SlaProgress {
@@ -227,384 +188,6 @@ function computeSlaProgress(ticket: Ticket, now: Date): SlaProgress | null {
     };
 }
 
-function Metric({ label, value, helper }: { label: string; value: ReactNode; helper?: string | null }) {
-    return (
-        <div>
-            <dt className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[#A1A1AA]">{label}</dt>
-            <dd className="mt-1.5 text-sm font-medium text-[#18181B]">{value || <span className="text-[#A1A1AA]">—</span>}</dd>
-            {helper && <p className="mt-0.5 text-xs text-[#A1A1AA]">{helper}</p>}
-        </div>
-    );
-}
-
-const SLA_TRACK_COLOR: Record<SlaProgress['tone'], string> = {
-    overdue: 'bg-red-500',
-    danger: 'bg-amber-500',
-    warn: 'bg-yellow-400',
-    closed: 'bg-[#A1A1AA]',
-    safe: 'bg-emerald-500',
-};
-
-const SLA_LABEL_TONE: Record<SlaProgress['tone'], string> = {
-    overdue: 'text-red-600',
-    danger: 'text-amber-600',
-    warn: 'text-yellow-700',
-    closed: 'text-[#71717A]',
-    safe: 'text-emerald-600',
-};
-
-function SlaBar({ progress }: { progress: SlaProgress }) {
-    const trackColor = SLA_TRACK_COLOR[progress.tone];
-    const labelTone = SLA_LABEL_TONE[progress.tone];
-
-    return (
-        <div className="rounded-md bg-[#FAFAF8] px-3 py-2.5">
-            <div className="flex items-center justify-between gap-3 text-xs">
-                <span className={cn('font-semibold uppercase tracking-[0.14em]', labelTone)}>{progress.label}</span>
-                {progress.helper && <span className="text-[#71717A]">{progress.helper}</span>}
-            </div>
-            <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[#E2E0D8]">
-                <div className={cn('h-full rounded-full transition-all', trackColor)} style={{ width: `${progress.percent}%` }} />
-            </div>
-        </div>
-    );
-}
-
-function TicketHeader({ ticket, permissions, staffOptions, teamOptions, availableStatuses }: { ticket: Ticket; permissions?: TicketShowProps['permissions']; staffOptions?: TicketShowProps['staffOptions']; teamOptions?: TicketShowProps['teamOptions']; availableStatuses?: TicketShowProps['availableStatuses'] }) {
-    const { copied, copy } = useCopy();
-    const [now, setNow] = useState<Date>(() => new Date());
-
-    useEffect(() => {
-        const id = window.setInterval(() => setNow(new Date()), 60_000);
-        return () => window.clearInterval(id);
-    }, []);
-
-    const sla = computeSlaProgress(ticket, now);
-
-    return (
-        <header className="rounded-[18px] border border-[#E2E0D8] bg-white p-6 shadow-sm shadow-[#18181B]/[0.03] xl:p-8">
-            <div className="flex flex-wrap items-start justify-between gap-4">
-                <div className="min-w-0 flex-1">
-                    <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-1.5 text-xs text-[#A1A1AA]">
-                        <Link href="/scp/queues" className="hover:text-[#18181B]">Tickets</Link>
-                        <span className="text-[#E2E0D8]">/</span>
-                        <button
-                            type="button"
-                            onClick={() => copy(`#${ticket.number}`, 'number')}
-                            className="inline-flex items-center gap-1 font-mono text-[#18181B] hover:text-[#EC4899]"
-                            title="Copy ticket number"
-                        >
-                            <span>#{ticket.number}</span>
-                            <HugeiconsIcon
-                                icon={copied === 'number' ? CheckmarkCircle02Icon : Copy01Icon}
-                                size={11}
-                                className={cn('transition-colors', copied === 'number' ? 'text-emerald-500' : 'text-[#A1A1AA]')}
-                            />
-                        </button>
-                        {ticket.created && (
-                            <>
-                                <span className="text-[#E2E0D8]">·</span>
-                                <span title={formatDateTime(ticket.created) ?? undefined}>
-                                    Created {formatRelative(ticket.created)}
-                                </span>
-                            </>
-                        )}
-                        {ticket.requester && (
-                            <>
-                                <span className="text-[#E2E0D8]">·</span>
-                                <span>by {ticket.requester}</span>
-                            </>
-                        )}
-                    </nav>
-                    <h1 className="mt-2 font-display text-2xl font-medium tracking-tight text-[#18181B]">
-                        {ticket.subject ?? `Ticket ${ticket.number}`}
-                    </h1>
-                    {ticket.requester_email && (
-                        <a href={`mailto:${ticket.requester_email}`} className="mt-1 inline-flex items-center gap-1.5 text-xs text-[#6366F1] hover:underline">
-                            <HugeiconsIcon icon={Mail01Icon} size={12} />
-                            {ticket.requester_email}
-                        </a>
-                    )}
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                    {permissions?.canSetStatus && availableStatuses ? (
-                        <StatusPicker
-                            ticketId={ticket.id}
-                            currentStatus={ticket.status}
-                            currentStatusState={ticket.status_state}
-                            availableStatuses={availableStatuses}
-                            expectedUpdated={ticket.updated}
-                        />
-                    ) : (
-                        <StatusBadge status={ticket.status} state={ticket.status_state} />
-                    )}
-                    <PriorityBadge priority={ticket.priority} />
-                    {permissions?.canAssign ? (
-                        <AssignmentDialog
-                            ticketId={ticket.id}
-                            expectedUpdated={ticket.updated ?? undefined}
-                            currentAssignee={ticket.assignee}
-                            staffOptions={staffOptions ?? []}
-                            teamOptions={teamOptions ?? []}
-                        />
-                    ) : ticket.assignee ? (
-                        <span className="inline-flex items-center gap-1.5 rounded-full border border-[#E2E0D8] bg-[#FAFAF8] px-2.5 py-1 text-xs font-medium text-[#71717A]">
-                            {ticket.assignee}
-                        </span>
-                    ) : null}
-                </div>
-            </div>
-
-            <dl className="mt-6 grid grid-cols-2 gap-4 border-t border-[#F4F2EB] pt-6 sm:grid-cols-3">
-                <Metric label="Department" value={ticket.department} />
-                <Metric
-                    label="Due date"
-                    value={ticket.duedate ? formatDateTime(ticket.duedate) : null}
-                    helper={ticket.duedate ? formatRelative(ticket.duedate) : null}
-                />
-                <Metric
-                    label="Updated"
-                    value={ticket.updated ? formatRelative(ticket.updated) : null}
-                    helper={ticket.updated ? formatDateTime(ticket.updated) : null}
-                />
-            </dl>
-
-            {sla && (
-                <div className="mt-5">
-                    <SlaBar progress={sla} />
-                </div>
-            )}
-        </header>
-    );
-}
-
-function TimelineEntry({ item }: { item: ThreadEntry }) {
-    const meta = entryMeta(item.type);
-    const { copied, copy } = useCopy();
-    const anchorId = entryAnchor(item.id);
-
-    const safeHtml = useMemo(() => {
-        if (!item.body) return '';
-        if ((item.format ?? '').toLowerCase() === 'html') {
-            return sanitizeHtml(item.body);
-        }
-        return null;
-    }, [item.body, item.format]);
-
-    function shareLink() {
-        const url = `${window.location.pathname}#${anchorId}`;
-        copy(url, anchorId);
-    }
-
-    return (
-        <article id={anchorId} className="group relative scroll-mt-24 rounded-[14px] border border-[#E2E0D8] bg-white p-5 shadow-sm shadow-[#18181B]/[0.02]">
-            <header className="flex flex-wrap items-center justify-between gap-3">
-                <div className="flex flex-wrap items-center gap-2">
-                    <span className={cn('inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]', meta.tone)}>
-                        <HugeiconsIcon icon={meta.icon} size={10} />
-                        {meta.label}
-                    </span>
-                    {item.author && <span className="text-sm font-medium text-[#18181B]">{item.author}</span>}
-                </div>
-                <div className="flex items-center gap-2 text-xs text-[#A1A1AA]">
-                    {item.created && (
-                        <time
-                            dateTime={item.created}
-                            title={formatDateTime(item.created) ?? undefined}
-                            className="inline-flex items-center gap-1"
-                        >
-                            <HugeiconsIcon icon={Clock01Icon} size={11} />
-                            {formatRelative(item.created)}
-                        </time>
-                    )}
-                    <button
-                        type="button"
-                        onClick={shareLink}
-                        title="Copy link to this entry"
-                        className="grid h-6 w-6 place-items-center rounded text-[#A1A1AA] opacity-0 transition-all hover:bg-[#F4F2EB] hover:text-[#EC4899] group-hover:opacity-100 focus-visible:opacity-100"
-                    >
-                        <HugeiconsIcon
-                            icon={copied === anchorId ? CheckmarkCircle02Icon : Link02Icon}
-                            size={12}
-                            className={copied === anchorId ? 'text-emerald-500' : undefined}
-                        />
-                    </button>
-                </div>
-            </header>
-            {safeHtml ? (
-                <div
-                    className="prose-ticket mt-4 text-sm leading-relaxed text-[#18181B]"
-                    dangerouslySetInnerHTML={{ __html: safeHtml }}
-                />
-            ) : item.body ? (
-                <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-[#18181B]">{item.body}</p>
-            ) : (
-                <p className="mt-4 text-sm italic text-[#A1A1AA]">No content.</p>
-            )}
-        </article>
-    );
-}
-
-function TimelineEvent({ item }: { item: ThreadEvent }) {
-    const anchorId = eventAnchor(item.id);
-
-    return (
-        <div id={anchorId} className="flex scroll-mt-24 items-start gap-3 rounded-md border border-dashed border-[#E2E0D8] bg-[#FAFAF8] px-4 py-3">
-            <div className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-white text-[#6366F1] ring-1 ring-[#E2E0D8]">
-                <HugeiconsIcon icon={Calendar01Icon} size={12} />
-            </div>
-            <div className="flex-1 text-xs text-[#71717A]">
-                <p className="font-medium text-[#18181B]">{item.label ?? 'Event'}</p>
-                {item.created && (
-                    <p className="mt-0.5">
-                        <time dateTime={item.created} title={formatDateTime(item.created) ?? undefined}>
-                            {formatRelative(item.created)}
-                        </time>
-                    </p>
-                )}
-            </div>
-        </div>
-    );
-}
-
-function Timeline({ items }: { items: TimelineItem[] }) {
-    const latestEntry = useMemo(() => {
-        for (let index = items.length - 1; index >= 0; index--) {
-            const item = items[index];
-            if (item.kind === 'entry') return item;
-        }
-        return null;
-    }, [items]);
-
-    function jumpToLatest() {
-        if (!latestEntry) return;
-        const target = document.getElementById(entryAnchor(latestEntry.id));
-        target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-
-    return (
-        <section className="rounded-[18px] border border-[#E2E0D8] bg-white p-6 shadow-sm shadow-[#18181B]/[0.03] xl:p-8">
-            <header className="flex flex-wrap items-center justify-between gap-3">
-                <div className="flex items-center gap-3">
-                    <h2 className="font-display text-lg font-medium text-[#18181B]">Timeline</h2>
-                    <span className="rounded-full bg-[#F4F2EB] px-2 py-0.5 text-[10px] font-semibold text-[#71717A]">
-                        {items.length} {items.length === 1 ? 'item' : 'items'}
-                    </span>
-                </div>
-                {latestEntry && items.length > 2 && (
-                    <button
-                        type="button"
-                        onClick={jumpToLatest}
-                        className="inline-flex items-center gap-1.5 rounded-md border border-[#E2E0D8] bg-white px-2.5 py-1.5 text-xs font-medium text-[#71717A] transition-colors hover:border-[#E2E0D8] hover:text-[#18181B]"
-                    >
-                        <HugeiconsIcon icon={ArrowDown01Icon} size={12} />
-                        Jump to latest
-                    </button>
-                )}
-            </header>
-            {items.length === 0 ? (
-                <p className="mt-5 text-sm text-[#71717A]">No thread entries or events were found.</p>
-            ) : (
-                <ol className="mt-6 space-y-4">
-                    {items.map((item) => (
-                        <li key={`${item.kind}-${item.id}`}>
-                            {item.kind === 'entry' ? <TimelineEntry item={item} /> : <TimelineEvent item={item} />}
-                        </li>
-                    ))}
-                </ol>
-            )}
-        </section>
-    );
-}
-
-function CustomFieldsPanel({ fields }: { fields: TicketShowProps['customFields'] }) {
-    const entries = Object.entries(fields);
-
-    return (
-        <SidebarPanel title="Custom Fields">
-            {entries.length === 0 ? (
-                <PanelEmpty text="No custom fields were captured." />
-            ) : (
-                <dl className="space-y-3 text-sm">
-                    {entries.map(([key, value]) => (
-                        <div key={key}>
-                            <dt className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#A1A1AA]">{key}</dt>
-                            <dd className="mt-1 break-words text-[#18181B]">
-                                {value === null || value === '' ? <span className="text-[#A1A1AA]">—</span> : String(value)}
-                            </dd>
-                        </div>
-                    ))}
-                </dl>
-            )}
-        </SidebarPanel>
-    );
-}
-
-function AttachmentsPanel({ attachments }: { attachments: Attachment[] }) {
-    const [preview, setPreview] = useState<Attachment | null>(null);
-
-    return (
-        <SidebarPanel title="Attachments" count={attachments.length}>
-            {attachments.length === 0 ? (
-                <PanelEmpty text="No attachments." />
-            ) : (
-                <ul className="space-y-2">
-                    {attachments.map((attachment) => {
-                        const previewable = isImage(attachment.mime) || isPdf(attachment.mime);
-                        const Icon = isImage(attachment.mime) ? Image01Icon : File01Icon;
-                        return (
-                            <li key={attachment.id}>
-                                <div className="group flex items-start gap-3 rounded-md border border-[#E2E0D8] bg-[#FAFAF8] px-3 py-2.5 text-sm transition-colors hover:bg-white">
-                                    <span className="grid h-8 w-8 shrink-0 place-items-center rounded-md bg-white text-[#6366F1] ring-1 ring-[#E2E0D8]">
-                                        <HugeiconsIcon icon={Icon} size={14} />
-                                    </span>
-                                    <div className="min-w-0 flex-1">
-                                        <p className="truncate font-medium text-[#18181B]">
-                                            {attachment.name ?? `File ${attachment.file_id}`}
-                                        </p>
-                                        <p className="mt-0.5 flex items-center gap-2 text-xs text-[#A1A1AA]">
-                                            {attachment.mime && <span className="truncate">{attachment.mime}</span>}
-                                            {formatBytes(attachment.size) && (
-                                                <>
-                                                    <span className="text-[#E2E0D8]">·</span>
-                                                    <span>{formatBytes(attachment.size)}</span>
-                                                </>
-                                            )}
-                                        </p>
-                                    </div>
-                                    <div className="flex flex-col gap-1">
-                                        {previewable && (
-                                            <button
-                                                type="button"
-                                                onClick={() => setPreview(attachment)}
-                                                className="grid h-7 w-7 place-items-center rounded text-[#A1A1AA] transition-colors hover:bg-[#F4F2EB] hover:text-[#EC4899]"
-                                                title="Preview"
-                                                aria-label="Preview attachment"
-                                            >
-                                                <HugeiconsIcon icon={Image01Icon} size={13} />
-                                            </button>
-                                        )}
-                                        <a
-                                            href={attachment.download_url}
-                                            className="grid h-7 w-7 place-items-center rounded text-[#A1A1AA] transition-colors hover:bg-[#F4F2EB] hover:text-[#EC4899]"
-                                            title="Download"
-                                            aria-label="Download attachment"
-                                            download
-                                        >
-                                            <HugeiconsIcon icon={Download01Icon} size={13} />
-                                        </a>
-                                    </div>
-                                </div>
-                            </li>
-                        );
-                    })}
-                </ul>
-            )}
-            <AttachmentPreview attachment={preview} onClose={() => setPreview(null)} />
-        </SidebarPanel>
-    );
-}
-
 function AttachmentPreview({ attachment, onClose }: { attachment: Attachment | null; onClose: () => void }) {
     const open = attachment !== null;
 
@@ -666,174 +249,313 @@ function AttachmentPreview({ attachment, onClose }: { attachment: Attachment | n
     );
 }
 
-function CollaboratorsPanel({ collaborators }: { collaborators: Collaborator[] }) {
-    return (
-        <SidebarPanel title="Collaborators" count={collaborators.length}>
-            {collaborators.length === 0 ? (
-                <PanelEmpty text="No collaborators." />
-            ) : (
-                <ul className="space-y-3">
-                    {collaborators.map((collaborator) => (
-                        <li key={collaborator.id} className="flex items-start gap-3">
-                            <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-[#F4F2EB] text-[#6366F1]">
-                                <HugeiconsIcon icon={UserGroupIcon} size={14} />
-                            </span>
-                            <div className="min-w-0 flex-1 text-sm">
-                                <p className="truncate font-medium text-[#18181B]">
-                                    {collaborator.name ?? collaborator.email ?? 'Unknown'}
-                                </p>
-                                {collaborator.email && collaborator.name && (
-                                    <p className="truncate text-xs text-[#A1A1AA]">{collaborator.email}</p>
-                                )}
-                                {collaborator.role && (
-                                    <span className="mt-1 inline-flex items-center rounded-full bg-[#FFF4EC] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[#6366F1]">
-                                        {collaborator.role}
-                                    </span>
-                                )}
-                            </div>
-                        </li>
-                    ))}
-                </ul>
-            )}
-        </SidebarPanel>
-    );
-}
-
-function ReferralsPanel({ referrals }: { referrals: Referral[] }) {
-    return (
-        <SidebarPanel title="Referrals" count={referrals.length}>
-            {referrals.length === 0 ? (
-                <PanelEmpty text="No referrals." />
-            ) : (
-                <ul className="space-y-2 text-sm">
-                    {referrals.map((referral) => (
-                        <li key={referral.id} className="flex items-center justify-between rounded-md border border-[#E2E0D8] bg-[#FAFAF8] px-3 py-2">
-                            <span className="flex items-center gap-2 font-medium text-[#18181B]">
-                                <HugeiconsIcon icon={Link01Icon} size={12} className="text-[#6366F1]" />
-                                {referral.object_type ?? 'object'} #{referral.object_id ?? '?'}
-                            </span>
-                            {referral.created && (
-                                <time dateTime={referral.created} className="text-xs text-[#A1A1AA]" title={formatDateTime(referral.created) ?? undefined}>
-                                    {formatRelative(referral.created)}
-                                </time>
-                            )}
-                        </li>
-                    ))}
-                </ul>
-            )}
-        </SidebarPanel>
-    );
-}
-
-function SidebarPanel({ title, count, children }: { title: string; count?: number; children: ReactNode }) {
-    return (
-        <section className="rounded-[18px] border border-[#E2E0D8] bg-white p-5 shadow-sm shadow-[#18181B]/[0.03]">
-            <header className="mb-4 flex items-center justify-between">
-                <h3 className="font-display text-base font-medium text-[#18181B]">{title}</h3>
-                {count !== undefined && (
-                    <span className="rounded-full bg-[#F4F2EB] px-2 py-0.5 text-[10px] font-semibold text-[#71717A]">{count}</span>
-                )}
-            </header>
-            {children}
-        </section>
-    );
-}
-
-function PanelEmpty({ text }: { text: string }) {
-    return <p className="text-sm text-[#71717A]">{text}</p>;
-}
-
-function StatusSummary({ ticket }: { ticket: Ticket }) {
-    return (
-        <SidebarPanel title="Summary">
-            <dl className="space-y-3 text-sm">
-                <SummaryRow icon={CheckmarkCircle02Icon} label="Status" value={ticket.status ?? '—'} />
-                <SummaryRow icon={AlertCircleIcon} label="Priority" value={ticket.priority ?? '—'} />
-                <SummaryRow icon={UserGroupIcon} label="Department" value={ticket.department ?? '—'} />
-                <SummaryRow icon={Calendar01Icon} label="Created" value={(ticket.created ? formatDateTime(ticket.created) : null) ?? '—'} />
-            </dl>
-        </SidebarPanel>
-    );
-}
-
-function SummaryRow({ icon, label, value }: { icon: typeof Mail01Icon; label: string; value: string }) {
-    return (
-        <div className="flex items-start gap-2.5">
-            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md bg-[#F4F2EB] text-[#6366F1]">
-                <HugeiconsIcon icon={icon} size={11} />
-            </span>
-            <div className="min-w-0 flex-1">
-                <dt className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#A1A1AA]">{label}</dt>
-                <dd className="mt-0.5 break-words text-[#18181B]">{value}</dd>
-            </div>
-        </div>
-    );
-}
-
 export default function TicketShow({ ticket, customFields, timeline, attachments, collaborators, referrals, permissions, staffOptions, teamOptions, availableStatuses }: TicketShowProps) {
+    const [activeTab, setActiveTab] = useState('conversation');
+    const [moreMenuOpen, setMoreMenuOpen] = useState(false);
+    const [now, setNow] = useState<Date>(() => new Date());
+
+    useEffect(() => {
+        const id = window.setInterval(() => setNow(new Date()), 60_000);
+        return () => window.clearInterval(id);
+    }, []);
+
+    const sla = computeSlaProgress(ticket, now);
+
+    const tabs = [
+        { id: 'conversation', label: 'Conversation' },
+        { id: 'task', label: 'Task' },
+        { id: 'activity', label: 'Activity Logs' },
+        { id: 'notes', label: 'Notes' },
+    ];
+
+    const sideIcons = [
+        UserIcon,
+        UserGroupIcon,
+        Chat01Icon,
+        SmartPhone01Icon,
+        Mail01Icon,
+    ];
+
+    // Reconstruct timeline into Thread Messages format
+    const threadMessages = useMemo(() => timeline.map(item => {
+        if (item.kind === 'event') {
+            return {
+                id: item.id,
+                type: 'system',
+                content: item.label ?? 'Event',
+                time: item.created ? formatDateTime(item.created) : '',
+            };
+        } else {
+            const isInternal = item.type === 'N';
+            const isAgent = item.type === 'M'; // Or R for response
+            return {
+                id: item.id,
+                type: isInternal ? 'internal' : (isAgent ? 'agent' : 'customer'),
+                author: item.author ?? 'Unknown',
+                avatar: (item.author ?? '?').slice(0, 2).toUpperCase(),
+                time: item.created ? formatDateTime(item.created) : '',
+                via: 'Portal',
+                content: sanitizeHtml(item.body ?? ''),
+                isHtml: (item.format ?? '').toLowerCase() === 'html'
+            };
+        }
+    }), [timeline]);
+
+    const [preview, setPreview] = useState<Attachment | null>(null);
+
     return (
         <>
             <SetPageHeader>
-                <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0 flex-1">
-                        <TicketHeaderTitle />
-                    </div>
-                    <div className="flex shrink-0 items-center gap-2 sm:gap-3">
+                <div className="flex w-full items-center justify-between">
+                    <div className="flex min-w-0 items-center gap-3">
                         <Link
                             href="/scp/queues"
-                            className="inline-flex h-7 items-center gap-1.5 rounded-[3px] border border-[#E2E0D8] bg-white px-3 text-[12px] font-medium uppercase leading-4 tracking-[1.2px] text-[#27272A] transition-colors hover:border-[#18181B] hover:bg-[#FAFAF8] hover:text-[#18181B]"
+                            className="flex items-center gap-1.5 whitespace-nowrap px-0 font-sans text-[13px] font-medium text-[#A1A1AA] hover:text-[#18181B]"
                         >
-                            <span aria-hidden>&larr;</span>
-                            Tickets
+                            <HugeiconsIcon icon={ArrowLeft01Icon} size={16} />
+                            Ticket List
                         </Link>
+
+                        <div className="flex gap-0.5">
+                            <IconBtn icon={ArrowLeft02Icon} size={28} className="border-none shadow-none" />
+                            <IconBtn icon={ArrowRight02Icon} size={28} className="border-none shadow-none" />
+                        </div>
+
+                        <div className="flex min-w-0 items-baseline gap-2.5">
+                            <span className="shrink-0 font-mono text-[14px] font-semibold text-[#18181B]">#{ticket.number}</span>
+                            <span className="truncate text-[15px] font-medium text-[#18181B]">{ticket.subject ?? 'No Subject'}</span>
+                        </div>
+                    </div>
+
+                    <div className="relative flex shrink-0 items-center gap-2.5">
+                        <IconBtn
+                            icon={MoreHorizontalIcon}
+                            size={34}
+                            onClick={() => setMoreMenuOpen(!moreMenuOpen)}
+                        />
+                        <SplitButton label="Submit as New" />
+
+                        {moreMenuOpen && (
+                            <div className="absolute right-14 top-full z-50 mt-1 w-[180px] rounded-md border border-[#E2E0D8] bg-white py-1.5 shadow-[0_8px_24px_rgba(0,0,0,0.1)]">
+                                {[
+                                    { icon: ComputerIcon, label: 'Remote Assist' },
+                                    { icon: RefreshIcon, label: 'Refresh' },
+                                    { icon: FilterIcon, label: 'Filters' },
+                                    { icon: Copy01Icon, label: 'Merge Ticket' },
+                                    { icon: Bookmark01Icon, label: 'Add to Shortcut' },
+                                    { icon: Delete01Icon, label: 'Delete', danger: true },
+                                ].map((item, i) => (
+                                    <button
+                                        key={item.label}
+                                        className={cn(
+                                            'flex w-full items-center gap-2 px-4 py-2 font-sans text-[13px] text-left transition-colors hover:bg-[#F4F2EB]',
+                                            item.danger ? 'text-red-600' : 'text-[#18181B]'
+                                        )}
+                                    >
+                                        <HugeiconsIcon icon={item.icon} size={16} className={item.danger ? 'text-red-600' : 'text-[#A1A1AA]'} />
+                                        {item.label}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 </div>
             </SetPageHeader>
 
-            <div className="space-y-6">
-                <TicketHeader
-                    ticket={ticket}
-                    permissions={permissions}
-                    staffOptions={staffOptions}
-                    teamOptions={teamOptions}
-                    availableStatuses={availableStatuses}
-                />
+            <div className="-mx-6 -my-5 flex h-[calc(100vh-80px)] flex-col sm:-mx-8 lg:-mx-10 lg:flex-row">
+                {/* Center / Thread Area */}
+                <div className="flex min-w-0 flex-1 flex-col border-r border-[#E2E0D8]">
+                    {/* Tabs */}
+                    <div className="flex shrink-0 justify-center gap-0 border-b border-[#E2E0D8]">
+                        {tabs.map(tab => (
+                            <button
+                                key={tab.id}
+                                onClick={() => setActiveTab(tab.id)}
+                                className={cn(
+                                    'mb-[-1px] border-b-2 px-5 py-2.5 font-sans text-[13px] transition-all',
+                                    activeTab === tab.id
+                                        ? 'border-[#F97316] font-medium text-[#F97316]'
+                                        : 'border-transparent font-normal text-[#A1A1AA] hover:text-[#18181B]'
+                                )}
+                            >
+                                {tab.label}
+                            </button>
+                        ))}
+                    </div>
 
-            <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_320px]">
-                <div className="space-y-6">
+                    {/* Messages Area */}
+                    <div className="custom-scrollbar flex-1 overflow-y-auto px-8 py-6">
+                        {threadMessages.length === 0 ? (
+                            <p className="text-sm text-[#A1A1AA]">No thread entries found.</p>
+                        ) : (
+                            threadMessages.map((msg, idx) => {
+                                if (msg.type === 'system') {
+                                    return (
+                                        <div key={msg.id + '-' + idx} className="mb-6 flex items-center gap-2.5">
+                                            <div className="flex h-8 w-8 items-center justify-center rounded-full border border-[#E2E0D8] bg-[#F4F2EB]">
+                                                <HugeiconsIcon icon={Ticket01Icon} size={14} className="text-[#A1A1AA]" />
+                                            </div>
+                                            <span className="text-[13px] text-[#A1A1AA]">
+                                                <strong className="font-medium text-[#18181B]">{msg.content}</strong>
+                                                {' · ' + msg.time}
+                                            </span>
+                                        </div>
+                                    );
+                                }
+
+                                const isAgent = msg.type === 'agent' || msg.type === 'internal';
+
+                                return (
+                                    <div key={msg.id + '-' + idx} className="mb-6 flex gap-3">
+                                        <div className={cn(
+                                            'flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold tracking-[0.02em]',
+                                            isAgent ? 'bg-gradient-to-br from-[#FB923C] via-[#EC4899] to-[#6366F1] text-white' : 'bg-[#E2E0D8] text-[#71717A]'
+                                        )}>
+                                            {msg.avatar}
+                                        </div>
+                                        <div className="flex-1">
+                                            <div className="mb-1 flex flex-wrap items-center gap-2">
+                                                <span className="text-[13px] font-semibold text-[#18181B]">{msg.author}</span>
+                                                <span className="text-[12px] text-[#71717A]">{'· ' + msg.time}</span>
+                                                <span className="text-[11px] text-[#71717A]">· Via</span>
+                                                <span className="inline-flex items-center gap-[3px] text-[11px] text-[#A1A1AA]">
+                                                    <HugeiconsIcon icon={msg.via === 'Email' ? Mail01Icon : Chat01Icon} size={12} className="text-[#71717A]" />
+                                                    {msg.via}
+                                                </span>
+                                            </div>
+                                            {msg.isHtml ? (
+                                                <div
+                                                    className="prose-ticket text-[14px] leading-[22px] text-[#18181B]"
+                                                    dangerouslySetInnerHTML={{ __html: msg.content }}
+                                                />
+                                            ) : (
+                                                <p className="whitespace-pre-wrap text-[14px] leading-[22px] text-[#18181B]">
+                                                    {msg.content}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </div>
+                                );
+                            })
+                        )}
+                    </div>
+
                     {permissions?.canPostNote && (
                         <NoteComposer ticketId={ticket.id} expectedUpdated={ticket.updated ?? ''} />
                     )}
-                    <Timeline items={timeline} />
                 </div>
 
-                <aside className="space-y-6 xl:sticky xl:top-6 xl:self-start">
-                    <StatusSummary ticket={ticket} />
-                    <CustomFieldsPanel fields={customFields} />
-                    <AttachmentsPanel attachments={attachments} />
-                    <CollaboratorsPanel collaborators={collaborators} />
-                    <ReferralsPanel referrals={referrals} />
-                </aside>
+                {/* Right Sidebar */}
+                <div className="flex w-[260px] shrink-0 overflow-hidden">
+                    <div className="custom-scrollbar flex-1 overflow-y-auto px-4 py-5">
+                        <h3 className="mb-5 text-[14px] font-semibold text-[#18181B]">Ticket Details</h3>
+
+                        <div className="mb-4">
+                            <label className="mb-1.5 block text-xs font-medium text-[#A1A1AA]">Ticket type</label>
+                            <select
+                                defaultValue={ticket.department ?? 'Incident'}
+                                className="w-full appearance-none rounded-sm border border-[#E2E0D8] bg-white px-3 py-2 pr-8 text-[13px] text-[#18181B] outline-none"
+                                style={{
+                                    backgroundImage: `url("data:image/svg+xml,%3Csvg width='12' height='12' viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 5l3 3 3-3' fill='none' stroke='%23A1A1AA' stroke-width='1.5'/%3E%3C/svg%3E")`,
+                                    backgroundRepeat: 'no-repeat',
+                                    backgroundPosition: 'right 10px center'
+                                }}
+                            >
+                                {['Incident', 'Problem', 'Question', 'Suggestion'].map(o => (
+                                    <option key={o} value={o}>{o}</option>
+                                ))}
+                            </select>
+                        </div>
+
+                        <div className="mb-4">
+                            <label className="mb-1.5 block text-xs font-medium text-[#A1A1AA]">Priority</label>
+                            <PrioritySegmented value={ticket.priority ?? 'High'} onChange={() => {}} />
+                        </div>
+
+                        <div className="mb-4">
+                            <label className="mb-1.5 block text-xs font-medium text-[#A1A1AA]">Linked Problem</label>
+                            <select
+                                defaultValue=""
+                                className="w-full appearance-none rounded-sm border border-[#E2E0D8] bg-white px-3 py-2 pr-8 text-[13px] text-[#71717A] outline-none"
+                                style={{
+                                    backgroundImage: `url("data:image/svg+xml,%3Csvg width='12' height='12' viewBox='0 0 12 12' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 5l3 3 3-3' fill='none' stroke='%23A1A1AA' stroke-width='1.5'/%3E%3C/svg%3E")`,
+                                    backgroundRepeat: 'no-repeat',
+                                    backgroundPosition: 'right 10px center'
+                                }}
+                            >
+                                <option value="">Select problems</option>
+                            </select>
+                        </div>
+
+                        <div className="mb-4">
+                            <label className="mb-1.5 block text-xs font-medium text-[#A1A1AA]">Tags</label>
+                            <div className="flex min-h-[60px] flex-wrap gap-1.5 rounded-sm border border-[#E2E0D8] p-2.5">
+                                <TagChip label="Support" onRemove={() => {}} />
+                            </div>
+                        </div>
+
+                        {sla && (
+                            <div className="mt-6 flex flex-col gap-2.5">
+                                <div className="rounded-md border border-[#E2E0D8] bg-white p-3">
+                                    <div className="mb-1 flex items-center gap-1.5">
+                                        <div className="h-1.5 w-1.5 rounded-full bg-[#F97316]" />
+                                        <span className="text-[11px] font-medium text-[#A1A1AA]">{sla.label} (SLA)</span>
+                                    </div>
+                                    <p className="text-[13px] font-medium text-[#18181B]">{sla.helper}</p>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Extra sections folded in */}
+                        {attachments.length > 0 && (
+                            <div className="mt-6">
+                                <h3 className="mb-2 text-[12px] font-semibold text-[#18181B]">Attachments ({attachments.length})</h3>
+                                <ul className="space-y-2">
+                                    {attachments.map(att => (
+                                        <li key={att.id} className="flex items-center justify-between rounded border border-[#E2E0D8] p-2 text-xs">
+                                            <span className="truncate">{att.name}</span>
+                                            <button onClick={() => setPreview(att)}><HugeiconsIcon icon={Image01Icon} size={14} /></button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+
+                        {Object.entries(customFields).length > 0 && (
+                            <div className="mt-6">
+                                <h3 className="mb-2 text-[12px] font-semibold text-[#18181B]">Custom Fields</h3>
+                                <dl className="space-y-2 text-xs">
+                                    {Object.entries(customFields).map(([key, val]) => (
+                                        <div key={key}>
+                                            <dt className="text-[#A1A1AA]">{key}</dt>
+                                            <dd className="text-[#18181B]">{String(val || '—')}</dd>
+                                        </div>
+                                    ))}
+                                </dl>
+                            </div>
+                        )}
+
+                        <AttachmentPreview attachment={preview} onClose={() => setPreview(null)} />
+                    </div>
+
+                    {/* Icon Strip */}
+                    <div className="flex w-10 shrink-0 flex-col items-center gap-1 border-l border-[#E2E0D8] bg-[#FAFAF8] pt-4">
+                        {sideIcons.map((ic, i) => (
+                            <button
+                                key={i}
+                                type="button"
+                                className={cn(
+                                    'flex h-8 w-8 items-center justify-center rounded-sm transition-colors',
+                                    i === 0 ? 'bg-[#F97316] text-white' : 'text-[#71717A] hover:bg-[#E2E0D8] hover:text-[#18181B]'
+                                )}
+                            >
+                                <HugeiconsIcon icon={ic} size={16} />
+                            </button>
+                        ))}
+                    </div>
+                </div>
             </div>
-        </div>
-    </>
-    );
-}
-
-function TicketHeaderTitle() {
-    const { props } = usePage<{ ticket?: Ticket }>();
-    const number = props.ticket?.number ?? '';
-
-    return (
-        <div className="flex items-baseline gap-2.5">
-            <h1 className="font-display text-xl font-medium tracking-[-0.02em] text-[#18181B]">
-                #{number}
-            </h1>
-            <span className="text-[#A1A1AA]">·</span>
-            <span className="font-body text-[11px] font-medium uppercase tracking-[0.12em] text-[#A1A1AA]">
-                Tickets
-            </span>
-        </div>
+        </>
     );
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,9 +24,16 @@ use App\Http\Controllers\Panels\PanelSwitchController;
 use App\Http\Controllers\Scp\AttachmentController;
 use App\Http\Controllers\Scp\DashboardController;
 use App\Http\Controllers\Scp\QueueController;
+use App\Http\Controllers\Scp\Queues\QueueColumnsController;
+use App\Http\Controllers\Scp\Queues\QueueConfigController;
 use App\Http\Controllers\Scp\SearchController;
 use App\Http\Controllers\Scp\StaffPreferencesController;
 use App\Http\Controllers\Scp\TicketController;
+use App\Http\Controllers\Scp\Tickets\AssignmentController;
+use App\Http\Controllers\Scp\Tickets\DraftController;
+use App\Http\Controllers\Scp\Tickets\LockController;
+use App\Http\Controllers\Scp\Tickets\NoteController;
+use App\Http\Controllers\Scp\Tickets\StatusController;
 use App\Http\Middleware\AuthenticateStaff;
 use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Support\Facades\Auth;
@@ -81,7 +88,28 @@ Route::prefix('scp')->name('scp.')->group(function () {
         Route::get('/queues', [QueueController::class, 'index'])->name('queues.index');
         Route::get('/queues/{queue}', [QueueController::class, 'show'])->name('queues.show');
         Route::get('/queues/{queue}/export', [QueueController::class, 'export'])->name('queues.export');
+        Route::patch('/queues/{queue}/columns', [QueueColumnsController::class, 'update'])->name('queues.columns.update');
+        Route::patch('/queues/{queue}/config', [QueueConfigController::class, 'update'])->name('queues.config.update');
         Route::get('/tickets/{ticket}', [TicketController::class, 'show'])->name('tickets.show');
+        Route::post('/tickets/{ticket}/lock', [LockController::class, 'acquire'])->name('tickets.lock.acquire');
+        Route::post('/tickets/{ticket}/lock/renew', [LockController::class, 'renew'])->name('tickets.lock.renew');
+        Route::delete('/tickets/{ticket}/lock', [LockController::class, 'release'])->name('tickets.lock.release');
+        Route::post('/tickets/{ticket}/notes', [NoteController::class, 'store'])
+            ->middleware('scp.ticket-lock')
+            ->name('tickets.notes.store');
+        Route::get('/tickets/{ticket}/draft', [DraftController::class, 'show'])->name('tickets.draft.show');
+        Route::post('/tickets/{ticket}/draft', [DraftController::class, 'store'])->name('tickets.draft.store');
+        Route::patch('/tickets/{ticket}/draft', [DraftController::class, 'update'])->name('tickets.draft.update');
+        Route::delete('/tickets/{ticket}/draft', [DraftController::class, 'destroy'])->name('tickets.draft.destroy');
+        Route::post('/tickets/{ticket}/assignment', [AssignmentController::class, 'store'])
+            ->middleware('scp.ticket-lock')
+            ->name('tickets.assignment.store');
+        Route::delete('/tickets/{ticket}/assignment', [AssignmentController::class, 'destroy'])
+            ->middleware('scp.ticket-lock')
+            ->name('tickets.assignment.destroy');
+        Route::post('/tickets/{ticket}/status', [StatusController::class, 'store'])
+            ->middleware('scp.ticket-lock')
+            ->name('tickets.status.store');
         Route::get('/attachments/{file}', [AttachmentController::class, 'download'])->name('attachments.download');
         Route::get('/search', [SearchController::class, 'index'])->name('search');
         Route::get('/preferences', [StaffPreferencesController::class, 'show'])->name('preferences.show');

--- a/tests/Feature/Admin/AdminTestHelpersTest.php
+++ b/tests/Feature/Admin/AdminTestHelpersTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Tests\Feature\Admin;
+
 use App\Http\Middleware\EnsureAdminAccess;
 use App\Http\Middleware\AuthenticateStaff;
 use App\Models\Admin\AdminAuditLog;
@@ -9,7 +11,6 @@ use App\Models\HelpTopic;
 use App\Models\Staff;
 use App\Policies\HelpTopicPolicy;
 use App\Services\Admin\AuditLogger;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -17,21 +18,26 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Schema;
 
-class FakeAdminHelperSubject extends Model
-{
-    protected $connection = 'osticket2';
-
-    protected $table = 'fake_admin_helper_subjects';
-
-    public $timestamps = false;
-
-    protected $guarded = [];
-}
-
 beforeEach(function (): void {
     seedPermissions();
 
+    Schema::connection('osticket2')->dropIfExists('admin_audit_log');
     Schema::connection('osticket2')->dropIfExists('fake_admin_helper_subjects');
+
+    Schema::connection('osticket2')->create('admin_audit_log', function (Blueprint $table): void {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('actor_id');
+        $table->string('action', 64);
+        $table->string('subject_type', 64);
+        $table->unsignedBigInteger('subject_id');
+        $table->json('before')->nullable();
+        $table->json('after')->nullable();
+        $table->json('metadata')->nullable();
+        $table->string('ip_address', 45)->nullable();
+        $table->string('user_agent', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+    });
+
     Schema::connection('osticket2')->create('fake_admin_helper_subjects', function (Blueprint $table): void {
         $table->bigIncrements('id');
         $table->string('name');
@@ -41,6 +47,7 @@ beforeEach(function (): void {
 afterEach(function (): void {
     Auth::guard('staff')->logout();
     Schema::connection('osticket2')->dropIfExists('fake_admin_helper_subjects');
+    Schema::connection('osticket2')->dropIfExists('admin_audit_log');
 });
 
 it('authenticates admin staff with admin access permission', function (): void {

--- a/tests/Feature/Admin/FakeAdminHelperSubject.php
+++ b/tests/Feature/Admin/FakeAdminHelperSubject.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FakeAdminHelperSubject extends Model
+{
+    protected $connection = 'osticket2';
+
+    protected $table = 'fake_admin_helper_subjects';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}

--- a/tests/Feature/Mail/OutboundMailGuardPhase2bTest.php
+++ b/tests/Feature/Mail/OutboundMailGuardPhase2bTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mail;
+
+use App\Models\Event;
+use App\Models\Queue;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+final class OutboundMailGuardPhase2bTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Mail::fake();
+        config(['osticket.ticket_lock' => '0']);
+
+        // Seed legacy event table
+        DB::connection('legacy')->table('event')->insertOrIgnore([
+            ['id' => 7, 'name' => 'created', 'description' => 'Created'],
+            ['id' => 100, 'name' => 'assigned', 'description' => 'Assigned'],
+            ['id' => 101, 'name' => 'released', 'description' => 'Released'],
+            ['id' => 200, 'name' => 'status', 'description' => 'Status Changed'],
+        ]);
+
+        // Seed legacy ticket_status table
+        DB::connection('legacy')->table('ticket_status')->insertOrIgnore([
+            ['id' => 1, 'name' => 'Open', 'state' => 'open'],
+            ['id' => 2, 'name' => 'Closed', 'state' => 'closed'],
+            ['id' => 3, 'name' => 'On Hold', 'state' => 'onhold'],
+        ]);
+
+        // Create permissions
+        Permission::create(['name' => 'tickets.post-note', 'guard_name' => 'staff']);
+        Permission::create(['name' => 'tickets.assign', 'guard_name' => 'staff']);
+        Permission::create(['name' => 'tickets.set-status', 'guard_name' => 'staff']);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        // Clean up legacy tables
+        DB::connection('legacy')->table('staff')->delete();
+        DB::connection('legacy')->table('ticket')->delete();
+        DB::connection('legacy')->table('thread')->delete();
+        DB::connection('legacy')->table('thread_event')->delete();
+        DB::connection('legacy')->table('thread_entry')->delete();
+        DB::connection('legacy')->table('_search')->delete();
+        DB::connection('legacy')->table('draft')->delete();
+        DB::connection('legacy')->table('queue')->delete();
+    }
+
+    public function test_all_phase_2b_write_surfaces_send_no_mail(): void
+    {
+        // Create admin staff with all required permissions
+        $staff = Staff::factory()->admin()->create();
+        $staff->givePermissionTo('tickets.post-note');
+        $staff->givePermissionTo('tickets.assign');
+        $staff->givePermissionTo('tickets.set-status');
+
+        // Create a second staff member for assignment
+        $assignee = Staff::factory()->create();
+
+        // Create ticket and threads
+        $ticket = Ticket::factory()->create(['status_id' => 1, 'dept_id' => 1]);
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'T',
+        ]);
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'A',
+        ]);
+
+        // Create queue for customization tests
+        $queue = Queue::factory()->create();
+
+        // 1. POST /scp/tickets/{ticket}/notes — post a note
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/notes", [
+                'body' => 'This is a test note',
+                'format' => 'html',
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+        $this->assertContains($response->status(), [200, 302]);
+
+        // Refresh ticket to get updated timestamp
+        $ticket->refresh();
+
+        // 2. POST /scp/tickets/{ticket}/assignment — assign to staff
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/assignment", [
+                'assignee_type' => 'staff',
+                'assignee_id' => $assignee->staff_id,
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+        $this->assertContains($response->status(), [200, 302]);
+
+        // Refresh ticket
+        $ticket->refresh();
+
+        // 3. DELETE /scp/tickets/{ticket}/assignment — unassign
+        $response = $this->actingAs($staff, 'staff')
+            ->deleteJson("/scp/tickets/{$ticket->ticket_id}/assignment", [
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+        $this->assertContains($response->status(), [200, 302, 204]);
+
+        // Refresh ticket
+        $ticket->refresh();
+
+        // 4. POST /scp/tickets/{ticket}/status — change status to onhold
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/status", [
+                'status_id' => 3,
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+        $this->assertContains($response->status(), [200, 302]);
+
+        // 5. POST /scp/tickets/{ticket}/draft — save a draft
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/draft", [
+                'body' => 'Draft note content',
+            ]);
+        $this->assertContains($response->status(), [200, 201]);
+
+        // Assert no mail was sent
+        Mail::assertNothingSent();
+    }
+}

--- a/tests/Feature/Scp/Audit/ScpActionLogMigrationTest.php
+++ b/tests/Feature/Scp/Audit/ScpActionLogMigrationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+
+test('scp_action_log table exists with required columns', function (): void {
+    expect(Schema::hasTable('scp_action_log'))->toBeTrue();
+
+    $columns = [
+        'id',
+        'staff_id',
+        'ticket_id',
+        'thread_id',
+        'queue_id',
+        'action',
+        'outcome',
+        'http_status',
+        'before_state',
+        'after_state',
+        'lock_id',
+        'request_id',
+        'ip_address',
+        'user_agent',
+        'created_at',
+    ];
+
+    foreach ($columns as $column) {
+        expect(Schema::hasColumn('scp_action_log', $column))
+            ->toBeTrue("Column {$column} should exist in scp_action_log table");
+    }
+});
+
+test('scp_action_log table has correct indexes', function (): void {
+    $indexes = Schema::getIndexes('scp_action_log');
+    $indexNames = array_map(fn ($idx) => $idx['name'], $indexes);
+
+    // Check for composite indexes
+    expect(in_array('scp_action_log_staff_id_created_at_index', $indexNames))->toBeTrue();
+    expect(in_array('scp_action_log_ticket_id_created_at_index', $indexNames))->toBeTrue();
+    expect(in_array('scp_action_log_action_created_at_index', $indexNames))->toBeTrue();
+});
+
+test('scp_action_log model can be instantiated', function (): void {
+    $model = new \App\Models\Scp\ScpActionLog();
+
+    expect($model)->toBeInstanceOf(\Illuminate\Database\Eloquent\Model::class);
+    expect($model->getTable())->toBe('scp_action_log');
+    expect($model->timestamps)->toBeFalse();
+});

--- a/tests/Feature/Scp/Queues/QueueCustomizationTest.php
+++ b/tests/Feature/Scp/Queues/QueueCustomizationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scp\Queues;
+
+use App\Models\Queue;
+use App\Models\Staff;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class QueueCustomizationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['osticket.ticket_lock' => '0']);
+
+        DB::connection('legacy')->table('staff')->delete();
+        DB::connection('legacy')->table('queue')->delete();
+        DB::connection('legacy')->table('queue_column')->delete();
+        DB::connection('legacy')->table('queue_columns')->delete();
+        DB::connection('legacy')->table('queue_config')->delete();
+    }
+
+    public function test_per_staff_column_edits_isolated(): void
+    {
+        $a = Staff::factory()->admin()->create();
+        $b = Staff::factory()->admin()->create();
+
+        $queue = Queue::factory()->create();
+
+        DB::connection('legacy')->table('queue_column')->insert([
+            [
+                'id' => 1,
+                'queue_id' => $queue->id,
+                'name' => 'X',
+                'sort' => 1,
+                'width' => 100,
+                'truncate' => 'wrap',
+                'translatable' => '',
+                'heading' => 'X',
+                'primary' => 'x',
+                'secondary' => '',
+                'filter' => '',
+                'flags' => 0,
+                'updated' => now()->toDateTimeString(),
+            ],
+        ]);
+
+        $response = $this->actingAs($a, 'staff')
+            ->patchJson("/scp/queues/{$queue->id}/columns", [
+                'columns' => [
+                    [
+                        'column_id' => 1,
+                        'sort' => 9,
+                        'width' => 222,
+                        'heading' => 'A-side',
+                    ],
+                ],
+            ]);
+
+        $response->assertFound();
+
+        $response = $this->actingAs($b, 'staff')
+            ->patchJson("/scp/queues/{$queue->id}/columns", [
+                'columns' => [
+                    [
+                        'column_id' => 1,
+                        'sort' => 1,
+                        'width' => 100,
+                        'heading' => 'B-side',
+                    ],
+                ],
+            ]);
+
+        $response->assertFound();
+
+        $this->assertDatabaseHas('queue_columns', [
+            'queue_id' => $queue->id,
+            'column_id' => 1,
+            'staff_id' => $a->staff_id,
+            'heading' => 'A-side',
+        ], 'legacy');
+
+        $this->assertDatabaseHas('queue_columns', [
+            'queue_id' => $queue->id,
+            'column_id' => 1,
+            'staff_id' => $b->staff_id,
+            'heading' => 'B-side',
+        ], 'legacy');
+    }
+
+    public function test_queue_config_update_succeeds(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $queue = Queue::factory()->create();
+
+        $response = $this->actingAs($staff, 'staff')
+            ->patchJson("/scp/queues/{$queue->id}/config", [
+                'sort_id' => 5,
+                'filter' => 'open',
+            ]);
+
+        $response->assertFound();
+
+        $this->assertDatabaseHas('queue_config', [
+            'queue_id' => $queue->id,
+            'staff_id' => $staff->staff_id,
+        ], 'legacy');
+
+        $config = DB::connection('legacy')
+            ->table('queue_config')
+            ->where('queue_id', $queue->id)
+            ->where('staff_id', $staff->staff_id)
+            ->first();
+
+        $setting = json_decode($config->setting, true);
+        $this->assertSame(5, $setting['sort_id']);
+        $this->assertSame('open', $setting['filter']);
+    }
+}

--- a/tests/Feature/Scp/Tickets/AssignmentControllerTest.php
+++ b/tests/Feature/Scp/Tickets/AssignmentControllerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scp\Tickets;
+
+use App\Models\Event;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+final class AssignmentControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['osticket.ticket_lock' => '0']);
+
+        Permission::create(['name' => 'tickets.assign', 'guard_name' => 'staff']);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        DB::connection('legacy')->table('staff')->truncate();
+        DB::connection('legacy')->table('ticket')->truncate();
+        DB::connection('legacy')->table('thread')->truncate();
+        DB::connection('legacy')->table('event')->truncate();
+    }
+
+    private function seedEvents(): void
+    {
+        Event::on('legacy')->create(['id' => 100, 'name' => 'assigned']);
+        Event::on('legacy')->create(['id' => 101, 'name' => 'released']);
+    }
+
+    public function test_assign_to_staff_succeeds(): void
+    {
+        $this->seedEvents();
+
+        $caller = Staff::factory()->admin()->create();
+        $caller->givePermissionTo('tickets.assign');
+
+        $assignee = Staff::factory()->create();
+        $ticket = Ticket::factory()->create();
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'T',
+        ]);
+
+        $response = $this->actingAs($caller, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/assignment", [
+                'assignee_type' => 'staff',
+                'assignee_id' => $assignee->staff_id,
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+
+        $response->assertStatus(302);
+        $this->assertDatabaseHas('ticket', [
+            'ticket_id' => $ticket->ticket_id,
+            'staff_id' => $assignee->staff_id,
+            'team_id' => 0,
+        ], 'legacy');
+    }
+
+    public function test_unassign_succeeds(): void
+    {
+        $this->seedEvents();
+
+        $caller = Staff::factory()->admin()->create();
+        $caller->givePermissionTo('tickets.assign');
+
+        $ticket = Ticket::factory()->create(['staff_id' => 5]);
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'T',
+        ]);
+
+        $response = $this->actingAs($caller, 'staff')
+            ->deleteJson("/scp/tickets/{$ticket->ticket_id}/assignment", [
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+
+        $response->assertStatus(302);
+        $this->assertDatabaseHas('ticket', [
+            'ticket_id' => $ticket->ticket_id,
+            'staff_id' => 0,
+            'team_id' => 0,
+        ], 'legacy');
+    }
+
+    public function test_returns_403_without_permission(): void
+    {
+        $caller = Staff::factory()->create();
+        $ticket = Ticket::factory()->create();
+
+        $response = $this->actingAs($caller, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/assignment", [
+                'assignee_type' => 'staff',
+                'assignee_id' => 1,
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_returns_409_on_stale_token(): void
+    {
+        $this->seedEvents();
+
+        $caller = Staff::factory()->admin()->create();
+        $caller->givePermissionTo('tickets.assign');
+
+        $ticket = Ticket::factory()->create();
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'T',
+        ]);
+
+        $response = $this->actingAs($caller, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/assignment", [
+                'assignee_type' => 'staff',
+                'assignee_id' => 1,
+                'comments' => null,
+                'expected_updated' => 'stale-token',
+            ]);
+
+        $response->assertStatus(409);
+    }
+}

--- a/tests/Feature/Scp/Tickets/DraftControllerTest.php
+++ b/tests/Feature/Scp/Tickets/DraftControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scp\Tickets;
+
+use App\Models\Draft;
+use App\Models\Staff;
+use App\Models\Ticket;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class DraftControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_show_returns_existing_draft(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+
+        Draft::on('legacy')->create([
+            'staff_id' => $staff->staff_id,
+            'namespace' => $namespace,
+            'body' => 'Test draft body',
+            'created' => now()->toDateTimeString(),
+            'updated' => now()->toDateTimeString(),
+        ]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->getJson("/scp/tickets/{$ticket->ticket_id}/draft");
+
+        $response->assertOk()
+            ->assertJsonPath('body', 'Test draft body')
+            ->assertJsonPath('updated', now()->toDateTimeString());
+    }
+
+    public function test_store_upserts_draft(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/draft", [
+                'body' => 'New draft body',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('body', 'New draft body');
+
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+        $this->assertDatabaseHas('draft', [
+            'staff_id' => $staff->staff_id,
+            'namespace' => $namespace,
+            'body' => 'New draft body',
+        ], 'legacy');
+    }
+
+    public function test_update_upserts_draft(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+
+        Draft::on('legacy')->create([
+            'staff_id' => $staff->staff_id,
+            'namespace' => $namespace,
+            'body' => 'Original body',
+            'created' => now()->toDateTimeString(),
+            'updated' => now()->toDateTimeString(),
+        ]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->patchJson("/scp/tickets/{$ticket->ticket_id}/draft", [
+                'body' => 'Updated body',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('body', 'Updated body');
+
+        $this->assertDatabaseHas('draft', [
+            'staff_id' => $staff->staff_id,
+            'namespace' => $namespace,
+            'body' => 'Updated body',
+        ], 'legacy');
+    }
+
+    public function test_destroy_removes_draft(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+
+        Draft::on('legacy')->create([
+            'staff_id' => $staff->staff_id,
+            'namespace' => $namespace,
+            'body' => 'Draft to delete',
+            'created' => now()->toDateTimeString(),
+            'updated' => now()->toDateTimeString(),
+        ]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->deleteJson("/scp/tickets/{$ticket->ticket_id}/draft");
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('draft', [
+            'staff_id' => $staff->staff_id,
+            'namespace' => $namespace,
+        ], 'legacy');
+    }
+}

--- a/tests/Feature/Scp/Tickets/DraftControllerTest.php
+++ b/tests/Feature/Scp/Tickets/DraftControllerTest.php
@@ -7,12 +7,20 @@ namespace Tests\Feature\Scp\Tickets;
 use App\Models\Draft;
 use App\Models\Staff;
 use App\Models\Ticket;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 final class DraftControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
 
     public function test_show_returns_existing_draft(): void
     {
@@ -83,6 +91,38 @@ final class DraftControllerTest extends TestCase
             'staff_id' => $staff->staff_id,
             'namespace' => $namespace,
             'body' => 'Updated body',
+        ], 'legacy');
+    }
+
+    public function test_update_preserves_original_created_timestamp(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+        $namespace = "ticket.note.{$ticket->ticket_id}";
+
+        Draft::on('legacy')->create([
+            'staff_id' => $staff->staff_id,
+            'namespace' => $namespace,
+            'body' => 'Original body',
+            'created' => '2026-05-03 09:00:00',
+            'updated' => '2026-05-03 09:00:00',
+        ]);
+
+        Carbon::setTestNow('2026-05-03 10:15:00');
+
+        $response = $this->actingAs($staff, 'staff')
+            ->patchJson("/scp/tickets/{$ticket->ticket_id}/draft", [
+                'body' => 'Updated body',
+            ]);
+
+        $response->assertOk();
+
+        $this->assertDatabaseHas('draft', [
+            'staff_id' => $staff->staff_id,
+            'namespace' => $namespace,
+            'body' => 'Updated body',
+            'created' => '2026-05-03 09:00:00',
+            'updated' => '2026-05-03 10:15:00',
         ], 'legacy');
     }
 

--- a/tests/Feature/Scp/Tickets/EnforceTicketLockMiddlewareTest.php
+++ b/tests/Feature/Scp/Tickets/EnforceTicketLockMiddlewareTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scp\Tickets;
+
+use App\Models\Staff;
+use App\Models\Ticket;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class EnforceTicketLockMiddlewareTest extends TestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Register a test route that uses the middleware
+        Route::middleware(['auth:staff', 'scp.ticket-lock'])
+            ->post('/__test/lock-probe/{ticket}', fn () => response()->noContent());
+
+        // Ensure legacy config table exists
+        if (! Schema::connection('legacy')->hasTable('config')) {
+            Schema::connection('legacy')->create('config', function ($table) {
+                $table->string('key')->primary();
+                $table->text('value')->nullable();
+            });
+        }
+    }
+
+    public function test_passes_in_disabled_mode(): void
+    {
+        DB::connection('legacy')->table('config')->updateOrInsert(
+            ['namespace' => 'core', 'key' => 'ticket_lock'],
+            ['value' => '0']
+        );
+
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/__test/lock-probe/{$ticket->ticket_id}");
+
+        $response->assertNoContent();
+    }
+
+    public function test_returns_423_in_on_view_mode_without_lock(): void
+    {
+        DB::connection('legacy')->table('config')->updateOrInsert(
+            ['namespace' => 'core', 'key' => 'ticket_lock'],
+            ['value' => '1']
+        );
+
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/__test/lock-probe/{$ticket->ticket_id}");
+
+        $response->assertStatus(423);
+        $response->assertJsonStructure(['message', 'held_by_staff_id', 'expires_at']);
+    }
+
+    public function test_passes_in_on_view_mode_with_owned_lock(): void
+    {
+        DB::connection('legacy')->table('config')->updateOrInsert(
+            ['namespace' => 'core', 'key' => 'ticket_lock'],
+            ['value' => '1']
+        );
+
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+
+        // Create a lock owned by this staff member
+        DB::connection('legacy')->table('lock')->insert([
+            'object_type' => 'T',
+            'object_id' => $ticket->ticket_id,
+            'staff_id' => $staff->staff_id,
+            'expire' => now()->addMinutes(5)->toDateTimeString(),
+        ]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/__test/lock-probe/{$ticket->ticket_id}");
+
+        $response->assertNoContent();
+    }
+}

--- a/tests/Feature/Scp/Tickets/LockControllerTest.php
+++ b/tests/Feature/Scp/Tickets/LockControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scp\Tickets;
+
+use App\Models\Staff;
+use App\Models\Ticket;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class LockControllerTest extends TestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->createLegacyConfigTable();
+    }
+
+    private function createLegacyConfigTable(): void
+    {
+        if (! Schema::connection('legacy')->hasTable('config')) {
+            Schema::connection('legacy')->create('config', function ($table) {
+                $table->id();
+                $table->string('namespace')->default('core');
+                $table->string('key');
+                $table->text('value')->nullable();
+                $table->unique(['namespace', 'key']);
+            });
+        }
+
+        DB::connection('legacy')->table('config')->truncate();
+        DB::connection('legacy')->table('config')->insert([
+            ['namespace' => 'core', 'key' => 'ticket_lock', 'value' => '0'],
+            ['namespace' => 'core', 'key' => 'lock_time', 'value' => '3'],
+        ]);
+    }
+
+    public function test_acquire_returns_200_with_lock_payload(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/lock");
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'lock_id',
+            'held_by_staff_id',
+            'expires_at',
+        ]);
+    }
+
+    public function test_acquire_returns_423_when_held_by_other(): void
+    {
+        $staff1 = Staff::factory()->admin()->create();
+        $staff2 = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+
+        $this->actingAs($staff1, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/lock")
+            ->assertOk();
+
+        $response = $this->actingAs($staff2, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/lock");
+
+        $response->assertStatus(423);
+        $response->assertJsonStructure([
+            'held_by_staff_id',
+            'expires_at',
+        ]);
+    }
+
+    public function test_renew_returns_200_for_owner(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+
+        $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/lock")
+            ->assertOk();
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/lock/renew");
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'lock_id',
+            'held_by_staff_id',
+            'expires_at',
+        ]);
+    }
+
+    public function test_release_returns_204(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $ticket = Ticket::factory()->create();
+
+        $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/lock")
+            ->assertOk();
+
+        $response = $this->actingAs($staff, 'staff')
+            ->deleteJson("/scp/tickets/{$ticket->ticket_id}/lock");
+
+        $response->assertNoContent();
+    }
+
+    public function test_guest_returns_404(): void
+    {
+        $ticket = Ticket::factory()->create();
+
+        $response = $this->postJson("/scp/tickets/{$ticket->ticket_id}/lock");
+
+        // TicketAccessibleScope hides all tickets from unauthenticated users,
+        // so route model binding returns 404 before auth middleware runs.
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/Scp/Tickets/NoteControllerTest.php
+++ b/tests/Feature/Scp/Tickets/NoteControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scp\Tickets;
+
+use App\Models\Event;
+use App\Models\LegacyPermission;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+final class NoteControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['osticket.ticket_lock' => '0']);
+    }
+
+    public function test_returns_403_without_permission(): void
+    {
+        Event::on('legacy')->create([
+            'id' => 7,
+            'name' => 'created',
+        ]);
+
+        $staff = Staff::factory()->create();
+
+        $ticket = Ticket::factory()->create();
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'T',
+        ]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/notes", [
+                'body' => 'This is a test note',
+                'format' => 'html',
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_returns_409_on_stale_token(): void
+    {
+        Event::on('legacy')->create([
+            'id' => 7,
+            'name' => 'created',
+        ]);
+
+        $perm = LegacyPermission::create(['name' => 'tickets.post-note', 'guard_name' => 'staff']);
+        $staff = Staff::factory()->create();
+        $staff->givePermissionTo($perm);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $ticket = Ticket::factory()->create();
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'T',
+        ]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/notes", [
+                'body' => 'This is a test note',
+                'format' => 'html',
+                'expected_updated' => 'stale-token-value',
+            ]);
+
+        $response->assertStatus(409);
+    }
+
+    public function test_posts_note_returns_success(): void
+    {
+        Event::on('legacy')->create([
+            'id' => 7,
+            'name' => 'created',
+        ]);
+
+        $perm = LegacyPermission::create(['name' => 'tickets.post-note', 'guard_name' => 'staff']);
+        $staff = Staff::factory()->create();
+        $staff->givePermissionTo($perm);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $ticket = Ticket::factory()->create();
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'T',
+        ]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/notes", [
+                'body' => 'This is a test note',
+                'format' => 'html',
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+
+        $response->assertStatus(302);
+    }
+}

--- a/tests/Feature/Scp/Tickets/ScpPhase2bParityCheckTest.php
+++ b/tests/Feature/Scp/Tickets/ScpPhase2bParityCheckTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scp\Tickets;
+
+use App\Models\Thread;
+use App\Models\Ticket;
+use Tests\TestCase;
+
+final class ScpPhase2bParityCheckTest extends TestCase
+{
+    public function test_command_can_read_ticket_without_authenticated_staff(): void
+    {
+        $ticket = Ticket::factory()->create(['dept_id' => 1]);
+        Thread::factory()->create([
+            'object_id' => $ticket->ticket_id,
+            'object_type' => 'T',
+        ]);
+
+        $this->artisan('scp:phase-2b-parity-check', ['--ticket' => $ticket->ticket_id])
+            ->expectsOutput('Parity check complete. 1 tickets, 0 errors.')
+            ->assertSuccessful();
+    }
+}

--- a/tests/Feature/Scp/Tickets/StatusControllerTest.php
+++ b/tests/Feature/Scp/Tickets/StatusControllerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Scp\Tickets;
+
+use App\Exceptions\ForbiddenStatusTransition;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+final class StatusControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['osticket.ticket_lock' => '0']);
+
+        DB::connection('legacy')->table('event')->insertOrIgnore([
+            ['id' => 200, 'name' => 'status', 'description' => 'Status Changed'],
+        ]);
+
+        DB::connection('legacy')->table('ticket_status')->insertOrIgnore([
+            ['id' => 1, 'name' => 'Open', 'state' => 'open'],
+            ['id' => 2, 'name' => 'Closed', 'state' => 'closed'],
+            ['id' => 3, 'name' => 'On Hold', 'state' => 'onhold'],
+        ]);
+
+        Permission::create(['name' => 'tickets.set-status', 'guard_name' => 'staff']);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        DB::connection('legacy')->table('staff')->delete();
+        DB::connection('legacy')->table('ticket')->delete();
+        DB::connection('legacy')->table('thread')->delete();
+        DB::connection('legacy')->table('thread_event')->delete();
+        DB::connection('legacy')->table('thread_entry')->delete();
+        DB::connection('legacy')->table('_search')->delete();
+    }
+
+    public function test_transitions_to_onhold_succeeds(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $staff->givePermissionTo('tickets.set-status');
+
+        $ticket = Ticket::factory()->create(['status_id' => 1, 'dept_id' => 1]);
+        $thread = Thread::factory()->create(['object_id' => $ticket->ticket_id]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/status", [
+                'status_id' => 3,
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+
+        $response->assertFound();
+        $this->assertDatabaseHas('ticket', [
+            'ticket_id' => $ticket->ticket_id,
+            'status_id' => 3,
+        ], 'legacy');
+    }
+
+    public function test_forbidden_transition_returns_422(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $staff->givePermissionTo('tickets.set-status');
+
+        $ticket = Ticket::factory()->create(['status_id' => 2, 'dept_id' => 1]);
+        $thread = Thread::factory()->create(['object_id' => $ticket->ticket_id]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/status", [
+                'status_id' => 1,
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('message', 'Forbidden status transition');
+    }
+
+    public function test_returns_403_without_permission(): void
+    {
+        $staff = Staff::factory()->create();
+
+        $ticket = Ticket::factory()->create(['status_id' => 1, 'dept_id' => 1]);
+        $thread = Thread::factory()->create(['object_id' => $ticket->ticket_id]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/status", [
+                'status_id' => 3,
+                'comments' => null,
+                'expected_updated' => (string) $ticket->updated,
+            ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_returns_409_on_stale_token(): void
+    {
+        $staff = Staff::factory()->admin()->create();
+        $staff->givePermissionTo('tickets.set-status');
+
+        $ticket = Ticket::factory()->create(['status_id' => 1, 'dept_id' => 1]);
+        $thread = Thread::factory()->create(['object_id' => $ticket->ticket_id]);
+
+        $response = $this->actingAs($staff, 'staff')
+            ->postJson("/scp/tickets/{$ticket->ticket_id}/status", [
+                'status_id' => 3,
+                'comments' => null,
+                'expected_updated' => '2020-01-01 00:00:00',
+            ]);
+
+        $response->assertStatus(409);
+        $response->assertJsonPath('message', 'Ticket was modified');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,21 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        if ($this->isRunningPhpUnit() && config('database.connections.legacy.driver') !== 'sqlite') {
+            throw new \RuntimeException(
+                'Refusing to run tests against a non-sqlite legacy database. '.
+                'Set LEGACY_DB_DRIVER=sqlite and LEGACY_DB_DATABASE to a disposable test database.'
+            );
+        }
+
+        // Prevent 60-second SQLite busy waits when multiple connections
+        // (sqlite, legacy, osticket2) share the same database file in tests.
+        if (config('database.connections.legacy.driver') === 'sqlite') {
+            DB::connection('sqlite')->statement('PRAGMA busy_timeout = 0');
+            DB::connection('legacy')->statement('PRAGMA busy_timeout = 0');
+            DB::connection('osticket2')->statement('PRAGMA busy_timeout = 0');
+        }
+
         if (config('database.connections.legacy.driver') === 'sqlite') {
             $dbPath = config('database.connections.legacy.database');
 
@@ -103,6 +118,133 @@ abstract class TestCase extends BaseTestCase
                 $table->primary(['permission_id', 'role_id']);
             });
 
+            $this->ensureLegacyTable($legacy, 'ticket', function (Blueprint $table) {
+                $table->unsignedInteger('ticket_id')->autoIncrement();
+                $table->string('number', 20)->unique();
+                $table->unsignedInteger('user_id')->default(0);
+                $table->unsignedInteger('status_id')->default(1);
+                $table->unsignedInteger('dept_id')->default(0);
+                $table->unsignedInteger('staff_id')->default(0);
+                $table->unsignedInteger('team_id')->default(0);
+                $table->unsignedInteger('sla_id')->default(0);
+                $table->unsignedInteger('email_id')->default(0);
+                $table->string('source', 32)->default('web');
+                $table->string('ip_address', 45)->nullable();
+                $table->tinyInteger('isoverdue')->default(0);
+                $table->tinyInteger('isanswered')->default(0);
+                $table->dateTime('duedate')->nullable();
+                $table->dateTime('closed')->nullable();
+                $table->dateTime('lastupdate')->useCurrent();
+                $table->dateTime('lastmessage')->useCurrent();
+                $table->dateTime('lastresponse')->useCurrent();
+                $table->dateTime('created')->useCurrent();
+                $table->dateTime('updated')->useCurrent();
+            });
+
+            $this->ensureLegacyTable($legacy, 'lock', function (Blueprint $table) {
+                $table->unsignedInteger('lock_id')->autoIncrement();
+                $table->char('object_type', 1)->default('T');
+                $table->unsignedInteger('object_id');
+                $table->unsignedInteger('staff_id');
+                $table->dateTime('expire');
+                $table->unique(['object_type', 'object_id']);
+            });
+
+            $this->ensureLegacyTable($legacy, 'config', function (Blueprint $table) {
+                $table->id();
+                $table->string('namespace', 64)->default('core');
+                $table->string('key', 64);
+                $table->text('value')->nullable();
+                $table->timestamp('updated')->nullable();
+                $table->unique(['namespace', 'key']);
+            });
+
+            $this->ensureLegacyTable($legacy, 'thread', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedInteger('object_id');
+                $table->char('object_type', 1)->default('T');
+                $table->dateTime('created')->useCurrent();
+                $table->dateTime('lastresponse')->nullable();
+            });
+
+            $this->ensureLegacyTable($legacy, 'queue', function (Blueprint $table) {
+                $table->unsignedInteger('id')->autoIncrement();
+                $table->unsignedInteger('parent_id')->default(0);
+                $table->unsignedInteger('staff_id')->default(0);
+                $table->string('flags', 255)->default('');
+                $table->string('title', 255);
+                $table->text('config')->nullable();
+                $table->dateTime('created')->useCurrent();
+                $table->dateTime('updated')->useCurrent();
+            });
+
+            $this->ensureLegacyTable($legacy, 'draft', function (Blueprint $table) {
+                $table->id();
+                $table->unsignedInteger('staff_id');
+                $table->string('namespace', 255);
+                $table->longText('body');
+                $table->dateTime('created')->useCurrent();
+                $table->dateTime('updated')->useCurrent();
+            });
+
+            $this->ensureLegacyTable($legacy, 'event', function (Blueprint $table) {
+                $table->unsignedInteger('id')->autoIncrement();
+                $table->string('name', 64);
+                $table->text('description')->nullable();
+            });
+
+            $this->ensureLegacyTable($legacy, 'ticket_status', function (Blueprint $table) {
+                $table->unsignedInteger('id')->autoIncrement();
+                $table->string('name', 64);
+                $table->string('state', 32);
+                $table->string('mode')->nullable();
+                $table->string('flags')->nullable();
+                $table->integer('sort')->default(0);
+                $table->json('properties')->nullable();
+                $table->timestamp('created')->nullable();
+                $table->timestamp('updated')->nullable();
+            });
+
+            $this->ensureLegacyTable($legacy, 'thread_entry', function (Blueprint $table) {
+                $table->unsignedInteger('id')->autoIncrement();
+                $table->unsignedInteger('thread_id');
+                $table->unsignedInteger('staff_id')->default(0);
+                $table->unsignedInteger('user_id')->default(0);
+                $table->char('type', 1);
+                $table->string('poster')->default('');
+                $table->string('source')->default('');
+                $table->string('title')->default('');
+                $table->text('body')->nullable();
+                $table->string('format')->default('text');
+                $table->dateTime('created')->nullable();
+                $table->dateTime('updated')->nullable();
+            });
+
+            $this->ensureLegacyTable($legacy, 'thread_event', function (Blueprint $table) {
+                $table->unsignedInteger('id')->autoIncrement();
+                $table->unsignedInteger('thread_id');
+                $table->char('thread_type', 1);
+                $table->unsignedInteger('event_id');
+                $table->unsignedInteger('staff_id');
+                $table->unsignedInteger('team_id')->default(0);
+                $table->unsignedInteger('dept_id')->default(0);
+                $table->unsignedInteger('topic_id')->default(0);
+                $table->json('data')->nullable();
+                $table->string('username')->nullable();
+                $table->unsignedInteger('uid')->nullable();
+                $table->char('uid_type', 1)->nullable();
+                $table->tinyInteger('annulled')->default(0);
+                $table->dateTime('timestamp');
+            });
+
+            $this->ensureLegacyTable($legacy, '_search', function (Blueprint $table) {
+                $table->string('object_type', 8);
+                $table->unsignedInteger('object_id');
+                $table->text('title');
+                $table->text('content');
+                $table->primary(['object_type', 'object_id']);
+            });
+
             $this->ensureLegacyTable($osticket2, 'staff_two_factor', function (Blueprint $table) {
                 $table->id();
                 $table->unsignedBigInteger('staff_id')->unique();
@@ -153,21 +295,7 @@ abstract class TestCase extends BaseTestCase
                 $table->timestamp('created_at')->useCurrent();
             });
 
-            $this->ensureLegacyTable($osticket2, 'admin_audit_log', function (Blueprint $table) {
-                $table->bigIncrements('id');
-                $table->unsignedBigInteger('actor_id');
-                $table->string('action', 64);
-                $table->string('subject_type', 64);
-                $table->unsignedBigInteger('subject_id');
-                $table->json('before')->nullable();
-                $table->json('after')->nullable();
-                $table->json('metadata')->nullable();
-                $table->string('ip_address', 45)->nullable();
-                $table->string('user_agent', 255)->nullable();
-                $table->timestamp('created_at')->useCurrent();
-            });
-
-            foreach (['admin_audit_log', 'access_log', 'staff_preferences', 'staff_auth_migrations', 'staff_two_factor'] as $table) {
+            foreach (['access_log', 'staff_preferences', 'staff_auth_migrations', 'staff_two_factor'] as $table) {
                 $osticket2Connection->table($table)->delete();
             }
 
@@ -180,18 +308,34 @@ abstract class TestCase extends BaseTestCase
                 'staff_dept_access',
                 'session',
                 'staff',
+                'ticket',
+                'thread',
+                'thread_entry',
+                'thread_event',
+                '_search',
+                'queue',
+                'lock',
+                'config',
+                'draft',
+                'event',
+                'ticket_status',
             ] as $table) {
                 $legacyConnection->table($table)->delete();
             }
         }
     }
 
+    private function isRunningPhpUnit(): bool
+    {
+        return app()->runningUnitTests()
+            || defined('PHPUNIT_COMPOSER_INSTALL')
+            || defined('__PHPUNIT_PHAR__');
+    }
+
     private function ensureLegacyTable($schema, string $table, \Closure $definition): void
     {
-        if ($schema->hasTable($table)) {
-            $schema->drop($table);
+        if (! $schema->hasTable($table)) {
+            $schema->create($table, $definition);
         }
-
-        $schema->create($table, $definition);
     }
 }

--- a/tests/Unit/Admin/AuditLoggerTest.php
+++ b/tests/Unit/Admin/AuditLoggerTest.php
@@ -1,24 +1,12 @@
 <?php
 
+namespace Tests\Unit\Admin;
+
 use App\Models\Staff;
 use App\Services\Admin\AuditLogger;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Schema;
-
-class FakeAuditedSubject extends Model
-{
-    protected $connection = 'osticket2';
-
-    protected $table = 'fake_audit_subjects';
-
-    public $timestamps = false;
-
-    protected $guarded = [];
-
-    protected static array $auditExcluded = ['password'];
-}
 
 beforeEach(function (): void {
     Schema::connection('osticket2')->dropIfExists('admin_audit_log');

--- a/tests/Unit/Admin/FakeAuditedSubject.php
+++ b/tests/Unit/Admin/FakeAuditedSubject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FakeAuditedSubject extends Model
+{
+    protected $connection = 'osticket2';
+
+    protected $table = 'fake_audit_subjects';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected static array $auditExcluded = ['password'];
+}

--- a/tests/Unit/Models/TicketStatusTest.php
+++ b/tests/Unit/Models/TicketStatusTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\TicketStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class TicketStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create ticket_status table if it doesn't exist
+        if (!Schema::connection('legacy')->hasTable('ticket_status')) {
+            Schema::connection('legacy')->create('ticket_status', function ($table) {
+                $table->unsignedInteger('id')->primary();
+                $table->string('name');
+                $table->string('state');
+                $table->string('mode')->nullable();
+                $table->string('flags')->nullable();
+                $table->integer('sort')->default(0);
+                $table->json('properties')->nullable();
+                $table->timestamp('created')->nullable();
+                $table->timestamp('updated')->nullable();
+            });
+        }
+    }
+
+    public function test_ticket_status_loads_state_column(): void
+    {
+        // Seed a ticket_status row
+        DB::connection('legacy')->table('ticket_status')->insert([
+            'id' => 1,
+            'name' => 'Open',
+            'state' => 'open',
+            'mode' => 'default',
+            'flags' => null,
+            'sort' => 0,
+            'properties' => null,
+            'created' => now(),
+            'updated' => now(),
+        ]);
+
+        // Load the model
+        $status = TicketStatus::find(1);
+
+        // Assert state column is loaded correctly
+        $this->assertNotNull($status);
+        $this->assertSame('open', $status->state);
+        $this->assertSame('Open', $status->name);
+    }
+}

--- a/tests/Unit/Policies/TicketActionPolicyTest.php
+++ b/tests/Unit/Policies/TicketActionPolicyTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Policies;
+
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Policies\TicketActionPolicy;
+use App\Services\DepartmentPermissionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+final class TicketActionPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private TicketActionPolicy $policy;
+
+    private MockInterface $deptService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->deptService = $this->mock(DepartmentPermissionService::class);
+        $this->policy = new TicketActionPolicy($this->deptService);
+    }
+
+    public function test_postNote_allowed_when_has_permission_and_dept_access(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.post-note')
+            ->andReturn(true);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 1]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->with($staff, 1)
+            ->andReturn(true);
+
+        $this->assertTrue($this->policy->postNote($staff, $ticket));
+    }
+
+    public function test_postNote_denied_when_missing_permission(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.post-note')
+            ->andReturn(false);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 1]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->never();
+
+        $this->assertFalse($this->policy->postNote($staff, $ticket));
+    }
+
+    public function test_postNote_denied_when_no_dept_access(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.post-note')
+            ->andReturn(true);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 1]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->with($staff, 1)
+            ->andReturn(false);
+
+        $this->assertFalse($this->policy->postNote($staff, $ticket));
+    }
+
+    public function test_assign_allowed_when_has_permission_and_dept_access(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.assign')
+            ->andReturn(true);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 2]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->with($staff, 2)
+            ->andReturn(true);
+
+        $this->assertTrue($this->policy->assign($staff, $ticket));
+    }
+
+    public function test_assign_denied_when_missing_permission(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.assign')
+            ->andReturn(false);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 2]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->never();
+
+        $this->assertFalse($this->policy->assign($staff, $ticket));
+    }
+
+    public function test_assign_denied_when_no_dept_access(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.assign')
+            ->andReturn(true);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 2]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->with($staff, 2)
+            ->andReturn(false);
+
+        $this->assertFalse($this->policy->assign($staff, $ticket));
+    }
+
+    public function test_setStatus_allowed_when_has_permission_and_dept_access(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.set-status')
+            ->andReturn(true);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 3]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->with($staff, 3)
+            ->andReturn(true);
+
+        $this->assertTrue($this->policy->setStatus($staff, $ticket));
+    }
+
+    public function test_setStatus_denied_when_missing_permission(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.set-status')
+            ->andReturn(false);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 3]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->never();
+
+        $this->assertFalse($this->policy->setStatus($staff, $ticket));
+    }
+
+    public function test_setStatus_denied_when_no_dept_access(): void
+    {
+        $staff = \Mockery::mock(Staff::class);
+        $staff->shouldReceive('can')
+            ->with('tickets.set-status')
+            ->andReturn(true);
+
+        $ticket = Ticket::factory()->create(['dept_id' => 3]);
+
+        $this->deptService->shouldReceive('hasAccessToDepartment')
+            ->with($staff, 3)
+            ->andReturn(false);
+
+        $this->assertFalse($this->policy->setStatus($staff, $ticket));
+    }
+}

--- a/tests/Unit/Services/Scp/Queues/QueueColumnsServiceTest.php
+++ b/tests/Unit/Services/Scp/Queues/QueueColumnsServiceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Queues;
+
+use App\Models\Queue;
+use App\Models\Staff;
+use App\Services\Scp\Queues\QueueColumnsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class QueueColumnsServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private QueueColumnsService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create queue_column table if it doesn't exist
+        if (!Schema::connection('legacy')->hasTable('queue_column')) {
+            Schema::connection('legacy')->create('queue_column', function ($table) {
+                $table->unsignedInteger('id')->autoIncrement();
+                $table->unsignedInteger('queue_id');
+                $table->string('name', 64);
+                $table->unsignedInteger('sort')->default(0);
+                $table->unsignedInteger('width')->default(0);
+                $table->tinyInteger('truncate')->default(0);
+                $table->tinyInteger('translatable')->default(0);
+                $table->string('heading', 64)->default('');
+                $table->tinyInteger('primary')->default(0);
+                $table->tinyInteger('secondary')->default(0);
+                $table->tinyInteger('filter')->default(0);
+                $table->string('flags', 255)->default('');
+                $table->timestamp('updated')->nullable();
+            });
+        }
+
+        // Create queue_columns table if it doesn't exist
+        if (!Schema::connection('legacy')->hasTable('queue_columns')) {
+            Schema::connection('legacy')->create('queue_columns', function ($table) {
+                $table->unsignedInteger('queue_id');
+                $table->unsignedInteger('column_id');
+                $table->unsignedInteger('staff_id');
+                $table->unsignedInteger('sort')->default(0);
+                $table->unsignedInteger('width')->default(0);
+                $table->string('heading', 64)->default('');
+                $table->string('bits', 255)->default('');
+                $table->primary(['queue_id', 'column_id', 'staff_id']);
+            });
+        }
+
+        // Clean up tables
+        DB::connection('legacy')->table('queue_columns')->delete();
+        DB::connection('legacy')->table('queue_column')->delete();
+
+        $this->service = new QueueColumnsService();
+    }
+
+    public function test_upserts_per_staff_column_rows(): void
+    {
+        $queue = Queue::factory()->create();
+        $staff = Staff::factory()->create();
+
+        // Seed queue_column rows
+        DB::connection('legacy')->table('queue_column')->insert([
+            ['id' => 1, 'queue_id' => $queue->id, 'name' => 'ticket_id', 'sort' => 0, 'width' => 100],
+            ['id' => 2, 'queue_id' => $queue->id, 'name' => 'subject', 'sort' => 1, 'width' => 200],
+        ]);
+
+        // Update columns for staff
+        $this->service->update($staff, $queue, [
+            ['column_id' => 1, 'sort' => 0, 'width' => 150, 'heading' => 'ID'],
+            ['column_id' => 2, 'sort' => 1, 'width' => 250, 'heading' => 'Subject'],
+        ]);
+
+        // Verify rows were upserted
+        $this->assertDatabaseHas(
+            'queue_columns',
+            [
+                'queue_id' => $queue->id,
+                'column_id' => 1,
+                'staff_id' => $staff->staff_id,
+                'sort' => 0,
+                'width' => 150,
+                'heading' => 'ID',
+            ],
+            'legacy'
+        );
+
+        $this->assertDatabaseHas(
+            'queue_columns',
+            [
+                'queue_id' => $queue->id,
+                'column_id' => 2,
+                'staff_id' => $staff->staff_id,
+                'sort' => 1,
+                'width' => 250,
+                'heading' => 'Subject',
+            ],
+            'legacy'
+        );
+    }
+
+    public function test_does_not_write_staff_id_zero_default_rows(): void
+    {
+        $queue = Queue::factory()->create();
+        $staff = Staff::factory()->create();
+
+        // Seed queue_column rows
+        DB::connection('legacy')->table('queue_column')->insert([
+            ['id' => 1, 'queue_id' => $queue->id, 'name' => 'ticket_id', 'sort' => 0, 'width' => 100],
+        ]);
+
+        // Update columns for staff
+        $this->service->update($staff, $queue, [
+            ['column_id' => 1, 'sort' => 0, 'width' => 150, 'heading' => 'ID'],
+        ]);
+
+        // Verify no staff_id=0 row exists
+        $zeroStaffRows = DB::connection('legacy')->table('queue_columns')
+            ->where('queue_id', $queue->id)
+            ->where('column_id', 1)
+            ->where('staff_id', 0)
+            ->count();
+
+        $this->assertSame(0, $zeroStaffRows);
+
+        // Verify the staff-specific row exists
+        $this->assertDatabaseHas(
+            'queue_columns',
+            [
+                'queue_id' => $queue->id,
+                'column_id' => 1,
+                'staff_id' => $staff->staff_id,
+            ],
+            'legacy'
+        );
+    }
+
+    public function test_throws_for_invalid_column_id(): void
+    {
+        $queue = Queue::factory()->create();
+        $staff = Staff::factory()->create();
+
+        // Seed queue_column rows
+        DB::connection('legacy')->table('queue_column')->insert([
+            ['id' => 1, 'queue_id' => $queue->id, 'name' => 'ticket_id', 'sort' => 0, 'width' => 100],
+        ]);
+
+        // Try to update with non-existent column_id
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->service->update($staff, $queue, [
+            ['column_id' => 999, 'sort' => 0, 'width' => 150, 'heading' => 'Invalid'],
+        ]);
+    }
+}

--- a/tests/Unit/Services/Scp/Queues/QueueConfigServiceTest.php
+++ b/tests/Unit/Services/Scp/Queues/QueueConfigServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Queues;
+
+use App\Models\Queue;
+use App\Models\Staff;
+use App\Services\Scp\Queues\QueueConfigService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class QueueConfigServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private QueueConfigService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!Schema::connection('legacy')->hasTable('queue_config')) {
+            Schema::connection('legacy')->create('queue_config', function ($table) {
+                $table->unsignedInteger('queue_id');
+                $table->unsignedInteger('staff_id');
+                $table->text('setting')->nullable();
+                $table->timestamp('updated')->nullable();
+                $table->primary(['queue_id', 'staff_id']);
+            });
+        }
+
+        DB::connection('legacy')->table('queue_config')->delete();
+
+        $this->service = new QueueConfigService();
+    }
+
+    public function test_upserts_config_json(): void
+    {
+        $queue = Queue::factory()->create();
+        $staff = Staff::factory()->create();
+
+        $config = [
+            'sort_id' => 5,
+            'filter' => 'status:open',
+            'criteria_inheritance' => true,
+            'columns_inheritance' => false,
+            'sort_inheritance' => true,
+        ];
+
+        $this->service->update($staff, $queue, $config);
+
+        $this->assertDatabaseHas(
+            'queue_config',
+            [
+                'queue_id' => $queue->id,
+                'staff_id' => $staff->staff_id,
+                'setting' => json_encode($config),
+            ],
+            'legacy'
+        );
+    }
+
+    public function test_updates_existing_config(): void
+    {
+        $queue = Queue::factory()->create();
+        $staff = Staff::factory()->create();
+
+        $initialConfig = [
+            'sort_id' => 1,
+            'filter' => 'status:open',
+            'criteria_inheritance' => true,
+            'columns_inheritance' => false,
+            'sort_inheritance' => true,
+        ];
+
+        $this->service->update($staff, $queue, $initialConfig);
+
+        $updatedConfig = [
+            'sort_id' => 2,
+            'filter' => 'status:closed',
+            'criteria_inheritance' => false,
+            'columns_inheritance' => true,
+            'sort_inheritance' => false,
+        ];
+
+        $this->service->update($staff, $queue, $updatedConfig);
+
+        $count = DB::connection('legacy')->table('queue_config')
+            ->where('queue_id', $queue->id)
+            ->where('staff_id', $staff->staff_id)
+            ->count();
+
+        $this->assertSame(1, $count);
+
+        $this->assertDatabaseHas(
+            'queue_config',
+            [
+                'queue_id' => $queue->id,
+                'staff_id' => $staff->staff_id,
+                'setting' => json_encode($updatedConfig),
+            ],
+            'legacy'
+        );
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/ActionLoggerTest.php
+++ b/tests/Unit/Services/Scp/Tickets/ActionLoggerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Models\Scp\ScpActionLog;
+use App\Models\Staff;
+use App\Services\Scp\Tickets\ActionLogger;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+final class ActionLoggerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ActionLogger $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->logger = new ActionLogger();
+    }
+
+    public function test_logs_success_action_with_full_context(): void
+    {
+        $staff = Staff::factory()->create();
+        $request = $this->createRequest('192.168.1.1', 'Mozilla/5.0', 'req-123');
+
+        $log = $this->logger->record(
+            staff: $staff,
+            action: 'ticket_update',
+            outcome: 'success',
+            httpStatus: 200,
+            ticketId: 42,
+            threadId: 10,
+            queueId: 5,
+            beforeState: ['status' => 'open'],
+            afterState: ['status' => 'closed'],
+            lockId: 'lock-abc',
+            request: $request
+        );
+
+        $this->assertInstanceOf(ScpActionLog::class, $log);
+        $this->assertDatabaseHas('scp_action_log', [
+            'staff_id' => $staff->staff_id,
+            'ticket_id' => 42,
+            'thread_id' => 10,
+            'queue_id' => 5,
+            'action' => 'ticket_update',
+            'outcome' => 'success',
+            'http_status' => 200,
+            'lock_id' => 'lock-abc',
+            'request_id' => 'req-123',
+            'ip_address' => '192.168.1.1',
+            'user_agent' => 'Mozilla/5.0',
+        ]);
+
+        $this->assertEquals(['status' => 'open'], $log->before_state);
+        $this->assertEquals(['status' => 'closed'], $log->after_state);
+    }
+
+    public function test_logs_failure_with_error_class(): void
+    {
+        $staff = Staff::factory()->create();
+        $request = $this->createRequest('10.0.0.1', 'Chrome/90', 'req-456');
+
+        $log = $this->logger->recordFailure(
+            staff: $staff,
+            action: 'ticket_lock_check',
+            httpStatus: 423,
+            ticketId: 99,
+            errorClass: 'TicketLockedException',
+            request: $request
+        );
+
+        $this->assertInstanceOf(ScpActionLog::class, $log);
+        $this->assertDatabaseHas('scp_action_log', [
+            'staff_id' => $staff->staff_id,
+            'ticket_id' => 99,
+            'action' => 'ticket_lock_check',
+            'outcome' => 'failed',
+            'http_status' => 423,
+            'request_id' => 'req-456',
+            'ip_address' => '10.0.0.1',
+            'user_agent' => 'Chrome/90',
+        ]);
+
+        $this->assertEquals(['error_class' => 'TicketLockedException'], $log->before_state);
+    }
+
+    private function createRequest(string $ip, string $userAgent, string $requestId): Request
+    {
+        $request = Request::create('/', 'GET', [], [], [], [
+            'REMOTE_ADDR' => $ip,
+            'HTTP_USER_AGENT' => $userAgent,
+        ]);
+        $request->headers->set('X-Request-Id', $requestId);
+
+        return $request;
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/AssignmentServiceTest.php
+++ b/tests/Unit/Services/Scp/Tickets/AssignmentServiceTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Models\Staff;
+use App\Models\Team;
+use App\Models\Thread;
+use App\Models\ThreadEvent;
+use App\Models\Ticket;
+use App\Services\Scp\Tickets\AssignmentService;
+use App\Services\Scp\Tickets\NotePostingService;
+use App\Services\Scp\Tickets\ThreadEventWriter;
+use App\Services\Scp\Tickets\TicketCacheUpdater;
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class AssignmentServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AssignmentService $service;
+
+    private NotePostingService $notePostingService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::connection('legacy')->dropIfExists('ticket');
+        Schema::connection('legacy')->create('ticket', function (Blueprint $table): void {
+            $table->unsignedInteger('ticket_id')->autoIncrement();
+            $table->string('number', 20)->unique();
+            $table->unsignedInteger('user_id')->default(0);
+            $table->unsignedInteger('status_id')->default(1);
+            $table->unsignedInteger('dept_id')->default(0);
+            $table->unsignedInteger('staff_id')->default(0);
+            $table->unsignedInteger('team_id')->default(0);
+            $table->unsignedInteger('sla_id')->default(0);
+            $table->unsignedInteger('email_id')->default(0);
+            $table->string('source', 32)->default('web');
+            $table->string('ip_address', 45)->nullable();
+            $table->tinyInteger('isoverdue')->default(0);
+            $table->tinyInteger('isanswered')->default(0);
+            $table->dateTime('duedate')->nullable();
+            $table->dateTime('closed')->nullable();
+            $table->dateTime('lastupdate')->useCurrent();
+            $table->dateTime('lastmessage')->useCurrent();
+            $table->dateTime('lastresponse')->useCurrent();
+            $table->dateTime('created')->useCurrent();
+            $table->dateTime('updated')->useCurrent();
+        });
+
+        $this->ensureLegacyTable('event', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->string('name')->unique();
+            $table->text('description')->nullable();
+        });
+
+        $this->ensureLegacyTable('thread_event', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->unsignedInteger('thread_id');
+            $table->char('thread_type', 1);
+            $table->unsignedInteger('event_id');
+            $table->unsignedInteger('staff_id');
+            $table->unsignedInteger('team_id')->default(0);
+            $table->unsignedInteger('dept_id')->default(0);
+            $table->unsignedInteger('topic_id')->default(0);
+            $table->json('data')->nullable();
+            $table->string('username')->nullable();
+            $table->unsignedInteger('uid')->nullable();
+            $table->char('uid_type', 1)->nullable();
+            $table->tinyInteger('annulled')->default(0);
+            $table->dateTime('timestamp');
+        });
+
+        $this->ensureLegacyTable('_search', function (Blueprint $table): void {
+            $table->string('object_type', 8);
+            $table->unsignedInteger('object_id');
+            $table->text('title');
+            $table->text('content');
+            $table->primary(['object_type', 'object_id']);
+        });
+
+        $this->ensureLegacyTable('thread_entry', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->unsignedInteger('thread_id');
+            $table->unsignedInteger('staff_id')->default(0);
+            $table->unsignedInteger('user_id')->default(0);
+            $table->char('type', 1);
+            $table->string('poster')->default('');
+            $table->string('source')->default('');
+            $table->string('title')->default('');
+            $table->text('body')->nullable();
+            $table->string('format')->default('text');
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+
+        $this->ensureLegacyTable('team', function (Blueprint $table): void {
+            $table->unsignedInteger('team_id')->autoIncrement();
+            $table->unsignedInteger('lead_id')->nullable();
+            $table->unsignedInteger('flags')->default(1);
+            $table->string('name', 64);
+            $table->string('notes', 255)->nullable();
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+
+        DB::connection('legacy')->table('thread_event')->delete();
+        DB::connection('legacy')->table('thread_entry')->delete();
+        DB::connection('legacy')->table('_search')->delete();
+        DB::connection('legacy')->table('event')->delete();
+        DB::connection('legacy')->table('team')->delete();
+
+        DB::connection('legacy')->table('event')->insert([
+            ['id' => 7, 'name' => 'created', 'description' => 'Note created'],
+            ['id' => 100, 'name' => 'assigned', 'description' => 'Ticket assigned'],
+            ['id' => 101, 'name' => 'released', 'description' => 'Ticket released'],
+        ]);
+
+        $this->notePostingService = app(NotePostingService::class);
+
+        $this->service = new AssignmentService(
+            app(ThreadEventWriter::class),
+            $this->notePostingService,
+            app(TicketCacheUpdater::class),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_assigns_to_staff_clears_team(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-03 16:00:00'));
+
+        $ticket = Ticket::factory()->create([
+            'staff_id' => 0,
+            'team_id' => 44,
+            'updated' => '2026-05-03 15:00:00',
+            'lastupdate' => '2026-05-03 15:00:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create([
+            'object_type' => 'T',
+        ]);
+        $caller = Staff::factory()->create([
+            'firstname' => 'Grace',
+            'lastname' => 'Hopper',
+        ]);
+        $assignee = Staff::factory()->create();
+
+        $this->service->assign(
+            ticket: $ticket,
+            thread: $thread,
+            caller: $caller,
+            type: 'staff',
+            assigneeId: $assignee->staff_id,
+            comments: 'Taking ownership',
+            expectedUpdated: '2026-05-03 15:00:00',
+        );
+
+        $ticket->refresh();
+
+        $this->assertSame($assignee->staff_id, (int) $ticket->staff_id);
+        $this->assertSame(0, (int) $ticket->team_id);
+        $this->assertSame('2026-05-03 16:00:00', (string) $ticket->updated);
+        $this->assertSame('2026-05-03 16:00:00', (string) $ticket->lastupdate);
+        $this->assertDatabaseHas('thread_entry', [
+            'thread_id' => $thread->id,
+            'staff_id' => $caller->staff_id,
+            'type' => 'N',
+            'format' => 'text',
+            'body' => 'Taking ownership',
+        ], 'legacy');
+
+        $event = ThreadEvent::on('legacy')->latest('id')->firstOrFail();
+        $data = json_decode((string) $event->data, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(100, (int) $event->event_id);
+        $this->assertSame($thread->id, (int) $event->thread_id);
+        $this->assertSame($caller->staff_id, (int) $event->staff_id);
+        $this->assertSame(['id' => $assignee->staff_id], $data['staff']);
+        $this->assertNull($data['team']);
+        $this->assertSame(['staff_id' => 0, 'team_id' => 44], $data['before']);
+    }
+
+    public function test_assigns_to_team_clears_staff(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-03 17:00:00'));
+
+        $assignedStaff = Staff::factory()->create();
+        $caller = Staff::factory()->create();
+        $team = Team::query()->create([
+            'lead_id' => $caller->staff_id,
+            'name' => 'Escalations',
+            'notes' => 'Ops queue',
+        ]);
+
+        $ticket = Ticket::factory()->create([
+            'staff_id' => $assignedStaff->staff_id,
+            'team_id' => 0,
+            'updated' => '2026-05-03 16:30:00',
+            'lastupdate' => '2026-05-03 16:30:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create([
+            'object_type' => 'T',
+        ]);
+
+        $this->service->assign(
+            ticket: $ticket,
+            thread: $thread,
+            caller: $caller,
+            type: 'team',
+            assigneeId: $team->team_id,
+            comments: null,
+            expectedUpdated: '2026-05-03 16:30:00',
+        );
+
+        $ticket->refresh();
+
+        $this->assertSame(0, (int) $ticket->staff_id);
+        $this->assertSame($team->team_id, (int) $ticket->team_id);
+        $this->assertSame('2026-05-03 17:00:00', (string) $ticket->updated);
+        $this->assertDatabaseCount('thread_entry', 0, 'legacy');
+
+        $event = ThreadEvent::on('legacy')->latest('id')->firstOrFail();
+        $data = json_decode((string) $event->data, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(100, (int) $event->event_id);
+        $this->assertNull($data['staff']);
+        $this->assertSame(['id' => $team->team_id], $data['team']);
+        $this->assertSame([
+            'staff_id' => $assignedStaff->staff_id,
+            'team_id' => 0,
+        ], $data['before']);
+    }
+
+    public function test_release_zeros_both_columns(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-03 18:00:00'));
+
+        $caller = Staff::factory()->create([
+            'firstname' => 'Katherine',
+            'lastname' => 'Johnson',
+        ]);
+        $team = Team::query()->create([
+            'lead_id' => $caller->staff_id,
+            'name' => 'Tier 2',
+        ]);
+        $assignedStaff = Staff::factory()->create();
+
+        $ticket = Ticket::factory()->create([
+            'staff_id' => $assignedStaff->staff_id,
+            'team_id' => $team->team_id,
+            'updated' => '2026-05-03 17:30:00',
+            'lastupdate' => '2026-05-03 17:30:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create([
+            'object_type' => 'T',
+        ]);
+
+        $this->service->release(
+            ticket: $ticket,
+            thread: $thread,
+            caller: $caller,
+            comments: 'Released for reassignment',
+            expectedUpdated: '2026-05-03 17:30:00',
+        );
+
+        $ticket->refresh();
+
+        $this->assertSame(0, (int) $ticket->staff_id);
+        $this->assertSame(0, (int) $ticket->team_id);
+        $this->assertSame('2026-05-03 18:00:00', (string) $ticket->updated);
+        $this->assertDatabaseHas('thread_entry', [
+            'thread_id' => $thread->id,
+            'staff_id' => $caller->staff_id,
+            'type' => 'N',
+            'format' => 'text',
+            'body' => 'Released for reassignment',
+        ], 'legacy');
+
+        $event = ThreadEvent::on('legacy')->latest('id')->firstOrFail();
+        $data = json_decode((string) $event->data, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(101, (int) $event->event_id);
+        $this->assertNull($data['staff']);
+        $this->assertNull($data['team']);
+        $this->assertSame([
+            'staff_id' => $assignedStaff->staff_id,
+            'team_id' => $team->team_id,
+        ], $data['before']);
+    }
+
+    private function ensureLegacyTable(string $table, \Closure $definition): void
+    {
+        if (! Schema::connection('legacy')->hasTable($table)) {
+            Schema::connection('legacy')->create($table, $definition);
+        }
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/LegacyConfigReaderTest.php
+++ b/tests/Unit/Services/Scp/Tickets/LegacyConfigReaderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Services\Scp\Tickets\LegacyConfigReader;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class LegacyConfigReaderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        
+        $schema = Schema::connection('legacy');
+        if (! $schema->hasTable('config')) {
+            $schema->create('config', function (Blueprint $table): void {
+                $table->id();
+                $table->string('namespace');
+                $table->string('key');
+                $table->text('value');
+                $table->timestamp('updated')->nullable();
+            });
+        }
+        
+        DB::connection('legacy')->table('config')->where('namespace', 'core')->delete();
+    }
+
+    public function test_returns_lock_disabled_when_setting_is_zero(): void
+    {
+        DB::connection('legacy')->table('config')->insert([
+            ['namespace' => 'core', 'key' => 'ticket_lock', 'value' => '0', 'updated' => now()],
+        ]);
+
+        $reader = new LegacyConfigReader();
+
+        $this->assertSame('disabled', $reader->ticketLockMode());
+    }
+
+    public function test_returns_on_view_when_setting_is_one(): void
+    {
+        DB::connection('legacy')->table('config')->insert([
+            ['namespace' => 'core', 'key' => 'ticket_lock', 'value' => '1', 'updated' => now()],
+        ]);
+
+        $reader = new LegacyConfigReader();
+        $this->assertSame('on_view', $reader->ticketLockMode());
+    }
+
+    public function test_returns_on_activity_when_setting_is_two(): void
+    {
+        DB::connection('legacy')->table('config')->insert([
+            ['namespace' => 'core', 'key' => 'ticket_lock', 'value' => '2', 'updated' => now()],
+        ]);
+
+        $reader = new LegacyConfigReader();
+        $this->assertSame('on_activity', $reader->ticketLockMode());
+    }
+
+    public function test_defaults_to_disabled_when_setting_missing(): void
+    {
+        $reader = new LegacyConfigReader();
+        $this->assertSame('disabled', $reader->ticketLockMode());
+    }
+
+    public function test_lock_time_returns_seconds_with_default_180(): void
+    {
+        DB::connection('legacy')->table('config')->insert([
+            ['namespace' => 'core', 'key' => 'lock_time', 'value' => '5', 'updated' => now()],
+        ]);
+
+        $reader = new LegacyConfigReader();
+        $this->assertSame(300, $reader->lockTime());  // 5 minutes = 300s
+    }
+
+    public function test_lock_time_default_when_missing(): void
+    {
+        $reader = new LegacyConfigReader();
+        $this->assertSame(180, $reader->lockTime());
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/LockServiceTest.php
+++ b/tests/Unit/Services/Scp/Tickets/LockServiceTest.php
@@ -1,0 +1,376 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Exceptions\TicketLockedException;
+use App\Models\Lock;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Scp\ScpActionLog;
+use App\Services\Scp\Tickets\ActionLogger;
+use App\Services\Scp\Tickets\LegacyConfigReader;
+use App\Services\Scp\Tickets\LockService;
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class LockServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private LockService $service;
+
+    private string $legacyDatabasePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->legacyDatabasePath = sys_get_temp_dir().'/lock-service-legacy.sqlite';
+        touch($this->legacyDatabasePath);
+
+        config()->set('database.connections.legacy.database', $this->legacyDatabasePath);
+        config()->set('database.connections.osticket2.database', $this->legacyDatabasePath);
+        DB::purge('legacy');
+        DB::purge('osticket2');
+
+        $this->ensureLegacyTables();
+        $this->resetTables();
+
+        $this->service = new LockService(new LegacyConfigReader(), new ActionLogger());
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        DB::purge('legacy');
+        DB::purge('osticket2');
+
+        if (isset($this->legacyDatabasePath) && file_exists($this->legacyDatabasePath)) {
+            unlink($this->legacyDatabasePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_acquire_creates_row_when_none_exists(): void
+    {
+        Carbon::setTestNow('2026-05-03 10:00:00');
+
+        $staff = $this->createStaff();
+        $ticket = $this->createTicket();
+        $this->setLockConfig(mode: '1', minutes: 5);
+
+        $lock = $this->service->acquire($staff, $ticket);
+
+        $this->assertInstanceOf(Lock::class, $lock);
+        $this->assertSame('T', $lock->object_type);
+        $this->assertSame($ticket->ticket_id, $lock->object_id);
+        $this->assertSame($staff->staff_id, $lock->staff_id);
+        $this->assertSame('2026-05-03 10:05:00', Carbon::parse($lock->expire)->toDateTimeString());
+        $this->assertDatabaseHas('lock', [
+            'lock_id' => $lock->lock_id,
+            'object_type' => 'T',
+            'object_id' => $ticket->ticket_id,
+            'staff_id' => $staff->staff_id,
+            'expire' => '2026-05-03 10:05:00',
+        ], 'legacy');
+    }
+
+    public function test_acquire_returns_existing_lock_when_held_by_caller(): void
+    {
+        Carbon::setTestNow('2026-05-03 10:00:00');
+
+        $staff = $this->createStaff();
+        $ticket = $this->createTicket();
+        $this->setLockConfig(mode: '1', minutes: 5);
+        $existing = $this->createLock($ticket, $staff, '2026-05-03 10:01:00');
+
+        Carbon::setTestNow('2026-05-03 10:02:00');
+
+        $lock = $this->service->acquire($staff, $ticket);
+
+        $this->assertSame($existing->lock_id, $lock->lock_id);
+        $this->assertSame('2026-05-03 10:07:00', Carbon::parse($lock->expire)->toDateTimeString());
+        $this->assertDatabaseHas('lock', [
+            'lock_id' => $existing->lock_id,
+            'staff_id' => $staff->staff_id,
+            'expire' => '2026-05-03 10:07:00',
+        ], 'legacy');
+    }
+
+    public function test_acquire_throws_when_held_by_other_and_not_expired(): void
+    {
+        Carbon::setTestNow('2026-05-03 10:00:00');
+
+        $caller = $this->createStaff();
+        $owner = $this->createStaff();
+        $ticket = $this->createTicket();
+        $this->setLockConfig(mode: '1', minutes: 5);
+        $this->createLock($ticket, $owner, '2026-05-03 10:05:00');
+
+        $this->expectException(TicketLockedException::class);
+
+        try {
+            $this->service->acquire($caller, $ticket);
+        } catch (TicketLockedException $exception) {
+            $this->assertSame($ticket->ticket_id, $exception->ticketId);
+            $this->assertSame($owner->staff_id, $exception->heldByStaffId);
+            $this->assertSame('2026-05-03 10:05:00', $exception->expiresAt);
+
+            throw $exception;
+        }
+    }
+
+    public function test_acquire_steals_when_existing_lock_expired(): void
+    {
+        Carbon::setTestNow('2026-05-03 10:10:00');
+
+        $caller = $this->createStaff();
+        $owner = $this->createStaff();
+        $ticket = $this->createTicket();
+        $this->setLockConfig(mode: '1', minutes: 5);
+        $existing = $this->createLock($ticket, $owner, '2026-05-03 10:09:00');
+
+        $lock = $this->service->acquire($caller, $ticket);
+
+        $this->assertSame($existing->lock_id, $lock->lock_id);
+        $this->assertSame($caller->staff_id, $lock->staff_id);
+        $this->assertSame('2026-05-03 10:15:00', Carbon::parse($lock->expire)->toDateTimeString());
+        $this->assertDatabaseHas('lock', [
+            'lock_id' => $existing->lock_id,
+            'staff_id' => $caller->staff_id,
+            'expire' => '2026-05-03 10:15:00',
+        ], 'legacy');
+        $this->assertDatabaseHas('scp_action_log', [
+            'staff_id' => $caller->staff_id,
+            'ticket_id' => $ticket->ticket_id,
+            'action' => 'lock.stolen',
+            'outcome' => 'success',
+            'http_status' => 200,
+            'lock_id' => (string) $existing->lock_id,
+        ]);
+
+        $audit = ScpActionLog::query()->where('action', 'lock.stolen')->firstOrFail();
+        $this->assertSame(['staff_id' => $owner->staff_id, 'expire' => '2026-05-03 10:09:00'], $audit->before_state);
+        $this->assertSame(['staff_id' => $caller->staff_id, 'expire' => '2026-05-03 10:15:00'], $audit->after_state);
+    }
+
+    public function test_renew_extends_expiry_for_owner(): void
+    {
+        Carbon::setTestNow('2026-05-03 10:00:00');
+
+        $staff = $this->createStaff();
+        $ticket = $this->createTicket();
+        $this->setLockConfig(mode: '1', minutes: 3);
+        $lock = $this->createLock($ticket, $staff, '2026-05-03 10:04:00');
+
+        Carbon::setTestNow('2026-05-03 10:02:00');
+
+        $renewed = $this->service->renew($staff, $ticket);
+
+        $this->assertSame($lock->lock_id, $renewed->lock_id);
+        $this->assertSame('2026-05-03 10:05:00', Carbon::parse($renewed->expire)->toDateTimeString());
+    }
+
+    public function test_renew_throws_for_non_owner(): void
+    {
+        Carbon::setTestNow('2026-05-03 10:00:00');
+
+        $caller = $this->createStaff();
+        $owner = $this->createStaff();
+        $ticket = $this->createTicket();
+        $this->setLockConfig(mode: '1', minutes: 5);
+        $this->createLock($ticket, $owner, '2026-05-03 10:05:00');
+
+        $this->expectException(TicketLockedException::class);
+
+        $this->service->renew($caller, $ticket);
+    }
+
+    public function test_release_deletes_owner_lock(): void
+    {
+        $staff = $this->createStaff();
+        $other = $this->createStaff();
+        $ticket = $this->createTicket();
+
+        $ownerLock = $this->createLock($ticket, $staff, '2026-05-03 10:05:00');
+        $otherLock = Lock::on('legacy')->create([
+            'object_type' => 'T',
+            'object_id' => $ticket->ticket_id + 1,
+            'staff_id' => $other->staff_id,
+            'expire' => '2026-05-03 10:05:00',
+        ]);
+
+        $this->service->release($staff, $ticket);
+
+        $this->assertDatabaseMissing('lock', ['lock_id' => $ownerLock->lock_id], 'legacy');
+        $this->assertDatabaseHas('lock', ['lock_id' => $otherLock->lock_id], 'legacy');
+    }
+
+    public function test_assert_held_by_passes_in_disabled_mode(): void
+    {
+        $staff = $this->createStaff();
+        $ticket = $this->createTicket();
+        $this->setLockConfig(mode: '0', minutes: 5);
+
+        $this->service->assertHeldBy($staff, $ticket);
+
+        $this->assertTrue(true);
+    }
+
+    public function test_assert_held_by_throws_on_view_mode_without_lock(): void
+    {
+        $staff = $this->createStaff();
+        $ticket = $this->createTicket();
+        $this->setLockConfig(mode: '1', minutes: 5);
+
+        $this->expectException(TicketLockedException::class);
+
+        try {
+            $this->service->assertHeldBy($staff, $ticket);
+        } catch (TicketLockedException $exception) {
+            $this->assertSame($ticket->ticket_id, $exception->ticketId);
+            $this->assertSame(0, $exception->heldByStaffId);
+            $this->assertSame('', $exception->expiresAt);
+
+            throw $exception;
+        }
+    }
+
+    private function ensureLegacyTables(): void
+    {
+        $schema = Schema::connection('legacy');
+
+        if (! $schema->hasTable('config')) {
+            $schema->create('config', function (Blueprint $table): void {
+                $table->id();
+                $table->string('namespace');
+                $table->string('key');
+                $table->text('value');
+                $table->timestamp('updated')->nullable();
+            });
+        }
+
+        if (! $schema->hasTable('ticket')) {
+            $schema->create('ticket', function (Blueprint $table): void {
+                $table->unsignedInteger('ticket_id')->autoIncrement();
+                $table->string('number')->default('T-1');
+                $table->unsignedInteger('user_id')->default(1);
+                $table->unsignedInteger('status_id')->default(1);
+                $table->unsignedInteger('dept_id')->default(1);
+                $table->unsignedInteger('staff_id')->default(0);
+                $table->unsignedInteger('sla_id')->default(0);
+                $table->unsignedInteger('email_id')->default(0);
+                $table->string('source')->default('Web');
+                $table->string('ip_address')->default('127.0.0.1');
+                $table->tinyInteger('isoverdue')->default(0);
+                $table->tinyInteger('isanswered')->default(0);
+                $table->timestamp('duedate')->nullable();
+                $table->timestamp('closed')->nullable();
+                $table->timestamp('lastupdate')->useCurrent();
+                $table->timestamp('lastmessage')->useCurrent();
+                $table->timestamp('lastresponse')->useCurrent();
+                $table->timestamp('created')->useCurrent();
+                $table->timestamp('updated')->useCurrent();
+            });
+        }
+
+        if (! $schema->hasTable('staff')) {
+            $schema->create('staff', function (Blueprint $table): void {
+                $table->unsignedInteger('staff_id')->autoIncrement();
+                $table->unsignedInteger('dept_id')->default(1);
+                $table->string('username', 32)->unique();
+                $table->string('firstname', 64)->default('');
+                $table->string('lastname', 64)->default('');
+                $table->string('email', 128)->default('');
+                $table->string('passwd', 128)->default('');
+                $table->tinyInteger('isactive')->default(1);
+                $table->tinyInteger('isadmin')->default(0);
+                $table->timestamp('created')->nullable();
+                $table->timestamp('lastlogin')->nullable();
+            });
+        }
+
+        if (! $schema->hasTable('lock')) {
+            $schema->create('lock', function (Blueprint $table): void {
+                $table->unsignedInteger('lock_id')->autoIncrement();
+                $table->char('object_type', 1);
+                $table->unsignedInteger('object_id');
+                $table->unsignedInteger('staff_id');
+                $table->timestamp('expire');
+            });
+        }
+    }
+
+    private function resetTables(): void
+    {
+        DB::connection('legacy')->table('lock')->delete();
+        DB::connection('legacy')->table('ticket')->delete();
+        DB::connection('legacy')->table('staff')->delete();
+        DB::connection('legacy')->table('config')->where('namespace', 'core')->delete();
+        ScpActionLog::query()->delete();
+    }
+
+    private function setLockConfig(string $mode, int $minutes): void
+    {
+        DB::connection('legacy')->table('config')->insert([
+            ['namespace' => 'core', 'key' => 'ticket_lock', 'value' => $mode, 'updated' => now()],
+            ['namespace' => 'core', 'key' => 'lock_time', 'value' => (string) $minutes, 'updated' => now()],
+        ]);
+    }
+
+    private function createTicket(): Ticket
+    {
+        return Ticket::on('legacy')->create([
+            'number' => 'T-'.fake()->unique()->numerify('#####'),
+            'user_id' => 1,
+            'status_id' => 1,
+            'dept_id' => 1,
+            'staff_id' => 0,
+            'sla_id' => 0,
+            'email_id' => 0,
+            'source' => 'Web',
+            'ip_address' => '127.0.0.1',
+            'isoverdue' => 0,
+            'isanswered' => 0,
+            'lastupdate' => now(),
+            'lastmessage' => now(),
+            'lastresponse' => now(),
+            'created' => now(),
+            'updated' => now(),
+        ]);
+    }
+
+    private function createStaff(): Staff
+    {
+        return Staff::on('legacy')->create([
+            'dept_id' => 1,
+            'username' => fake()->unique()->userName(),
+            'firstname' => fake()->firstName(),
+            'lastname' => fake()->lastName(),
+            'email' => fake()->unique()->safeEmail(),
+            'passwd' => 'password',
+            'isactive' => 1,
+            'isadmin' => 0,
+            'created' => now(),
+            'lastlogin' => null,
+        ]);
+    }
+
+    private function createLock(Ticket $ticket, Staff $staff, string $expire): Lock
+    {
+        return Lock::on('legacy')->create([
+            'object_type' => 'T',
+            'object_id' => $ticket->ticket_id,
+            'staff_id' => $staff->staff_id,
+            'expire' => $expire,
+        ]);
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/NotePostingServiceTest.php
+++ b/tests/Unit/Services/Scp/Tickets/NotePostingServiceTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Exceptions\TicketModifiedConcurrentlyException;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use App\Models\ThreadEntry;
+use App\Services\Scp\Tickets\NotePostingService;
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class NotePostingServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private NotePostingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensureLegacyTable('event', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->string('name')->unique();
+            $table->text('description')->nullable();
+        });
+
+        $this->ensureLegacyTable('thread_event', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->unsignedInteger('thread_id');
+            $table->char('thread_type', 1);
+            $table->unsignedInteger('event_id');
+            $table->unsignedInteger('staff_id');
+            $table->unsignedInteger('team_id')->default(0);
+            $table->unsignedInteger('dept_id')->default(0);
+            $table->unsignedInteger('topic_id')->default(0);
+            $table->json('data')->nullable();
+            $table->string('username')->nullable();
+            $table->unsignedInteger('uid')->nullable();
+            $table->char('uid_type', 1)->nullable();
+            $table->tinyInteger('annulled')->default(0);
+            $table->dateTime('timestamp');
+        });
+
+        $this->ensureLegacyTable('_search', function (Blueprint $table): void {
+            $table->string('object_type', 8);
+            $table->unsignedInteger('object_id');
+            $table->text('title');
+            $table->text('content');
+            $table->primary(['object_type', 'object_id']);
+        });
+
+        $this->ensureLegacyTable('thread_entry', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->unsignedInteger('thread_id');
+            $table->unsignedInteger('staff_id')->default(0);
+            $table->unsignedInteger('user_id')->default(0);
+            $table->char('type', 1);
+            $table->string('poster')->default('');
+            $table->string('source')->default('');
+            $table->string('title')->default('');
+            $table->text('body')->nullable();
+            $table->string('format')->default('text');
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+
+        foreach (['_search', 'thread_event', 'thread_entry', 'event', 'thread', 'ticket', 'staff'] as $table) {
+            DB::connection('legacy')->table($table)->delete();
+        }
+
+        DB::connection('legacy')->table('event')->insertOrIgnore([
+            ['id' => 7, 'name' => 'created'],
+        ]);
+
+        $this->service = app(NotePostingService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_posts_note_with_full_side_effect_chain(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-03 11:15:00'));
+
+        $ticket = Ticket::factory()->create([
+            'lastupdate' => '2026-05-03 09:00:00',
+            'updated' => '2026-05-03 09:00:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create([
+            'object_type' => 'T',
+            'lastresponse' => '2026-05-03 09:00:00',
+        ]);
+        $staff = Staff::factory()->create([
+            'firstname' => 'Ada',
+            'lastname' => 'Lovelace',
+        ]);
+        $body = '<p>Internal <strong>note</strong> body</p>';
+
+        $entry = $this->service->post(
+            ticket: $ticket,
+            thread: $thread,
+            staff: $staff,
+            body: $body,
+            format: 'html',
+            expectedUpdated: '2026-05-03 09:00:00',
+        );
+
+        $this->assertInstanceOf(ThreadEntry::class, $entry);
+
+        $this->assertDatabaseHas('thread_entry', [
+            'id' => $entry->id,
+            'thread_id' => $thread->id,
+            'staff_id' => $staff->staff_id,
+            'type' => 'N',
+            'format' => 'html',
+            'body' => $body,
+            'title' => '',
+            'poster' => 'Ada Lovelace',
+            'created' => '2026-05-03 11:15:00',
+            'updated' => '2026-05-03 11:15:00',
+        ], 'legacy');
+
+        $this->assertDatabaseHas('thread_event', [
+            'thread_id' => $thread->id,
+            'event_id' => 7,
+            'staff_id' => $staff->staff_id,
+            'username' => 'Ada Lovelace',
+            'uid' => $staff->staff_id,
+            'uid_type' => 'S',
+            'data' => json_encode(['entry_id' => $entry->id]),
+        ], 'legacy');
+
+        $this->assertDatabaseHas('_search', [
+            'object_type' => 'THE',
+            'object_id' => $entry->id,
+            'title' => '',
+            'content' => 'Internal note body',
+        ], 'legacy');
+
+        $ticket->refresh();
+        $thread->refresh();
+
+        $this->assertSame('2026-05-03 11:15:00', $ticket->lastupdate);
+        $this->assertSame('2026-05-03 11:15:00', $ticket->updated);
+        $this->assertSame('2026-05-03 11:15:00', $thread->lastresponse);
+    }
+
+    public function test_throws_409_on_concurrent_modification(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-03 12:00:00'));
+
+        $ticket = Ticket::factory()->create([
+            'updated' => '2026-05-03 11:00:00',
+            'lastupdate' => '2026-05-03 11:00:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create([
+            'object_type' => 'T',
+        ]);
+        $staff = Staff::factory()->create();
+
+        try {
+            $this->service->post(
+                ticket: $ticket,
+                thread: $thread,
+                staff: $staff,
+                body: 'Stale note',
+                format: 'text',
+                expectedUpdated: '2026-05-03 10:59:59',
+            );
+
+            $this->fail('Expected TicketModifiedConcurrentlyException was not thrown.');
+        } catch (TicketModifiedConcurrentlyException $exception) {
+            $this->assertSame($ticket->ticket_id, $exception->ticketId);
+            $this->assertSame('2026-05-03 11:00:00', $exception->currentUpdated);
+        }
+
+        $this->assertDatabaseCount('thread_entry', 0, 'legacy');
+        $this->assertDatabaseCount('thread_event', 0, 'legacy');
+        $this->assertDatabaseCount('_search', 0, 'legacy');
+    }
+
+    private function ensureLegacyTable(string $table, \Closure $definition): void
+    {
+        if (! Schema::connection('legacy')->hasTable($table)) {
+            Schema::connection('legacy')->create($table, $definition);
+        }
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/SearchIndexerTest.php
+++ b/tests/Unit/Services/Scp/Tickets/SearchIndexerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Services\Scp\Tickets\SearchIndexer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class SearchIndexerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private SearchIndexer $indexer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create _search table if it doesn't exist
+        if (!Schema::connection('legacy')->hasTable('_search')) {
+            Schema::connection('legacy')->create('_search', function ($table) {
+                $table->string('object_type', 8);
+                $table->unsignedInteger('object_id');
+                $table->text('title');
+                $table->text('content');
+                $table->primary(['object_type', 'object_id']);
+            });
+        }
+
+        $this->indexer = new SearchIndexer();
+    }
+
+    public function test_inserts_search_row(): void
+    {
+        $this->indexer->index('ticket', 123, 'Test Ticket', 'This is a test ticket with <b>HTML</b> content');
+
+        $this->assertDatabaseHas(
+            '_search',
+            [
+                'object_type' => 'ticket',
+                'object_id' => 123,
+                'title' => 'Test Ticket',
+                'content' => 'This is a test ticket with HTML content',
+            ],
+            'legacy'
+        );
+    }
+
+    public function test_updates_existing_row_on_duplicate(): void
+    {
+        // Insert first time
+        $this->indexer->index('ticket', 456, 'Original Title', 'Original content');
+
+        // Verify first insert
+        $this->assertDatabaseHas(
+            '_search',
+            [
+                'object_type' => 'ticket',
+                'object_id' => 456,
+                'title' => 'Original Title',
+            ],
+            'legacy'
+        );
+
+        // Index same object again with different content
+        $this->indexer->index('ticket', 456, 'Updated Title', 'Updated &amp; modified content');
+
+        // Verify only one row exists with updated data
+        $count = DB::connection('legacy')->table('_search')
+            ->where('object_type', 'ticket')
+            ->where('object_id', 456)
+            ->count();
+
+        $this->assertSame(1, $count);
+
+        $this->assertDatabaseHas(
+            '_search',
+            [
+                'object_type' => 'ticket',
+                'object_id' => 456,
+                'title' => 'Updated Title',
+                'content' => 'Updated & modified content',
+            ],
+            'legacy'
+        );
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/StatusTransitionServiceTest.php
+++ b/tests/Unit/Services/Scp/Tickets/StatusTransitionServiceTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Exceptions\ForbiddenStatusTransition;
+use App\Models\Staff;
+use App\Models\Ticket;
+use App\Models\Thread;
+use App\Services\Scp\Tickets\NotePostingService;
+use App\Services\Scp\Tickets\StatusTransitionService;
+use App\Services\Scp\Tickets\ThreadEventWriter;
+use App\Services\Scp\Tickets\TicketCacheUpdater;
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class StatusTransitionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ThreadEventWriter $threadEvents;
+
+    private NotePostingService $notes;
+
+    private TicketCacheUpdater $cacheUpdater;
+
+    private StatusTransitionService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ensureLegacyTable('ticket_status', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->primary();
+            $table->string('name');
+            $table->string('state');
+            $table->string('mode')->nullable();
+            $table->string('flags')->nullable();
+            $table->integer('sort')->default(0);
+            $table->json('properties')->nullable();
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+
+        $this->ensureLegacyTable('event', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->string('name')->unique();
+            $table->text('description')->nullable();
+        });
+
+        $this->ensureLegacyTable('thread_event', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->unsignedInteger('thread_id');
+            $table->char('thread_type', 1);
+            $table->unsignedInteger('event_id');
+            $table->unsignedInteger('staff_id');
+            $table->unsignedInteger('team_id')->default(0);
+            $table->unsignedInteger('dept_id')->default(0);
+            $table->unsignedInteger('topic_id')->default(0);
+            $table->json('data')->nullable();
+            $table->string('username')->nullable();
+            $table->unsignedInteger('uid')->nullable();
+            $table->char('uid_type', 1)->nullable();
+            $table->tinyInteger('annulled')->default(0);
+            $table->dateTime('timestamp');
+        });
+
+        $this->ensureLegacyTable('_search', function (Blueprint $table): void {
+            $table->string('object_type', 8);
+            $table->unsignedInteger('object_id');
+            $table->text('title');
+            $table->text('content');
+            $table->primary(['object_type', 'object_id']);
+        });
+
+        $this->ensureLegacyTable('thread_entry', function (Blueprint $table): void {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->unsignedInteger('thread_id');
+            $table->unsignedInteger('staff_id')->default(0);
+            $table->unsignedInteger('user_id')->default(0);
+            $table->char('type', 1);
+            $table->string('poster')->default('');
+            $table->string('source')->default('');
+            $table->string('title')->default('');
+            $table->text('body')->nullable();
+            $table->string('format')->default('text');
+            $table->dateTime('created')->nullable();
+            $table->dateTime('updated')->nullable();
+        });
+
+        DB::connection('legacy')->table('ticket_status')->insertOrIgnore([
+            ['id' => 1, 'name' => 'Open', 'state' => 'open'],
+            ['id' => 2, 'name' => 'Closed', 'state' => 'closed'],
+            ['id' => 3, 'name' => 'On Hold', 'state' => 'onhold'],
+        ]);
+
+        DB::connection('legacy')->table('event')->insertOrIgnore([
+            'id' => 200,
+            'name' => 'status',
+            'description' => 'Ticket status changed',
+        ]);
+
+        $this->threadEvents = app(ThreadEventWriter::class);
+        $this->notes = app(NotePostingService::class);
+        $this->cacheUpdater = app(TicketCacheUpdater::class);
+
+        $this->service = new StatusTransitionService(
+            $this->threadEvents,
+            $this->notes,
+            $this->cacheUpdater,
+        );
+    }
+
+    public function test_open_to_onhold_allowed(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-03 09:05:00'));
+
+        $ticket = Ticket::factory()->create([
+            'status_id' => 1,
+            'lastupdate' => '2026-05-03 09:00:00',
+            'updated' => '2026-05-03 09:00:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create(['object_type' => 'T']);
+        $staff = Staff::factory()->create();
+
+        $this->service->transition(
+            ticket: $ticket,
+            thread: $thread,
+            caller: $staff,
+            targetStatusId: 3,
+            comments: null,
+            expectedUpdated: '2026-05-03 09:00:00',
+        );
+
+        $ticket->refresh();
+        $thread->refresh();
+
+        $this->assertSame(3, (int) $ticket->status_id);
+        $this->assertSame('2026-05-03 09:05:00', $ticket->updated);
+        $this->assertSame('2026-05-03 09:05:00', $ticket->lastupdate);
+        $this->assertSame('2026-05-03 09:05:00', $thread->lastresponse);
+
+        $this->assertDatabaseHas('thread_event', [
+            'thread_id' => $thread->id,
+            'event_id' => 200,
+            'staff_id' => $staff->staff_id,
+            'data' => json_encode([
+                'from' => ['id' => 1, 'name' => 'Open', 'state' => 'open'],
+                'to' => ['id' => 3, 'name' => 'On Hold', 'state' => 'onhold'],
+            ]),
+        ], 'legacy');
+    }
+
+    public function test_onhold_to_open_allowed(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-05-03 09:35:00'));
+
+        $ticket = Ticket::factory()->create([
+            'status_id' => 3,
+            'lastupdate' => '2026-05-03 09:30:00',
+            'updated' => '2026-05-03 09:30:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create(['object_type' => 'T']);
+        $staff = Staff::factory()->create();
+
+        $this->service->transition(
+            ticket: $ticket,
+            thread: $thread,
+            caller: $staff,
+            targetStatusId: 1,
+            comments: null,
+            expectedUpdated: '2026-05-03 09:30:00',
+        );
+
+        $ticket->refresh();
+        $thread->refresh();
+
+        $this->assertSame(1, (int) $ticket->status_id);
+        $this->assertSame('2026-05-03 09:35:00', $ticket->updated);
+        $this->assertSame('2026-05-03 09:35:00', $thread->lastresponse);
+
+        $this->assertDatabaseHas('thread_event', [
+            'thread_id' => $thread->id,
+            'event_id' => 200,
+            'staff_id' => $staff->staff_id,
+            'data' => json_encode([
+                'from' => ['id' => 3, 'name' => 'On Hold', 'state' => 'onhold'],
+                'to' => ['id' => 1, 'name' => 'Open', 'state' => 'open'],
+            ]),
+        ], 'legacy');
+    }
+
+    public function test_closed_to_open_forbidden(): void
+    {
+        $ticket = Ticket::factory()->create([
+            'status_id' => 2,
+            'updated' => '2026-05-03 10:00:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create(['object_type' => 'T']);
+        $staff = Staff::factory()->create();
+
+        try {
+            $this->service->transition(
+                ticket: $ticket,
+                thread: $thread,
+                caller: $staff,
+                targetStatusId: 1,
+                comments: null,
+                expectedUpdated: '2026-05-03 10:00:00',
+            );
+
+            $this->fail('Expected ForbiddenStatusTransition was not thrown.');
+        } catch (ForbiddenStatusTransition $exception) {
+            $this->assertSame('closed', $exception->fromState);
+            $this->assertSame('open', $exception->toState);
+        }
+
+        $ticket->refresh();
+
+        $this->assertSame(2, (int) $ticket->status_id);
+        $this->assertDatabaseMissing('thread_event', [
+            'thread_id' => $thread->id,
+            'event_id' => 200,
+            'staff_id' => $staff->staff_id,
+        ], 'legacy');
+    }
+
+    public function test_open_to_closed_forbidden(): void
+    {
+        $ticket = Ticket::factory()->create([
+            'status_id' => 1,
+            'updated' => '2026-05-03 10:15:00',
+        ]);
+        $thread = Thread::factory()->for($ticket, 'ticket')->create(['object_type' => 'T']);
+        $staff = Staff::factory()->create();
+
+        try {
+            $this->service->transition(
+                ticket: $ticket,
+                thread: $thread,
+                caller: $staff,
+                targetStatusId: 2,
+                comments: null,
+                expectedUpdated: '2026-05-03 10:15:00',
+            );
+
+            $this->fail('Expected ForbiddenStatusTransition was not thrown.');
+        } catch (ForbiddenStatusTransition $exception) {
+            $this->assertSame('open', $exception->fromState);
+            $this->assertSame('closed', $exception->toState);
+        }
+
+        $ticket->refresh();
+
+        $this->assertSame(1, (int) $ticket->status_id);
+        $this->assertDatabaseMissing('thread_event', [
+            'thread_id' => $thread->id,
+            'event_id' => 200,
+            'staff_id' => $staff->staff_id,
+        ], 'legacy');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    private function ensureLegacyTable(string $table, \Closure $definition): void
+    {
+        if (! Schema::connection('legacy')->hasTable($table)) {
+            Schema::connection('legacy')->create($table, $definition);
+        }
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/ThreadEventWriterTest.php
+++ b/tests/Unit/Services/Scp/Tickets/ThreadEventWriterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Models\Staff;
+use App\Models\Thread;
+use App\Models\ThreadEvent;
+use App\Services\Scp\Tickets\ThreadEventWriter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class ThreadEventWriterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ThreadEventWriter $writer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->writer = app(ThreadEventWriter::class);
+
+        // Create legacy event table if it doesn't exist
+        if (! Schema::connection('legacy')->hasTable('event')) {
+            Schema::connection('legacy')->create('event', function ($table) {
+                $table->id();
+                $table->string('name')->unique();
+                $table->text('description')->nullable();
+            });
+        }
+
+        // Create legacy thread table if it doesn't exist
+        if (! Schema::connection('legacy')->hasTable('thread')) {
+            Schema::connection('legacy')->create('thread', function ($table) {
+                $table->id();
+                $table->unsignedInteger('object_id');
+                $table->char('object_type', 1);
+                $table->timestamp('created')->useCurrent();
+            });
+        }
+
+        // Create legacy thread_event table if it doesn't exist
+        if (! Schema::connection('legacy')->hasTable('thread_event')) {
+            Schema::connection('legacy')->create('thread_event', function ($table) {
+                $table->id();
+                $table->unsignedInteger('thread_id');
+                $table->char('thread_type', 1);
+                $table->unsignedInteger('event_id');
+                $table->unsignedInteger('staff_id');
+                $table->unsignedInteger('team_id')->default(0);
+                $table->unsignedInteger('dept_id')->default(0);
+                $table->unsignedInteger('topic_id')->default(0);
+                $table->json('data')->nullable();
+                $table->string('username')->nullable();
+                $table->unsignedInteger('uid')->nullable();
+                $table->char('uid_type', 1)->nullable();
+                $table->tinyInteger('annulled')->default(0);
+                $table->timestamp('timestamp')->useCurrent();
+            });
+        }
+
+        // Seed the event table with an 'assigned' event
+        DB::connection('legacy')->table('event')->insertOrIgnore([
+            'id' => 1,
+            'name' => 'assigned',
+            'description' => 'Ticket assigned',
+        ]);
+    }
+
+    public function test_records_assigned_event_with_correct_event_id_and_data_shape(): void
+    {
+        // Create test data
+        $thread = Thread::factory()->create();
+        $staff = Staff::factory()->create();
+
+        // Record the event
+        $result = $this->writer->record(
+            thread: $thread,
+            eventName: 'assigned',
+            entryId: 123,
+            staff: $staff,
+            data: ['assigned_to' => $staff->staff_id]
+        );
+
+        // Assert the result is a ThreadEvent instance
+        $this->assertInstanceOf(ThreadEvent::class, $result);
+
+        // Assert the ThreadEvent was created with correct values
+        $this->assertDatabaseHas('thread_event', [
+            'thread_id' => $thread->id,
+            'thread_type' => 'A',
+            'event_id' => 1,
+            'staff_id' => $staff->staff_id,
+            'team_id' => 0,
+            'dept_id' => 0,
+            'topic_id' => 0,
+            'uid' => $staff->staff_id,
+            'uid_type' => 'S',
+            'annulled' => 0,
+        ], 'legacy');
+
+        // Assert data is JSON encoded
+        $this->assertDatabaseHas('thread_event', [
+            'id' => $result->id,
+            'data' => json_encode(['assigned_to' => $staff->staff_id]),
+        ], 'legacy');
+
+        // Assert username is set
+        $this->assertNotNull($result->username);
+    }
+
+    public function test_throws_for_unknown_event_name(): void
+    {
+        $thread = Thread::factory()->create();
+        $staff = Staff::factory()->create();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown event name: unknown_event');
+
+        $this->writer->record(
+            thread: $thread,
+            eventName: 'unknown_event',
+            entryId: null,
+            staff: $staff
+        );
+    }
+}

--- a/tests/Unit/Services/Scp/Tickets/ThreadEventWriterTest.php
+++ b/tests/Unit/Services/Scp/Tickets/ThreadEventWriterTest.php
@@ -73,7 +73,7 @@ final class ThreadEventWriterTest extends TestCase
         ]);
     }
 
-    public function test_records_assigned_event_with_correct_event_id_and_data_shape(): void
+    public function test_records_assigned_event_with_correct_event_id_thread_type_and_data_shape(): void
     {
         // Create test data
         $thread = Thread::factory()->create();
@@ -94,7 +94,7 @@ final class ThreadEventWriterTest extends TestCase
         // Assert the ThreadEvent was created with correct values
         $this->assertDatabaseHas('thread_event', [
             'thread_id' => $thread->id,
-            'thread_type' => 'A',
+            'thread_type' => 'T',
             'event_id' => 1,
             'staff_id' => $staff->staff_id,
             'team_id' => 0,
@@ -113,6 +113,25 @@ final class ThreadEventWriterTest extends TestCase
 
         // Assert username is set
         $this->assertNotNull($result->username);
+    }
+
+    public function test_records_task_thread_events_with_task_thread_type(): void
+    {
+        $thread = Thread::factory()->create(['object_type' => 'A']);
+        $staff = Staff::factory()->create();
+
+        $result = $this->writer->record(
+            thread: $thread,
+            eventName: 'assigned',
+            entryId: null,
+            staff: $staff,
+        );
+
+        $this->assertDatabaseHas('thread_event', [
+            'id' => $result->id,
+            'thread_id' => $thread->id,
+            'thread_type' => 'A',
+        ], 'legacy');
     }
 
     public function test_throws_for_unknown_event_name(): void

--- a/tests/Unit/Services/Scp/Tickets/TicketCacheUpdaterTest.php
+++ b/tests/Unit/Services/Scp/Tickets/TicketCacheUpdaterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scp\Tickets;
+
+use App\Models\Ticket;
+use App\Models\Thread;
+use App\Services\Scp\Tickets\TicketCacheUpdater;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class TicketCacheUpdaterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_touches_ticket_lastupdate_and_thread_lastresponse(): void
+    {
+        // Set a fixed test time
+        $testTime = Carbon::parse('2026-05-03 14:30:00');
+        Carbon::setTestNow($testTime);
+
+        // Create a ticket and thread
+        $ticket = Ticket::factory()->create();
+        $thread = Thread::factory()->for($ticket, 'ticket')->create();
+
+        // Move time forward to ensure timestamps change
+        Carbon::setTestNow($testTime->addMinutes(5));
+        $newTime = Carbon::now();
+
+        // Create the service and call touch()
+        $updater = new TicketCacheUpdater();
+        $updater->touch($ticket, $thread);
+
+        // Refresh models from database
+        $ticket->refresh();
+        $thread->refresh();
+
+        // Assert ticket timestamps were updated to new time
+        $this->assertEquals($newTime->toDateTimeString(), $ticket->lastupdate);
+        $this->assertEquals($newTime->toDateTimeString(), $ticket->updated);
+
+        // Assert thread lastresponse was updated to new time
+        $this->assertNotNull($thread->lastresponse);
+        $this->assertEquals($newTime->toDateTimeString(), $thread->lastresponse);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_touches_ticket_without_thread(): void
+    {
+        // Set a fixed test time
+        $testTime = Carbon::parse('2026-05-03 15:45:00');
+        Carbon::setTestNow($testTime);
+
+        // Create a ticket without a thread
+        $ticket = Ticket::factory()->create();
+
+        // Move time forward to ensure timestamps change
+        Carbon::setTestNow($testTime->addMinutes(5));
+        $newTime = Carbon::now();
+
+        // Create the service and call touch() without thread
+        $updater = new TicketCacheUpdater();
+        $updater->touch($ticket);
+
+        // Refresh model from database
+        $ticket->refresh();
+
+        // Assert ticket timestamps were updated to new time
+        $this->assertEquals($newTime->toDateTimeString(), $ticket->lastupdate);
+        $this->assertEquals($newTime->toDateTimeString(), $ticket->updated);
+
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #68. Adds Phase 2b internal SCP actions: ticket locking, action audit log, internal notes, drafts, assignment, on-hold status transitions, queue customization, parity checks, and refreshed ticket-detail action UI. These are staff-only legacy write paths and intentionally keep outbound mail disabled until Phase 3.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->