### PR TITLE
Bootstrap support tables setup

### DIFF
--- a/app/Console/Commands/EnsureLegacyPermissionTables.php
+++ b/app/Console/Commands/EnsureLegacyPermissionTables.php
@@ -40,7 +40,7 @@ final class EnsureLegacyPermissionTables extends Command
         app(PermissionRegistrar::class)->forgetCachedPermissions();
 
         if ($this->option('seed')) {
-            $this->call(PermissionCatalogSeeder::class);
+            $this->call('db:seed', ['--class' => PermissionCatalogSeeder::class, '--force' => true]);
         }
 
         $this->info('Legacy permission tables are ready.');

--- a/app/Console/Commands/EnsureLegacyPermissionTables.php
+++ b/app/Console/Commands/EnsureLegacyPermissionTables.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Database\Seeders\PermissionCatalogSeeder;
+use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\PermissionRegistrar;
+
+final class EnsureLegacyPermissionTables extends Command
+{
+    protected $signature = 'legacy:ensure-permission-tables {--seed : Seed the application permission catalog}';
+
+    protected $description = 'Create missing Spatie permission tables on the configured legacy permission connection.';
+
+    public function handle(): int
+    {
+        $this->prepareSqliteDatabase();
+
+        $schema = Schema::connection(config('permission.connection', 'legacy'));
+        $tables = config('permission.table_names', []);
+        $columns = config('permission.column_names', []);
+
+        $this->ensureTableConfig($tables);
+
+        $pivotRole = $columns['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columns['permission_pivot_key'] ?? 'permission_id';
+        $modelMorphKey = $columns['model_morph_key'] ?? 'model_id';
+
+        $this->ensurePermissions($schema, $tables['permissions']);
+        $this->ensureRoles($schema, $tables['roles']);
+        $this->ensureModelHasPermissions($schema, $tables['model_has_permissions'], $pivotPermission, $modelMorphKey);
+        $this->ensureModelHasRoles($schema, $tables['model_has_roles'], $pivotRole, $modelMorphKey);
+        $this->ensureRoleHasPermissions($schema, $tables['role_has_permissions'], $pivotPermission, $pivotRole);
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        if ($this->option('seed')) {
+            $this->call(PermissionCatalogSeeder::class);
+        }
+
+        $this->info('Legacy permission tables are ready.');
+
+        return self::SUCCESS;
+    }
+
+    private function prepareSqliteDatabase(): void
+    {
+        $connection = (string) config('permission.connection', 'legacy');
+
+        $this->prepareSqliteConnection(config('database.default'));
+        $this->prepareSqliteConnection($connection);
+    }
+
+    private function prepareSqliteConnection(?string $connection): void
+    {
+        if (! is_string($connection) || $connection === '') {
+            return;
+        }
+
+        if (config("database.connections.{$connection}.driver") !== 'sqlite') {
+            return;
+        }
+
+        $database = config("database.connections.{$connection}.database");
+
+        if (! is_string($database) || $database === '' || $database === ':memory:' || file_exists($database)) {
+            return;
+        }
+
+        $directory = dirname($database);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+
+        touch($database);
+    }
+
+    /**
+     * @param  array<string, string>  $tables
+     */
+    private function ensureTableConfig(array $tables): void
+    {
+        $required = ['permissions', 'roles', 'model_has_permissions', 'model_has_roles', 'role_has_permissions'];
+        $missing = array_values(array_filter($required, fn (string $key): bool => empty($tables[$key])));
+
+        if ($missing !== []) {
+            throw new \RuntimeException('Missing permission table config keys: '.implode(', ', $missing));
+        }
+    }
+
+    private function ensurePermissions(Builder $schema, string $tableName): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, ['id', 'name', 'guard_name']);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+    }
+
+    private function ensureRoles(Builder $schema, string $tableName): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, ['id', 'name', 'guard_name']);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name');
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+    }
+
+    private function ensureModelHasPermissions(Builder $schema, string $tableName, string $pivotPermission, string $modelMorphKey): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, [$pivotPermission, $modelMorphKey, 'model_type']);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table) use ($pivotPermission, $modelMorphKey): void {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->string('model_type');
+            $table->unsignedBigInteger($modelMorphKey);
+            $table->index([$modelMorphKey, 'model_type'], 'model_has_permissions_model_id_model_type_index');
+            $table->primary([$pivotPermission, $modelMorphKey, 'model_type'], 'model_has_permissions_permission_model_type_primary');
+        });
+    }
+
+    private function ensureModelHasRoles(Builder $schema, string $tableName, string $pivotRole, string $modelMorphKey): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, [$pivotRole, $modelMorphKey, 'model_type']);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table) use ($pivotRole, $modelMorphKey): void {
+            $table->unsignedBigInteger($pivotRole);
+            $table->string('model_type');
+            $table->unsignedBigInteger($modelMorphKey);
+            $table->index([$modelMorphKey, 'model_type'], 'model_has_roles_model_id_model_type_index');
+            $table->primary([$pivotRole, $modelMorphKey, 'model_type'], 'model_has_roles_role_model_type_primary');
+        });
+    }
+
+    private function ensureRoleHasPermissions(Builder $schema, string $tableName, string $pivotPermission, string $pivotRole): void
+    {
+        if ($schema->hasTable($tableName)) {
+            $this->guardRequiredColumns($schema, $tableName, [$pivotPermission, $pivotRole]);
+
+            return;
+        }
+
+        $schema->create($tableName, function (Blueprint $table) use ($pivotPermission, $pivotRole): void {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+    }
+
+    /**
+     * @param  list<string>  $requiredColumns
+     */
+    private function guardRequiredColumns(Builder $schema, string $tableName, array $requiredColumns): void
+    {
+        $existingColumns = $schema->getColumnListing($tableName);
+        $missingColumns = array_values(array_diff($requiredColumns, $existingColumns));
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Existing %s table is missing required column(s): %s.',
+            $schema->getConnection()->getTablePrefix().$tableName,
+            implode(', ', $missingColumns),
+        ));
+    }
+}

