### PR TITLE
[codex] Add outbound mail ownership swap

### DIFF
--- a/app/Exceptions/Scp/LegacyOwnedEventException.php
+++ b/app/Exceptions/Scp/LegacyOwnedEventException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Scp;
+
+use RuntimeException;
+
+final class LegacyOwnedEventException extends RuntimeException
+{
+    public function __construct(public readonly string $eventClass)
+    {
+        parent::__construct(
+            sprintf('Event class "%s" is owned by legacy osTicket; Laravel must not dispatch mail for it.', $eventClass),
+        );
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -50,6 +50,7 @@ class HandleInertiaRequests extends Middleware
             'status' => fn () => $request->session()->get('status'),
             'currentPanel' => fn () => $this->getCurrentPanel($routeName, $staff),
             'currentPanelNav' => fn () => $this->getCurrentPanelNav($routeName),
+            'mail_event_owner' => config('mail.event_class_owner'),
             'auth' => fn () => [
                 'staff' => $staff
                     ? $this->buildStaffAuthData($staff, $request)

--- a/app/Mail/EventClassHeader.php
+++ b/app/Mail/EventClassHeader.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+final class EventClassHeader
+{
+    public const NAME = 'X-Ost-Event-Class';
+
+    public const REPLY = 'reply';
+
+    public const CLOSE_NOTIFY = 'close_notify';
+
+    /**
+     * @return list<string>
+     */
+    public static function known(): array
+    {
+        return [self::REPLY, self::CLOSE_NOTIFY];
+    }
+}

--- a/app/Mail/OutboundMailGuard.php
+++ b/app/Mail/OutboundMailGuard.php
@@ -18,6 +18,10 @@ class OutboundMailGuard
             return;
         }
 
+        if ($this->isLaravelOwnedEvent($event)) {
+            return;
+        }
+
         if ($this->allRecipientsExplicitlyAllowed($event)) {
             return;
         }
@@ -28,6 +32,19 @@ class OutboundMailGuard
     private function isPasswordReset(MessageSending $event): bool
     {
         return ($event->data['__laravel_mailable'] ?? null) === PasswordResetLinkMail::class;
+    }
+
+    private function isLaravelOwnedEvent(MessageSending $event): bool
+    {
+        $headers = $event->message->getHeaders();
+
+        if (! $headers->has(EventClassHeader::NAME)) {
+            return false;
+        }
+
+        $eventClass = $headers->get(EventClassHeader::NAME)->getBodyAsString();
+
+        return (string) config("mail.event_class_owner.{$eventClass}", 'legacy') === 'laravel';
     }
 
     private function allRecipientsExplicitlyAllowed(MessageSending $event): bool

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -29,6 +29,7 @@ use App\Policies\TeamPolicy;
 use App\Policies\TicketActionPolicy;
 use App\Services\Admin\DepartmentRoleResolver;
 use App\Services\LegacyHasher;
+use App\Services\Scp\Mail\OutboundMailDispatcher;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Hashing\HashManager;
 use Illuminate\Mail\Events\MessageSending;
@@ -44,7 +45,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(OutboundMailDispatcher::class);
     }
 
     /**

--- a/app/Services/Scp/Mail/OutboundMailDispatcher.php
+++ b/app/Services/Scp/Mail/OutboundMailDispatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scp\Mail;
+
+use App\Exceptions\Scp\LegacyOwnedEventException;
+use App\Mail\EventClassHeader;
+use Illuminate\Mail\Mailable;
+use Illuminate\Support\Facades\Mail;
+use InvalidArgumentException;
+use Symfony\Component\Mime\Email;
+
+class OutboundMailDispatcher
+{
+    public function dispatch(string $eventClass, string $recipient, Mailable $mailable): void
+    {
+        if (! in_array($eventClass, EventClassHeader::known(), true)) {
+            throw new InvalidArgumentException(sprintf('Unknown event class "%s".', $eventClass));
+        }
+
+        $owner = (string) config("mail.event_class_owner.{$eventClass}", 'legacy');
+
+        if ($owner !== 'laravel') {
+            throw new LegacyOwnedEventException($eventClass);
+        }
+
+        $mailable->withSymfonyMessage(function (Email $message) use ($eventClass): void {
+            $message->getHeaders()->addTextHeader(EventClassHeader::NAME, $eventClass);
+        });
+
+        Mail::to($recipient)->send($mailable);
+    }
+}

--- a/config/mail.php
+++ b/config/mail.php
@@ -122,4 +122,9 @@ return [
         ))),
     ],
 
+    'event_class_owner' => [
+        'reply' => env('MAIL_OWNER_REPLY', 'legacy'),
+        'close_notify' => env('MAIL_OWNER_CLOSE_NOTIFY', 'legacy'),
+    ],
+
 ];

--- a/docs/runbooks/phase-2b-rollback.md
+++ b/docs/runbooks/phase-2b-rollback.md
@@ -22,3 +22,6 @@
 - `scp_action_log` rows, keep for postmortem.
 - The `scp_action_log` table itself, additive, doesn't touch legacy.
 - `lock` table, legacy still uses it; harmless to leave.
+
+## See also
+- `phase-2c-mail-swap.md` covers per-event-class rollback for Task 10b customer mail. Use that runbook for reply and close-with-notify rollbacks; this runbook covers the broader Phase 2b write surface.

--- a/docs/runbooks/phase-2c-mail-swap.md
+++ b/docs/runbooks/phase-2c-mail-swap.md
@@ -1,0 +1,29 @@
+# Phase 2c Outbound Mail Ownership Swap
+
+## Audience
+Operator flipping one event class at a time from legacy to Laravel.
+
+## Pre-flight (per class)
+- `php artisan test --compact --filter='OutboundMail'` is green.
+- Staging deploy already flipped the same env var and lived green for 24 hours.
+- Mailbox monitor confirms staging sent exactly one customer email per staff action in canary spot-check.
+
+## Flip procedure (per class)
+1. Set the env var in production:
+   - Reply: `MAIL_OWNER_REPLY=laravel`
+   - Close-with-notify: `MAIL_OWNER_CLOSE_NOTIFY=laravel`
+2. Redeploy.
+3. Confirm `php artisan config:show mail.event_class_owner` reflects the new value.
+4. Spot-check with a real ticket: action in new SCP sends exactly one customer email; legacy SCP does not log a parallel send.
+
+## Rollback (per class)
+1. Set the env var back to `legacy`.
+2. Redeploy.
+3. Confirm:
+   - The matching Inertia button disappears from new SCP for the next page load.
+   - `php artisan tinker --execute 'app(\App\Services\Scp\Mail\OutboundMailDispatcher::class)->dispatch("reply", "test@example.com", new \Tests\Support\TestMailable);'` throws `LegacyOwnedEventException`.
+
+## What this runbook does not touch
+- `ost_config` rows. Legacy continues operating identically for non-canary use.
+- Inbound mail piper. Customer reply threading is unaffected.
+- Cron and overdue alerts. Those remain in legacy until Task 13.

--- a/tests/Feature/Inertia/MailOwnershipSharedPropTest.php
+++ b/tests/Feature/Inertia/MailOwnershipSharedPropTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Staff;
+use Inertia\Testing\AssertableInertia;
+
+it('exposes mail event ownership map to Inertia shared props', function (): void {
+    config([
+        'mail.event_class_owner.reply' => 'laravel',
+        'mail.event_class_owner.close_notify' => 'legacy',
+    ]);
+
+    $staff = Staff::factory()->admin()->create();
+
+    $this->actingAs($staff, 'staff')
+        ->get(route('scp.preferences.show'))
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('mail_event_owner.reply', 'laravel')
+            ->where('mail_event_owner.close_notify', 'legacy'));
+});

--- a/tests/Feature/Mail/OutboundMailOwnershipSwapTest.php
+++ b/tests/Feature/Mail/OutboundMailOwnershipSwapTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Exceptions\Scp\LegacyOwnedEventException;
+use App\Mail\EventClassHeader;
+use App\Mail\OutboundMailGuard;
+use App\Services\Scp\Mail\OutboundMailDispatcher;
+use Illuminate\Mail\Events\MessageSending;
+use Illuminate\Support\Facades\Mail;
+use Symfony\Component\Mime\Email;
+use Tests\Support\TestMailable;
+
+it('defaults all event classes to legacy ownership', function (): void {
+    expect(config('mail.event_class_owner.reply'))->toBe('legacy')
+        ->and(config('mail.event_class_owner.close_notify'))->toBe('legacy');
+});
+
+it('reads ownership overrides from env', function (): void {
+    config(['mail.event_class_owner.reply' => 'laravel']);
+
+    expect(config('mail.event_class_owner.reply'))->toBe('laravel')
+        ->and(config('mail.event_class_owner.close_notify'))->toBe('legacy');
+});
+
+it('guard allows marker-tagged mail when class is laravel-owned in production', function (): void {
+    app()->detectEnvironment(fn (): string => 'production');
+    config(['mail.event_class_owner.reply' => 'laravel']);
+
+    $message = (new Email)
+        ->from('staff@example.com')
+        ->to('customer@example.com')
+        ->subject('Re: ticket')
+        ->html('<p>hi</p>');
+    $message->getHeaders()->addTextHeader(EventClassHeader::NAME, EventClassHeader::REPLY);
+
+    expect(fn () => app(OutboundMailGuard::class)->handle(new MessageSending($message)))
+        ->not->toThrow(RuntimeException::class);
+});
+
+it('guard throws on marker-tagged mail when class is legacy-owned in production', function (): void {
+    app()->detectEnvironment(fn (): string => 'production');
+    config(['mail.event_class_owner.reply' => 'legacy']);
+
+    $message = (new Email)
+        ->from('staff@example.com')
+        ->to('customer@example.com')
+        ->subject('Re: ticket')
+        ->html('<p>hi</p>');
+    $message->getHeaders()->addTextHeader(EventClassHeader::NAME, EventClassHeader::REPLY);
+
+    expect(fn () => app(OutboundMailGuard::class)->handle(new MessageSending($message)))
+        ->toThrow(RuntimeException::class);
+});
+
+it('guard throws on unmarked mail in production even when a class is laravel-owned', function (): void {
+    app()->detectEnvironment(fn (): string => 'production');
+    config(['mail.event_class_owner.reply' => 'laravel']);
+
+    $message = (new Email)
+        ->from('staff@example.com')
+        ->to('customer@example.com')
+        ->subject('Re: ticket')
+        ->html('<p>hi</p>');
+
+    expect(fn () => app(OutboundMailGuard::class)->handle(new MessageSending($message)))
+        ->toThrow(RuntimeException::class);
+});
+
+it('flipping one event class does not enable another', function (): void {
+    Mail::fake();
+    config([
+        'mail.event_class_owner.reply' => 'laravel',
+        'mail.event_class_owner.close_notify' => 'legacy',
+    ]);
+
+    app(OutboundMailDispatcher::class)
+        ->dispatch(EventClassHeader::REPLY, 'customer@example.com', new TestMailable);
+
+    expect(fn () => app(OutboundMailDispatcher::class)
+        ->dispatch(EventClassHeader::CLOSE_NOTIFY, 'customer@example.com', new TestMailable))
+        ->toThrow(LegacyOwnedEventException::class);
+
+    Mail::assertSent(TestMailable::class, 1);
+});

--- a/tests/Support/TestMailable.php
+++ b/tests/Support/TestMailable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Illuminate\Mail\Mailable;
+
+class TestMailable extends Mailable
+{
+    public function build(): self
+    {
+        return $this->subject('test')->html('<p>hi</p>');
+    }
+}

--- a/tests/Unit/Services/Scp/Mail/OutboundMailDispatcherTest.php
+++ b/tests/Unit/Services/Scp/Mail/OutboundMailDispatcherTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Exceptions\Scp\LegacyOwnedEventException;
+use App\Mail\EventClassHeader;
+use App\Services\Scp\Mail\OutboundMailDispatcher;
+use Illuminate\Support\Facades\Mail;
+use Symfony\Component\Mime\Email;
+use Tests\Support\TestMailable;
+
+beforeEach(function (): void {
+    Mail::fake();
+});
+
+it('throws when the event class is legacy-owned', function (): void {
+    config(['mail.event_class_owner.reply' => 'legacy']);
+
+    expect(fn () => app(OutboundMailDispatcher::class)
+        ->dispatch(EventClassHeader::REPLY, 'customer@example.com', new TestMailable))
+        ->toThrow(LegacyOwnedEventException::class);
+
+    Mail::assertNothingSent();
+});
+
+it('sends the mail with marker header when laravel-owned', function (): void {
+    config(['mail.event_class_owner.reply' => 'laravel']);
+
+    app(OutboundMailDispatcher::class)
+        ->dispatch(EventClassHeader::REPLY, 'customer@example.com', new TestMailable);
+
+    Mail::assertSent(TestMailable::class, function (TestMailable $mail): bool {
+        $message = new Email;
+
+        foreach ($mail->callbacks as $callback) {
+            $callback($message);
+        }
+
+        return in_array('customer@example.com', collect($mail->to)->pluck('address')->all(), true)
+            && $message->getHeaders()->get(EventClassHeader::NAME)?->getBodyAsString() === EventClassHeader::REPLY;
+    });
+});
+
+it('throws on unknown event class even when laravel-owned', function (): void {
+    config(['mail.event_class_owner.bogus' => 'laravel']);
+
+    expect(fn () => app(OutboundMailDispatcher::class)
+        ->dispatch('bogus', 'customer@example.com', new TestMailable))
+        ->toThrow(InvalidArgumentException::class);
+});


### PR DESCRIPTION
Adds a Laravel-side ownership swap for Task 10b customer mail by introducing per-event-class flags, marker headers, and an OutboundMailDispatcher that refuses legacy-owned events. Extends the production outbound mail guard to allow only marker-tagged Laravel-owned mail while continuing to block unmarked or legacy-owned customer mail. Exposes the ownership map to Inertia as mail_event_owner for future UI gating and adds the Phase 2c runbook for per-class flips and rollback. Validated with focused Pest mail/Inertia tests, existing guard/shared-prop tests, config and dispatcher smoke checks, Pint, and git diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mail event ownership management system to control which email events are handled by legacy vs. Laravel infrastructure
  * New configuration for customizing event ownership per mail type

* **Documentation**
  * Added Phase 2c runbook documenting the mail ownership swap procedure for operators

* **Tests**
  * Added comprehensive test coverage for mail event ownership configuration and functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chachajona/osTicket2.0/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->