### PR TITLE
fix(admin): remove staff hard-delete (Task 11 data-integrity rule)

### DIFF
--- a/app/Http/Controllers/Admin/StaffController.php
+++ b/app/Http/Controllers/Admin/StaffController.php
@@ -11,7 +11,6 @@ use App\Models\LegacyRole;
 use App\Models\Staff;
 use App\Services\Admin\StaffService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -128,19 +127,6 @@ class StaffController extends Controller
         return redirect()
             ->route('admin.staff.edit', $staff)
             ->with('status', 'Staff member updated.');
-    }
-
-    public function destroy(Request $request, Staff $staff): RedirectResponse
-    {
-        $this->authorize('delete', $staff);
-
-        /** @var Staff $actor */
-        $actor = $request->user('staff');
-        $this->staffService->delete($staff, $actor);
-
-        return redirect()
-            ->route('admin.staff.index')
-            ->with('status', 'Staff member deleted.');
     }
 
     /**

--- a/app/Policies/StaffPolicy.php
+++ b/app/Policies/StaffPolicy.php
@@ -13,7 +13,6 @@ class StaffPolicy
         return $staff->hasAdminPermission(
             'admin.staff.create',
             'admin.staff.update',
-            'admin.staff.delete',
         );
     }
 
@@ -25,10 +24,5 @@ class StaffPolicy
     public function update(Staff $staff, Staff $subject): bool
     {
         return $subject instanceof Staff && $staff->hasAdminPermission('admin.staff.update');
-    }
-
-    public function delete(Staff $staff, Staff $subject): bool
-    {
-        return $subject instanceof Staff && $staff->hasAdminPermission('admin.staff.delete');
     }
 }

--- a/app/Services/Admin/StaffService.php
+++ b/app/Services/Admin/StaffService.php
@@ -67,21 +67,6 @@ class StaffService
         return $staff;
     }
 
-    public function delete(Staff $staff, Staff $actor): void
-    {
-        $staff->loadMissing(['department', 'role', 'departmentAccesses', 'teams', 'twoFactorCredential']);
-        $before = $this->snapshot($staff);
-
-        DB::connection('legacy')->transaction(function () use ($staff): void {
-            StaffDeptAccess::query()->where('staff_id', (int) $staff->getKey())->delete();
-            TeamMember::query()->where('staff_id', (int) $staff->getKey())->delete();
-            $staff->syncRoles([]);
-            $staff->delete();
-        });
-
-        $this->auditLogger->record($actor, 'staff.delete', $staff, before: $before, after: null);
-    }
-
     /**
      * @param  array<string, mixed>  $data
      * @return array<string, mixed>

--- a/database/seeders/PermissionCatalogSeeder.php
+++ b/database/seeders/PermissionCatalogSeeder.php
@@ -83,7 +83,6 @@ class PermissionCatalogSeeder extends Seeder
                 'admin.role.delete',
                 'admin.staff.create',
                 'admin.staff.update',
-                'admin.staff.delete',
                 'admin.department.create',
                 'admin.department.update',
                 'admin.department.delete',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,9 @@
 {
-    "name": "rio-de-janeiro",
+    "name": "santo-domingo-v1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "rio-de-janeiro",
             "dependencies": {
                 "@base-ui/react": "^1.4.0",
                 "@fontsource-variable/geist-mono": "^5.2.7",

--- a/resources/js/pages/Admin/Staff/Edit.tsx
+++ b/resources/js/pages/Admin/Staff/Edit.tsx
@@ -1,8 +1,6 @@
-import { useState } from 'react';
-import { Head, Link, router, useForm } from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
 import { appShellLayout } from '@/layouts/AppShell';
 import { PageHeader } from '@/components/layout/PageHeader';
-import { ConfirmDialog } from '@/components/admin/ConfirmDialog';
 import { FormGrid } from '@/components/admin/FormGrid';
 import { FormSection } from '@/components/admin/FormSection';
 import { Button, buttonVariants } from '@/components/ui/button';
@@ -12,7 +10,7 @@ import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { Delete01Icon, FloppyDiskIcon, PlusSignIcon } from '@hugeicons/core-free-icons';
+import { FloppyDiskIcon, PlusSignIcon } from '@hugeicons/core-free-icons';
 import type { ReactElement } from 'react';
 
 declare global {
@@ -104,7 +102,6 @@ function SelectField({
 
 export default function StaffEdit({ staffMember, departmentOptions, roleOptions, teamOptions }: Props) {
     const isEdit = !!staffMember;
-    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
     const { data, setData, post, patch, processing, errors } = useForm({
         username: staffMember?.username ?? '',
@@ -127,12 +124,6 @@ export default function StaffEdit({ staffMember, departmentOptions, roleOptions,
         })) ?? [],
         teams: staffMember?.teams.map(String) ?? [],
     });
-
-    const handleDelete = () => {
-        if (!staffMember) return;
-
-        router.delete(route('admin.staff.destroy', staffMember.id));
-    };
 
     const addDepartmentAccess = () => {
         setData('dept_access', [...data.dept_access, { dept_id: '', role_id: '' }]);
@@ -162,26 +153,13 @@ export default function StaffEdit({ staffMember, departmentOptions, roleOptions,
                 title={isEdit ? 'Edit Staff Member' : 'Create Staff Member'}
                 subtitle="Manage core profile data, access, team membership, and password settings."
                 headerActions={
-                    <>
-                        <Link
-                            href={route('admin.staff.index')}
-                            className="inline-flex h-7 items-center gap-1.5 rounded-[3px] border border-[#E2E0D8] bg-white px-3 text-[12px] font-medium uppercase leading-4 tracking-[1.2px] text-[#27272A] transition-colors hover:border-[#18181B] hover:bg-[#FAFAF8] hover:text-[#18181B]"
-                        >
-                            <span aria-hidden>&larr;</span>
-                            Back to Staff
-                        </Link>
-                        {isEdit && staffMember && (
-                            <Button
-                                type="button"
-                                variant="outline"
-                                className="border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
-                                onClick={() => setShowDeleteConfirm(true)}
-                            >
-                                <HugeiconsIcon icon={Delete01Icon} size={18} className="mr-2" />
-                                Delete Staff
-                            </Button>
-                        )}
-                    </>
+                    <Link
+                        href={route('admin.staff.index')}
+                        className="inline-flex h-7 items-center gap-1.5 rounded-[3px] border border-[#E2E0D8] bg-white px-3 text-[12px] font-medium uppercase leading-4 tracking-[1.2px] text-[#27272A] transition-colors hover:border-[#18181B] hover:bg-[#FAFAF8] hover:text-[#18181B]"
+                    >
+                        <span aria-hidden>&larr;</span>
+                        Back to Staff
+                    </Link>
                 }
             />
 
@@ -428,23 +406,6 @@ export default function StaffEdit({ staffMember, departmentOptions, roleOptions,
                     </Button>
                 </div>
             </form>
-
-            {isEdit && staffMember && (
-                <ConfirmDialog
-                    open={showDeleteConfirm}
-                    onOpenChange={setShowDeleteConfirm}
-                    title="Delete Staff Member"
-                    description={
-                        <>
-                            Are you sure you want to delete <strong>{staffMember.username}</strong>? This action cannot be
-                            undone.
-                        </>
-                    }
-                    confirmText="Delete Staff"
-                    variant="destructive"
-                    onConfirm={handleDelete}
-                />
-            )}
         </>
     );
 }

--- a/resources/js/pages/Admin/Staff/Index.tsx
+++ b/resources/js/pages/Admin/Staff/Index.tsx
@@ -1,8 +1,6 @@
-import { useState } from 'react';
-import { Head, Link, router } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 import { appShellLayout } from '@/layouts/AppShell';
 import { PageHeader } from '@/components/layout/PageHeader';
-import { ConfirmDialog } from '@/components/admin/ConfirmDialog';
 import { buttonVariants } from '@/components/ui/button';
 import {
     Table,
@@ -13,7 +11,7 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { Delete01Icon, PencilEdit01Icon, PlusSignIcon } from '@hugeicons/core-free-icons';
+import { PencilEdit01Icon, PlusSignIcon } from '@hugeicons/core-free-icons';
 import type { ReactElement } from 'react';
 
 declare global {
@@ -44,16 +42,6 @@ interface Props {
 }
 
 export default function StaffIndex({ staff }: Props) {
-    const [staffToDelete, setStaffToDelete] = useState<StaffRow | null>(null);
-
-    const handleDelete = () => {
-        if (!staffToDelete) return;
-
-        router.delete(route('admin.staff.destroy', staffToDelete.id), {
-            onSuccess: () => setStaffToDelete(null),
-        });
-    };
-
     return (
         <>
             <Head title="Staff" />
@@ -118,14 +106,6 @@ export default function StaffIndex({ staff }: Props) {
                                                 <HugeiconsIcon icon={PencilEdit01Icon} size={18} />
                                                 <span className="sr-only">Edit</span>
                                             </Link>
-                                            <button
-                                                type="button"
-                                                className={`${buttonVariants({ variant: 'ghost', size: 'icon' })} text-red-600 hover:bg-red-50 hover:text-red-700`}
-                                                onClick={() => setStaffToDelete(member)}
-                                            >
-                                                <HugeiconsIcon icon={Delete01Icon} size={18} />
-                                                <span className="sr-only">Delete</span>
-                                            </button>
                                         </div>
                                     </TableCell>
                                 </TableRow>
@@ -134,21 +114,6 @@ export default function StaffIndex({ staff }: Props) {
                     </TableBody>
                 </Table>
             </div>
-
-            <ConfirmDialog
-                open={staffToDelete !== null}
-                onOpenChange={(isOpen) => !isOpen && setStaffToDelete(null)}
-                title="Delete Staff Member"
-                description={
-                    <>
-                        Are you sure you want to delete <strong>{staffToDelete?.name}</strong>? This removes department
-                        access and team membership.
-                    </>
-                }
-                confirmText="Delete Staff"
-                variant="destructive"
-                onConfirm={handleDelete}
-            />
         </>
     );
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,7 +125,7 @@ Route::middleware([AuthenticateStaff::class, 'admin.access'])->prefix('admin')->
     Route::resource('filters', FilterController::class)->except(['show']);
     Route::resource('roles', RoleController::class)->except(['show']);
     Route::resource('slas', SlaController::class)->except(['show']);
-    Route::resource('staff', StaffController::class)->except(['show']);
+    Route::resource('staff', StaffController::class)->except(['show', 'destroy']);
     Route::resource('teams', TeamController::class)->except(['show']);
 });
 

--- a/tests/Feature/Admin/StaffAdminTest.php
+++ b/tests/Feature/Admin/StaffAdminTest.php
@@ -13,11 +13,11 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
 use Spatie\Permission\PermissionRegistrar;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\assertDatabaseMissing;
-use function Pest\Laravel\delete;
 use function Pest\Laravel\from;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
@@ -467,54 +467,11 @@ it('updates a staff member, rehashes password, syncs relationships, and writes a
     );
 });
 
-it('deletes a staff member, cascades relationships, and writes an audit log', function (): void {
-    $department = Department::query()->create(['name' => 'Support', 'ispublic' => 1]);
-    $secondaryDepartment = Department::query()->create(['name' => 'Billing', 'ispublic' => 1]);
-    $role = LegacyRole::query()->create(['name' => 'Managers', 'guard_name' => 'staff']);
-    $overrideRole = LegacyRole::query()->create(['name' => 'Escalations', 'guard_name' => 'staff']);
-    $team = Team::query()->create(['name' => 'Escalations', 'flags' => 1, 'created' => now(), 'updated' => now()]);
-
-    $member = Staff::factory()->create([
-        'dept_id' => $department->id,
-        'role_id' => $role->id,
-        'username' => 'jrivera',
-        'isvisible' => 1,
-        'updated' => now(),
-    ]);
-    $member->syncRoles([$role]);
-
-    StaffDeptAccess::query()->create([
-        'staff_id' => $member->staff_id,
-        'dept_id' => $secondaryDepartment->id,
-        'role_id' => $overrideRole->id,
-        'flags' => 0,
-    ]);
-    TeamMember::query()->create(['team_id' => $team->team_id, 'staff_id' => $member->staff_id, 'flags' => 0]);
-
-    $staff = grantStaffPermissions(actingAsAdmin(), ['admin.staff.delete']);
-
-    actingAs($staff, 'staff');
-
-    delete(route('admin.staff.destroy', $member))
-        ->assertRedirect(route('admin.staff.index'));
-
-    assertDatabaseMissing('staff', ['staff_id' => $member->staff_id], 'legacy');
-    assertDatabaseMissing('staff_dept_access', ['staff_id' => $member->staff_id], 'legacy');
-    assertDatabaseMissing('team_member', ['staff_id' => $member->staff_id], 'legacy');
-
-    assertAuditLogged(
-        'staff.delete',
-        $member,
-        staffAuditPayload(
-            $member,
-            [['dept_id' => $secondaryDepartment->id, 'role_id' => $overrideRole->id]],
-            [$team->team_id],
-        ),
-        null,
-    );
+it('does not expose a staff destroy route — disable via isactive instead', function (): void {
+    expect(fn () => route('admin.staff.destroy', 1))->toThrow(RouteNotFoundException::class);
 });
 
-it('forbids unauthorized updates and deletion', function (): void {
+it('forbids unauthorized updates', function (): void {
     $department = Department::query()->create(['name' => 'Support', 'ispublic' => 1]);
     $role = LegacyRole::query()->create(['name' => 'Managers', 'guard_name' => 'staff']);
     $member = Staff::factory()->create([
@@ -536,8 +493,6 @@ it('forbids unauthorized updates and deletion', function (): void {
         'isadmin' => false,
         'isvisible' => true,
     ])->assertForbidden();
-
-    delete(route('admin.staff.destroy', $member))->assertForbidden();
 
     expect(AdminAuditLog::query()->where('subject_type', 'Staff')->count())->toBe(0);
 });


### PR DESCRIPTION
## Summary

- Removes the staff destroy route, controller action, service method, policy ability, and `admin.staff.delete` permission key
- Removes the Delete buttons + confirm dialogs from `Admin/Staff/Index.tsx` and `Admin/Staff/Edit.tsx`
- Updates `StaffAdminTest` — replaces the delete-success test with one that asserts the route no longer exists, and trims the unauthorized test to cover updates only

## Why

Task 11 acceptance criteria include a **Must NOT** rule: *"Do NOT delete staff (disable instead — data integrity)."* Hard-deleting a row would cascade out `staff_dept_access` and `team_member`, and orphan historic references in legacy ticket/thread tables. The supported off-switch is the existing `isactive` toggle, which is still in the edit form.

Closes #9 once merged.

## Test plan

- [x] `php artisan test --compact --filter=StaffAdmin` — 9 passed
- [x] `php artisan test --compact --filter=Admin` — 26 admin feature tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `vendor/bin/pint --dirty` — clean
- [ ] Manual: visit `/admin/staff` and `/admin/staff/{id}/edit` — no Delete button rendered; submitting an `isactive=false` update disables the staff member