--- a/app/Console/Commands/EnsureOsticket2SupportTables.php
+++ b/app/Console/Commands/EnsureOsticket2SupportTables.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\Schema;
+
+final class EnsureOsticket2SupportTables extends Command
+{
+    protected $signature = 'osticket2:ensure-support-tables';
+
+    protected $description = 'Create or backfill app support tables on the configured osticket2 connection.';
+
+    public function handle(): int
+    {
+        $this->prepareSqliteDatabase();
+
+        $schema = Schema::connection('osticket2');
+
+        $this->ensureStaffTwoFactor($schema);
+        $this->ensureStaffAuthMigrations($schema);
+        $this->ensureStaffPreferences($schema);
+        $this->ensureAccessLog($schema);
+        $this->ensureAdminAuditLog($schema);
+        $this->ensureMigrationProgress($schema);
+
+        $this->info('osticket2 support tables are ready.');
+
+        return self::SUCCESS;
+    }
+
+    private function prepareSqliteDatabase(): void
+    {
+        if (config('database.connections.osticket2.driver') !== 'sqlite') {
+            return;
+        }
+
+        $database = config('database.connections.osticket2.database');
+
+        if (! is_string($database) || $database === '' || $database === ':memory:' || file_exists($database)) {
+            return;
+        }
+
+        $directory = dirname($database);
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+
+        touch($database);
+    }
+
+    private function ensureStaffTwoFactor(Builder $schema): void
+    {
+        if (! $schema->hasTable('staff_two_factor')) {
+            $schema->create('staff_two_factor', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->unique();
+                $table->text('two_factor_secret')->nullable();
+                $table->text('two_factor_recovery_codes')->nullable();
+                $table->timestamp('two_factor_confirmed_at')->nullable();
+                $table->timestamps();
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'staff_two_factor', ['id', 'staff_id']);
+        $this->addMissingColumns($schema, 'staff_two_factor', [
+            'two_factor_secret' => fn (Blueprint $table) => $table->text('two_factor_secret')->nullable(),
+            'two_factor_recovery_codes' => fn (Blueprint $table) => $table->text('two_factor_recovery_codes')->nullable(),
+            'two_factor_confirmed_at' => fn (Blueprint $table) => $table->timestamp('two_factor_confirmed_at')->nullable(),
+            'created_at' => fn (Blueprint $table) => $table->timestamp('created_at')->nullable(),
+            'updated_at' => fn (Blueprint $table) => $table->timestamp('updated_at')->nullable(),
+        ]);
+    }
+
+    private function ensureStaffAuthMigrations(Builder $schema): void
+    {
+        if (! $schema->hasTable('staff_auth_migrations')) {
+            $schema->create('staff_auth_migrations', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->unique();
+                $table->timestamp('migrated_at')->nullable();
+                $table->timestamp('must_upgrade_after')->nullable();
+                $table->string('upgrade_method', 32)->nullable();
+                $table->timestamp('dismissed_migration_banner_at')->nullable();
+                $table->timestamps();
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'staff_auth_migrations', ['id', 'staff_id']);
+        $this->addMissingColumns($schema, 'staff_auth_migrations', [
+            'migrated_at' => fn (Blueprint $table) => $table->timestamp('migrated_at')->nullable(),
+            'must_upgrade_after' => fn (Blueprint $table) => $table->timestamp('must_upgrade_after')->nullable(),
+            'upgrade_method' => fn (Blueprint $table) => $table->string('upgrade_method', 32)->nullable(),
+            'dismissed_migration_banner_at' => fn (Blueprint $table) => $table->timestamp('dismissed_migration_banner_at')->nullable(),
+            'created_at' => fn (Blueprint $table) => $table->timestamp('created_at')->nullable(),
+            'updated_at' => fn (Blueprint $table) => $table->timestamp('updated_at')->nullable(),
+        ]);
+    }
+
+    private function ensureStaffPreferences(Builder $schema): void
+    {
+        if (! $schema->hasTable('staff_preferences')) {
+            $schema->create('staff_preferences', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->unique();
+                $table->string('theme', 16)->default('system');
+                $table->string('language', 16)->nullable();
+                $table->string('timezone', 64)->nullable();
+                $table->json('notifications')->nullable();
+                $table->string('last_active_panel', 16)->default('scp');
+                $table->string('default_scp_tab', 64)->nullable();
+                $table->string('default_admin_tab', 64)->nullable();
+                $table->boolean('created_by_migration_2026_04_26_000100')->default(true);
+                $table->boolean('created_by_migration_2026_05_02_000100')->default(true);
+                $table->timestamps();
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'staff_preferences', ['id', 'staff_id']);
+        $this->addMissingColumns($schema, 'staff_preferences', [
+            'theme' => fn (Blueprint $table) => $table->string('theme', 16)->default('system'),
+            'language' => fn (Blueprint $table) => $table->string('language', 16)->nullable(),
+            'timezone' => fn (Blueprint $table) => $table->string('timezone', 64)->nullable(),
+            'notifications' => fn (Blueprint $table) => $table->json('notifications')->nullable(),
+            'last_active_panel' => fn (Blueprint $table) => $table->string('last_active_panel', 16)->default('scp'),
+            'default_scp_tab' => fn (Blueprint $table) => $table->string('default_scp_tab', 64)->nullable(),
+            'default_admin_tab' => fn (Blueprint $table) => $table->string('default_admin_tab', 64)->nullable(),
+            'created_at' => fn (Blueprint $table) => $table->timestamp('created_at')->nullable(),
+            'updated_at' => fn (Blueprint $table) => $table->timestamp('updated_at')->nullable(),
+        ]);
+    }
+
+    private function ensureAccessLog(Builder $schema): void
+    {
+        if (! $schema->hasTable('access_log')) {
+            $schema->create('access_log', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('staff_id')->index();
+                $table->string('action', 128);
+                $table->string('subject_type', 64)->nullable();
+                $table->unsignedBigInteger('subject_id')->nullable();
+                $table->json('metadata')->nullable();
+                $table->string('ip_address', 45)->nullable();
+                $table->text('user_agent')->nullable();
+                $table->boolean('created_by_migration_2026_04_26_000200')->default(true);
+                $table->timestamp('created_at')->useCurrent();
+
+                $table->index(['subject_type', 'subject_id']);
+                $table->index('created_at');
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'access_log', ['id', 'staff_id', 'action', 'created_at']);
+        $this->addMissingColumns($schema, 'access_log', [
+            'subject_type' => fn (Blueprint $table) => $table->string('subject_type', 64)->nullable(),
+            'subject_id' => fn (Blueprint $table) => $table->unsignedBigInteger('subject_id')->nullable(),
+            'metadata' => fn (Blueprint $table) => $table->json('metadata')->nullable(),
+            'ip_address' => fn (Blueprint $table) => $table->string('ip_address', 45)->nullable(),
+            'user_agent' => fn (Blueprint $table) => $table->text('user_agent')->nullable(),
+        ]);
+    }
+
+    private function ensureAdminAuditLog(Builder $schema): void
+    {
+        if (! $schema->hasTable('admin_audit_log')) {
+            $schema->create('admin_audit_log', function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('actor_id');
+                $table->string('action', 64);
+                $table->string('subject_type', 64);
+                $table->unsignedBigInteger('subject_id');
+                $table->json('before')->nullable();
+                $table->json('after')->nullable();
+                $table->json('metadata')->nullable();
+                $table->string('ip_address', 45)->nullable();
+                $table->string('user_agent', 255)->nullable();
+                $table->timestamp('created_at')->useCurrent();
+
+                $table->index(['subject_type', 'subject_id', 'created_at'], 'admin_audit_log_subject_created_idx');
+                $table->index(['actor_id', 'created_at'], 'admin_audit_log_actor_created_idx');
+                $table->index(['action', 'created_at'], 'admin_audit_log_action_created_idx');
+            });
+
+            return;
+        }
+
+        $this->guardRequiredColumns($schema, 'admin_audit_log', ['id', 'actor_id', 'action', 'subject_type', 'subject_id', 'created_at']);
+    }
+
+    private function ensureMigrationProgress(Builder $schema): void
+    {
+        if ($schema->hasTable('_migration_progress')) {
+            $this->guardRequiredColumns($schema, '_migration_progress', ['table_name', 'status']);
+
+            return;
+        }
+
+        $schema->create('_migration_progress', function (Blueprint $table): void {
+            $table->string('table_name', 120)->primary();
+            $table->string('last_id', 255)->nullable();
+            $table->string('status', 32)->default('pending');
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * @param  array<string, callable(Blueprint): mixed>  $columns
+     */
+    private function addMissingColumns(Builder $schema, string $tableName, array $columns): void
+    {
+        $existingColumns = $schema->getColumnListing($tableName);
+        $missingColumns = array_diff(array_keys($columns), $existingColumns);
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        $schema->table($tableName, function (Blueprint $table) use ($columns, $missingColumns): void {
+            foreach ($missingColumns as $column) {
+                $columns[$column]($table);
+            }
+        });
+    }
+
+    /**
+     * @param  list<string>  $requiredColumns
+     */
+    private function guardRequiredColumns(Builder $schema, string $tableName, array $requiredColumns): void
+    {
+        $existingColumns = $schema->getColumnListing($tableName);
+        $missingColumns = array_values(array_diff($requiredColumns, $existingColumns));
+
+        if ($missingColumns === []) {
+            return;
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Existing %s table is missing required column(s): %s.',
+            $schema->getConnection()->getTablePrefix().$tableName,
+            implode(', ', $missingColumns),
+        ));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
             "@php artisan key:generate",
             "@php artisan migrate --force",
+            "@php artisan osticket2:ensure-support-tables --ansi",
             "npm install --ignore-scripts",
             "npm run build"
         ],

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\"",
             "@php artisan key:generate",
             "@php artisan migrate --force",
+            "@php artisan legacy:ensure-permission-tables --seed --ansi",
             "@php artisan osticket2:ensure-support-tables --ansi",
             "npm install --ignore-scripts",
             "npm run build"

--- a/config/database.php
+++ b/config/database.php
@@ -16,7 +16,7 @@ $legacy = env('LEGACY_DB_DRIVER', 'mysql') === 'sqlite'
         'driver' => 'mysql',
         'host' => env('LEGACY_DB_HOST', '127.0.0.1'),
         'port' => env('LEGACY_DB_PORT', '3307'),
-        'database' => env('LEGACY_DB_DATABASE', 'osticketdb_rl'),
+        'database' => env('LEGACY_DB_DATABASE', 'osticketdb_sbb'),
         'username' => env('LEGACY_DB_USERNAME', 'root'),
         'password' => env('LEGACY_DB_PASSWORD', ''),
         'unix_socket' => env('DB_SOCKET', ''),

--- a/config/database.php
+++ b/config/database.php
@@ -16,7 +16,7 @@ $legacy = env('LEGACY_DB_DRIVER', 'mysql') === 'sqlite'
         'driver' => 'mysql',
         'host' => env('LEGACY_DB_HOST', '127.0.0.1'),
         'port' => env('LEGACY_DB_PORT', '3307'),
-        'database' => env('LEGACY_DB_DATABASE', 'osticketdb_sbb'),
+        'database' => env('LEGACY_DB_DATABASE', 'osticketdb_rl'),
         'username' => env('LEGACY_DB_USERNAME', 'root'),
         'password' => env('LEGACY_DB_PASSWORD', ''),
         'unix_socket' => env('DB_SOCKET', ''),

--- a/tests/Feature/Admin/AdminTestHelpersTest.php
+++ b/tests/Feature/Admin/AdminTestHelpersTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Tests\Feature\Admin;
+
 use App\Http\Middleware\EnsureAdminAccess;
 use App\Http\Middleware\AuthenticateStaff;
 use App\Models\Admin\AdminAuditLog;
@@ -9,7 +11,6 @@ use App\Models\HelpTopic;
 use App\Models\Staff;
 use App\Policies\HelpTopicPolicy;
 use App\Services\Admin\AuditLogger;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -17,21 +18,26 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Schema;
 
-class FakeAdminHelperSubject extends Model
-{
-    protected $connection = 'osticket2';
-
-    protected $table = 'fake_admin_helper_subjects';
-
-    public $timestamps = false;
-
-    protected $guarded = [];
-}
-
 beforeEach(function (): void {
     seedPermissions();
 
+    Schema::connection('osticket2')->dropIfExists('admin_audit_log');
     Schema::connection('osticket2')->dropIfExists('fake_admin_helper_subjects');
+
+    Schema::connection('osticket2')->create('admin_audit_log', function (Blueprint $table): void {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('actor_id');
+        $table->string('action', 64);
+        $table->string('subject_type', 64);
+        $table->unsignedBigInteger('subject_id');
+        $table->json('before')->nullable();
+        $table->json('after')->nullable();
+        $table->json('metadata')->nullable();
+        $table->string('ip_address', 45)->nullable();
+        $table->string('user_agent', 255)->nullable();
+        $table->timestamp('created_at')->useCurrent();
+    });
+
     Schema::connection('osticket2')->create('fake_admin_helper_subjects', function (Blueprint $table): void {
         $table->bigIncrements('id');
         $table->string('name');
@@ -41,6 +47,7 @@ beforeEach(function (): void {
 afterEach(function (): void {
     Auth::guard('staff')->logout();
     Schema::connection('osticket2')->dropIfExists('fake_admin_helper_subjects');
+    Schema::connection('osticket2')->dropIfExists('admin_audit_log');
 });
 
 it('authenticates admin staff with admin access permission', function (): void {

--- a/tests/Feature/Admin/FakeAdminHelperSubject.php
+++ b/tests/Feature/Admin/FakeAdminHelperSubject.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FakeAdminHelperSubject extends Model
+{
+    protected $connection = 'osticket2';
+
+    protected $table = 'fake_admin_helper_subjects';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+}

--- a/tests/Unit/Admin/AuditLoggerTest.php
+++ b/tests/Unit/Admin/AuditLoggerTest.php
@@ -1,24 +1,12 @@
 <?php
 
+namespace Tests\Unit\Admin;
+
 use App\Models\Staff;
 use App\Services\Admin\AuditLogger;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Schema;
-
-class FakeAuditedSubject extends Model
-{
-    protected $connection = 'osticket2';
-
-    protected $table = 'fake_audit_subjects';
-
-    public $timestamps = false;
-
-    protected $guarded = [];
-
-    protected static array $auditExcluded = ['password'];
-}
 
 beforeEach(function (): void {
     Schema::connection('osticket2')->dropIfExists('admin_audit_log');

--- a/tests/Unit/Admin/FakeAuditedSubject.php
+++ b/tests/Unit/Admin/FakeAuditedSubject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Admin;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FakeAuditedSubject extends Model
+{
+    protected $connection = 'osticket2';
+
+    protected $table = 'fake_audit_subjects';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected static array $auditExcluded = ['password'];
+}


### PR DESCRIPTION
## Summary

Stacked on #69. Adds setup hardening commands for osticket2 support tables and legacy permission tables, then wires them into Composer bootstrap. Also extracts fake admin audit test subjects into namespaced fixtures so support-table and audit tests stay deterministic.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/chachajona/osticket2.0/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->